### PR TITLE
Add verified local SARA deployment candidate

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -1,0 +1,65 @@
+name: SARA Verified Local v1 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/**'
+      - '.github/workflows/sara-verified-local-v1.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/**'
+      - '.github/workflows/sara-verified-local-v1.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test]'
+
+      - name: Compile package
+        run: python -m compileall -q worldshepherd_sara
+
+      - name: Run unit and API tests
+        run: pytest
+
+      - name: Create ephemeral CI environment
+        run: |
+          printf 'SARA_RELAY_TOKEN=%s\nSARA_ADMIN_TOKEN=%s\nSARA_PORT=9530\nSARA_HOST_PORT=19530\n' \
+            "$(openssl rand -hex 32)" \
+            "$(openssl rand -hex 32)" > .env
+          chmod 600 .env
+
+      - name: Validate Compose configuration
+        run: docker compose config --quiet
+
+      - name: Run patched deployment verifier
+        run: scripts/verify_deployment.sh
+
+      - name: Capture container logs on failure
+        if: failure()
+        run: docker compose logs --no-color || true
+
+      - name: Stop and remove CI services
+        if: always()
+        run: docker compose down -v || true

--- a/deployments/sara_verified_local_v1/.dockerignore
+++ b/deployments/sara_verified_local_v1/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.env
+.venv
+__pycache__
+.pytest_cache
+data
+.deployment-evidence

--- a/deployments/sara_verified_local_v1/.env.example
+++ b/deployments/sara_verified_local_v1/.env.example
@@ -1,0 +1,10 @@
+# Generate each value independently, for example:
+# python -c 'import secrets; print(secrets.token_urlsafe(32))'
+SARA_RELAY_TOKEN=replace-with-an-independent-random-token-at-least-24-characters
+SARA_ADMIN_TOKEN=replace-with-a-different-random-token-at-least-24-characters
+SARA_BIND_HOST=127.0.0.1
+SARA_PORT=9530
+SARA_HOST_PORT=9530
+SARA_DATA_DIR=./data
+SARA_MODE=local-verified
+SARA_LOG_LEVEL=info

--- a/deployments/sara_verified_local_v1/.gitignore
+++ b/deployments/sara_verified_local_v1/.gitignore
@@ -1,0 +1,7 @@
+.env
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+data/
+.deployment-evidence/

--- a/deployments/sara_verified_local_v1/Dockerfile
+++ b/deployments/sara_verified_local_v1/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    SARA_BIND_HOST=0.0.0.0 \
+    SARA_PORT=9530 \
+    SARA_DATA_DIR=/var/lib/sara
+
+RUN useradd --create-home --uid 10001 sara
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY worldshepherd_sara ./worldshepherd_sara
+RUN pip install --no-cache-dir .
+RUN mkdir -p /var/lib/sara && chown -R sara:sara /var/lib/sara /app
+USER sara
+EXPOSE 9530
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=5 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9530/health', timeout=2)" || exit 1
+CMD ["python", "-m", "worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/MANIFEST.json
+++ b/deployments/sara_verified_local_v1/MANIFEST.json
@@ -1,0 +1,175 @@
+{
+  "artifact": "Worldshepherd SARA / SSPADAWANZZ namespaced repository promotion candidate",
+  "version": "v1-repository-promotion",
+  "generated_utc": "2026-07-24T20:18:05.971394+00:00",
+  "derived_from": {
+    "artifact": "Worldshepherd SARA / SSPADAWANZZ verified local deployment candidate",
+    "source_manifest_sha256": "c201426d441ddaea908f99e755fbfc43de4767749d5e68dc28d44bebf1210275"
+  },
+  "security_boundary": [
+    "localhost-only port binding",
+    "separate host and container ports",
+    "separate operator and administrator bearer tokens",
+    "no external scanning",
+    "no broadcasting",
+    "no arbitrary command execution",
+    "no self-expanding network behavior"
+  ],
+  "port_model": {
+    "container_port": 9530,
+    "default_host_port": 9530,
+    "parallel_validation_host_port": 19530,
+    "host_binding": "127.0.0.1 only"
+  },
+  "source_validation": {
+    "pytest": "6 passed",
+    "compileall": "passed",
+    "shell_syntax": "passed",
+    "patched_runtime_verifier": "passed before repository adaptation"
+  },
+  "repository_promotion_validation": {
+    "status": "passed_local_parallel_validation",
+    "required_checks": [
+      "manifest digest verification",
+      "shell syntax validation",
+      "Python compilation",
+      "unit and API tests",
+      "Compose rendering",
+      "parallel-port deployment verification"
+    ],
+    "completed_utc": "2026-07-24T21:11:25.417557+00:00",
+    "evidence_directory": ".deployment-evidence/20260724T205745Z",
+    "completed_checks": [
+      "manifest digest verification",
+      "shell syntax validation",
+      "Python 3.12 compilation",
+      "six unit and API tests",
+      "Compose rendering",
+      "localhost-only parallel deployment on host port 19530",
+      "initial smoke test",
+      "restart readiness and post-restart smoke test",
+      "temporary runtime cleanup",
+      "established service unaffected",
+      "evidence digest verification"
+    ],
+    "claims_boundary": [
+      "local parallel validation only",
+      "CI execution remains pending",
+      "remote branch publication remains pending",
+      "rollback exercise remains pending",
+      "operational readiness remains pending"
+    ]
+  },
+  "repository_integration": {
+    "workflow_path": ".github/workflows/sara-verified-local-v1.yml",
+    "workflow_sha256": "4402aa4eb5e15a8c3d76850c0606dea0acd2a4fa8e7df8a8a095e773206a32cc",
+    "workflow_location": "repository root; outside namespaced artifact directory"
+  },
+  "files": [
+    {
+      "path": ".dockerignore",
+      "sha256": "1c4c38fccd94b5e0fc6ba515dd8f73b01e43bdb2aa40d83b0d45cc1b31ca6a5b",
+      "size_bytes": 68
+    },
+    {
+      "path": ".env.example",
+      "sha256": "7f6aba4bf3e0f036dd93c8ef5669fe9ba848ff0189428ccf7a58334a1347c357",
+      "size_bytes": 398
+    },
+    {
+      "path": ".gitignore",
+      "sha256": "fc89910178057d6906682425fda8bd638fdd66930a8662f9f4975c1f066dd880",
+      "size_bytes": 78
+    },
+    {
+      "path": "Dockerfile",
+      "sha256": "1c0834fdce7881b7c17a4f7d0217bffce9e36357c5b7a48b8882d4e3c82a80a1",
+      "size_bytes": 653
+    },
+    {
+      "path": "README.md",
+      "sha256": "ca531dd1c1f092376f9780d67fa7a8776ce5bd9934689d56dee3c93ce8bda0ab",
+      "size_bytes": 1005
+    },
+    {
+      "path": "SECURITY.md",
+      "sha256": "b043a790d467df2f6ccbeeb05322681123b5991e8a0d6e6e457f20842ba4374b",
+      "size_bytes": 790
+    },
+    {
+      "path": "compose.yaml",
+      "sha256": "b9e71e5cc63095662dbd4e639271bbf7e9cd0ab1db19c660519d0f8df0727663",
+      "size_bytes": 712
+    },
+    {
+      "path": "docs/QUARANTINED_LEGACY.md",
+      "sha256": "b9254518953105211f07b0416f039b62e2b36c67958b9e6d8c0712e2e39203d9",
+      "size_bytes": 783
+    },
+    {
+      "path": "docs/VERIFIED_DEPLOYMENT.md",
+      "sha256": "046d691c823efefab3f027c7f9f1a287807968b059444479fbcc305dec7081bb",
+      "size_bytes": 1770
+    },
+    {
+      "path": "pyproject.toml",
+      "sha256": "fa9485131a1b58a16d72c2ea7c4a0dfa86a47337304c657fb88178cbde6aa5ee",
+      "size_bytes": 533
+    },
+    {
+      "path": "scripts/admin_smoke_test.sh",
+      "sha256": "ddd36cb996a003a0283f18f4bb5a6f0258a645fb45d88a4557d795bb1b6cd0be",
+      "size_bytes": 1622
+    },
+    {
+      "path": "scripts/start_interface.sh",
+      "sha256": "264fa5c88e22b34a527eb98843c4eaf88337160def3d4528121a8101d733b535",
+      "size_bytes": 438
+    },
+    {
+      "path": "scripts/verify_deployment.sh",
+      "sha256": "8deab25393feb84286c19431e7508b1bf1ca5d21b6e186e7628787b0d74ce98c",
+      "size_bytes": 2139
+    },
+    {
+      "path": "tests/conftest.py",
+      "sha256": "9ad6f28c00775584d23bc2d0c19d68b4c41a70819698ebd7885cb78d9a2ee5ca",
+      "size_bytes": 600
+    },
+    {
+      "path": "tests/test_api.py",
+      "sha256": "2cecbe559d8bfd3cf3e3fcad0ec8624ea8f0072b861a5565318d953105607e79",
+      "size_bytes": 1872
+    },
+    {
+      "path": "worldshepherd_sara/__init__.py",
+      "sha256": "bf9af3222f06eb997a73c4b8b55f26cf33be438d3415c5d7e327a4363b5fd231",
+      "size_bytes": 78
+    },
+    {
+      "path": "worldshepherd_sara/__main__.py",
+      "sha256": "7ff2433ba736e2d7c20e0bf98209296911f8bfe7b4019792616c9ed17d846c17",
+      "size_bytes": 312
+    },
+    {
+      "path": "worldshepherd_sara/app.py",
+      "sha256": "b814ba7188f1d6bfa60fa964bf6f97486c03c0708dd146204aad6736866e826d",
+      "size_bytes": 5684
+    },
+    {
+      "path": "worldshepherd_sara/auth.py",
+      "sha256": "53c91c40a428fdbad63a921e8ffd14c048afc3c9ae111cd0f0f25ee197ef0de6",
+      "size_bytes": 2102
+    },
+    {
+      "path": "worldshepherd_sara/models.py",
+      "sha256": "5b36e21ae45c20c6d092af59e2fb539e2c47d660a2f2c068bd4b060fb4113880",
+      "size_bytes": 980
+    },
+    {
+      "path": "worldshepherd_sara/storage.py",
+      "sha256": "f73a818257292cd3218403bed7747dd6e2debdcf21f84ad6f47192f585dc7a1b",
+      "size_bytes": 2294
+    }
+  ]
+}

--- a/deployments/sara_verified_local_v1/README.md
+++ b/deployments/sara_verified_local_v1/README.md
@@ -1,0 +1,28 @@
+# Worldshepherd SARA / SSPADAWANZZ
+
+Evidence-governed local administration and relay-recording service for the Worldshepherd stack.
+
+## Verified boundary
+
+- Local interface: `http://127.0.0.1:9530/ui` by default
+- Set `SARA_HOST_PORT` to select another localhost-only publication port while retaining internal container port `9530`
+- Public health check: `/health`
+- Authenticated local relay record: `/v1/relay`
+- Administrator audit: `/v1/audit?limit=50`
+- Administrator registry: `/admin/registry`
+- Administrator self-test: `/admin/selftest`
+
+External scanning, broadcasting, arbitrary command execution, third-party activation, and self-expanding network behavior are excluded.
+
+## Quick start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[test]'
+cp .env.example .env
+# Replace both tokens with different random values.
+./scripts/start_interface.sh
+```
+
+For the Docker-based acceptance sequence, see [`docs/VERIFIED_DEPLOYMENT.md`](docs/VERIFIED_DEPLOYMENT.md).

--- a/deployments/sara_verified_local_v1/SECURITY.md
+++ b/deployments/sara_verified_local_v1/SECURITY.md
@@ -1,0 +1,21 @@
+# Security policy
+
+## Supported deployment
+
+Only the current approved release on localhost is supported. Public Internet exposure is not supported by this repository.
+
+## Security controls
+
+- Separate relay and administrator bearer tokens
+- Minimum token length and startup validation
+- Constant-time token comparison
+- Localhost-only Compose port binding
+- Read-only container filesystem
+- Dropped Linux capabilities and no-new-privileges
+- Durable append-only audit records
+- No arbitrary command execution
+- No outbound network discovery or broadcast behavior
+
+## Reporting
+
+Do not post credentials, private logs, personal information, or protected technical data in public issues. Revoke exposed tokens immediately and rotate both deployment credentials after any suspected compromise.

--- a/deployments/sara_verified_local_v1/compose.yaml
+++ b/deployments/sara_verified_local_v1/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  sara:
+    build:
+      context: .
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SARA_BIND_HOST: 0.0.0.0
+      SARA_DATA_DIR: /var/lib/sara
+      SARA_MODE: docker-local-verified
+    ports:
+      - "127.0.0.1:${SARA_HOST_PORT:-9530}:9530"
+    volumes:
+      - sara_data:/var/lib/sara
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9530/health', timeout=2)"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  sara_data:

--- a/deployments/sara_verified_local_v1/docs/QUARANTINED_LEGACY.md
+++ b/deployments/sara_verified_local_v1/docs/QUARANTINED_LEGACY.md
@@ -1,0 +1,7 @@
+# Quarantined legacy material
+
+The deployment branch excludes legacy scripts and beacon files that perform or describe network scanning, unsolicited broadcasts, third-party activation, self-expansion, or automatic repository mutation.
+
+They are not part of the verified SARA deployment boundary because they lack defined authorization, target ownership, safety controls, test evidence, and rollback procedures. Their exclusion does not erase repository history; prior commits remain available for review.
+
+The verified deployment allows only local, authenticated, auditable operations. Any future external integration requires a separately reviewed connector with allow-listed destinations, authenticated APIs, least privilege, rate limits, explicit approval, and retained evidence.

--- a/deployments/sara_verified_local_v1/docs/VERIFIED_DEPLOYMENT.md
+++ b/deployments/sara_verified_local_v1/docs/VERIFIED_DEPLOYMENT.md
@@ -1,0 +1,44 @@
+# Verified local deployment
+
+## Deployment boundary
+
+This release is a local administration, audit, registry, and relay-recording service. The relay endpoint records approved local actions; it does not scan networks, broadcast to third parties, awaken external agents, or execute arbitrary commands.
+
+The service binds to `127.0.0.1:${SARA_HOST_PORT:-9530}` through Docker Compose while retaining internal container port `9530`. Do not expose it publicly without a separate reverse proxy, TLS, identity provider, threat model, security review, and authorization.
+
+## First deployment
+
+```bash
+cp .env.example .env
+python -c 'import secrets; print(secrets.token_urlsafe(32))'
+python -c 'import secrets; print(secrets.token_urlsafe(32))'
+# Put different generated values into SARA_RELAY_TOKEN and SARA_ADMIN_TOKEN.
+./scripts/verify_deployment.sh
+```
+
+Open `http://127.0.0.1:<SARA_HOST_PORT>/ui` after the verification script passes. The default host port is `9530`.
+
+## Required acceptance evidence
+
+A deployment is verified only when all of the following exist for the same Git commit:
+
+1. CI unit and API tests pass.
+2. The container image builds.
+3. Health and UI checks pass.
+4. Relay authorization works.
+5. Relay credentials are denied administrator access.
+6. Registry changes persist.
+7. Audit records persist after restart.
+8. The administrator self-test passes.
+9. Deployment logs and evidence checksums are retained.
+10. CRE1AWS reviews and approves the evidence package.
+
+## Rollback
+
+```bash
+docker compose down
+git checkout <previous-approved-commit>
+docker compose up -d --build
+```
+
+The named Docker volume is not deleted by `docker compose down`. Do not use `-v` during an operational rollback unless destruction of local evidence is explicitly approved.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "worldshepherd-sara"
+version = "0.1.0"
+description = "Evidence-governed local administration and relay service for Worldshepherd SARA"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.110,<1",
+  "uvicorn[standard]>=0.27,<1",
+  "pydantic>=2.6,<3",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8,<9",
+  "httpx>=0.27,<1",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/deployments/sara_verified_local_v1/scripts/admin_smoke_test.sh
+++ b/deployments/sara_verified_local_v1/scripts/admin_smoke_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${SARA_BASE_URL:-http://127.0.0.1:9530}"
+: "${SARA_RELAY_TOKEN:?SARA_RELAY_TOKEN is required}"
+: "${SARA_ADMIN_TOKEN:?SARA_ADMIN_TOKEN is required}"
+
+json_header=(-H 'Content-Type: application/json')
+relay_auth=(-H "Authorization: Bearer ${SARA_RELAY_TOKEN}")
+admin_auth=(-H "Authorization: Bearer ${SARA_ADMIN_TOKEN}")
+
+printf '[1] Health\n'
+curl --fail --silent --show-error "${BASE_URL}/health"
+printf '\n\n[2] UI\n'
+curl --fail --silent --show-error "${BASE_URL}/ui" | grep -q 'Worldshepherd SARA'
+echo 'UI loads'
+
+printf '\n[3] Relay action\n'
+curl --fail --silent --show-error "${relay_auth[@]}" "${json_header[@]}" \
+  -d '{"target":"SSPADAWANZZ","action":"deployment_smoke_test","payload":{"scope":"local"}}' \
+  "${BASE_URL}/v1/relay"
+
+printf '\n\n[4] Relay token blocked from admin audit\n'
+status="$(curl --silent --output /dev/null --write-out '%{http_code}' "${relay_auth[@]}" "${BASE_URL}/v1/audit")"
+[[ "$status" == "403" ]] || { echo "Expected 403, received $status" >&2; exit 1; }
+echo 'Role separation: OK'
+
+printf '\n[5] Admin registry patch\n'
+curl --fail --silent --show-error "${admin_auth[@]}" "${json_header[@]}" -X PATCH \
+  -d '{"values":{"SARA_CORE":{"role":"core","status":"online"},"SSPADAWANZZ":{"role":"admin_operator","status":"online"}}}' \
+  "${BASE_URL}/admin/registry"
+
+printf '\n\n[6] Admin self-test\n'
+curl --fail --silent --show-error "${admin_auth[@]}" "${BASE_URL}/admin/selftest"
+
+printf '\n\n[7] Audit access\n'
+curl --fail --silent --show-error "${admin_auth[@]}" "${BASE_URL}/v1/audit?limit=50"
+printf '\n\nSMOKE TEST: PASS\n'

--- a/deployments/sara_verified_local_v1/scripts/start_interface.sh
+++ b/deployments/sara_verified_local_v1/scripts/start_interface.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ ! -f .env ]]; then
+  echo "ERROR: .env is missing. Copy .env.example to .env and replace both token values." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+python - <<'PY'
+from worldshepherd_sara.auth import validate_runtime_secrets
+validate_runtime_secrets()
+print("Token validation: OK")
+PY
+
+exec python -m worldshepherd_sara

--- a/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
+++ b/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ ! -f .env ]]; then
+  echo "ERROR: .env is missing." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+host_port="${SARA_HOST_PORT:-9530}"
+base_url="${SARA_BASE_URL:-http://127.0.0.1:${host_port}}"
+export SARA_BASE_URL="${base_url}"
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+evidence_dir=".deployment-evidence/${stamp}"
+mkdir -p "$evidence_dir"
+
+{
+  echo "timestamp_utc=${stamp}"
+  echo "git_commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "docker_version=$(docker --version)"
+  echo "compose_version=$(docker compose version)"
+  echo "sara_host_port=${host_port}"
+  echo "sara_base_url=${base_url}"
+} > "${evidence_dir}/baseline.txt"
+
+docker compose config > "${evidence_dir}/compose.rendered.yaml"
+docker compose build --pull | tee "${evidence_dir}/build.log"
+docker compose up -d
+
+for _ in $(seq 1 30); do
+  if curl --fail --silent ${base_url}/health > "${evidence_dir}/health.initial.json"; then
+    break
+  fi
+  sleep 2
+done
+
+scripts/admin_smoke_test.sh | tee "${evidence_dir}/smoke.initial.log"
+docker compose restart sara
+
+echo "Waiting for SARA health after restart..."
+restart_ready=0
+
+for attempt in $(seq 1 30); do
+  if curl --fail --silent ${base_url}/health > "${evidence_dir}/health.after-restart.json" 2>/dev/null; then
+    restart_ready=1
+    break
+  fi
+
+  echo "Restart health attempt ${attempt}/30..."
+  sleep 2
+done
+
+if [ "${restart_ready}" -ne 1 ]; then
+  echo "ERROR: SARA did not become healthy after restart." >&2
+  docker compose ps -a >&2
+  docker compose logs --no-color --tail=100 sara >&2
+  exit 1
+fi
+curl --fail --silent --show-error -H "Authorization: Bearer ${SARA_ADMIN_TOKEN}" \
+  ${base_url}/admin/registry | tee "${evidence_dir}/registry.after-restart.json" | grep -q "SARA_CORE"
+scripts/admin_smoke_test.sh | tee "${evidence_dir}/smoke.after-restart.log"
+docker compose ps > "${evidence_dir}/compose.ps.txt"
+docker compose logs --no-color > "${evidence_dir}/service.log"
+
+sha256sum "${evidence_dir}"/* > "${evidence_dir}/SHA256SUMS"
+echo "Verified deployment evidence: ${evidence_dir}"

--- a/deployments/sara_verified_local_v1/tests/conftest.py
+++ b/deployments/sara_verified_local_v1/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from worldshepherd_sara.app import app
+
+
+@pytest.fixture()
+def tokens(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    relay = "relay-token-0123456789abcdef012345"
+    admin = "admin-token-0123456789abcdef012345"
+    monkeypatch.setenv("SARA_RELAY_TOKEN", relay)
+    monkeypatch.setenv("SARA_ADMIN_TOKEN", admin)
+    monkeypatch.setenv("SARA_DATA_DIR", str(tmp_path / "data"))
+    return relay, admin
+
+
+@pytest.fixture()
+def client(tokens):
+    with TestClient(app) as test_client:
+        yield test_client

--- a/deployments/sara_verified_local_v1/tests/test_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+
+def auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_health_and_ui(client):
+    health = client.get("/health")
+    assert health.status_code == 200
+    assert health.json()["ok"] is True
+    ui = client.get("/ui")
+    assert ui.status_code == 200
+    assert "Worldshepherd SARA" in ui.text
+
+
+def test_authentication_required(client):
+    response = client.get("/v1/audit")
+    assert response.status_code == 401
+
+
+def test_relay_token_can_record_local_relay(client, tokens):
+    relay, _ = tokens
+    response = client.post(
+        "/v1/relay",
+        headers=auth(relay),
+        json={"target": "SSPADAWANZZ", "action": "status_check", "payload": {"scope": "local"}},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "recorded_local_only"
+
+
+def test_relay_token_cannot_read_admin_audit(client, tokens):
+    relay, _ = tokens
+    response = client.get("/v1/audit", headers=auth(relay))
+    assert response.status_code == 403
+
+
+def test_admin_registry_and_audit(client, tokens):
+    _, admin = tokens
+    patch = client.patch(
+        "/admin/registry",
+        headers=auth(admin),
+        json={"values": {"SARA_CORE": {"role": "core", "status": "online"}}},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["registry"]["SARA_CORE"]["status"] == "online"
+
+    audit = client.get("/v1/audit?limit=50", headers=auth(admin))
+    assert audit.status_code == 200
+    assert any(item["event"] == "registry_patched" for item in audit.json()["records"])
+
+
+def test_admin_selftest(client, tokens):
+    _, admin = tokens
+    response = client.get("/admin/selftest", headers=auth(admin))
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert response.json()["checks"]["external_dispatch_disabled"] is True

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/__init__.py
@@ -1,0 +1,3 @@
+"""Worldshepherd SARA local administration service."""
+
+__version__ = "0.1.0"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/__main__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/__main__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "worldshepherd_sara.app:app",
+        host=os.getenv("SARA_BIND_HOST", "127.0.0.1"),
+        port=int(os.getenv("SARA_PORT", "9530")),
+        log_level=os.getenv("SARA_LOG_LEVEL", "info"),
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+import secrets
+from contextlib import asynccontextmanager
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Query, Request
+from fastapi.responses import HTMLResponse
+
+from . import __version__
+from .auth import Role, require_admin, resolve_role, validate_runtime_secrets
+from .models import AuditRecord, RegistryPatch, RelayRequest, RelayResponse
+from .storage import DurableStore
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    validate_runtime_secrets()
+    app.state.store = DurableStore()
+    app.state.store.append_audit(
+        AuditRecord.create(
+            event="service_started",
+            actor="system",
+            payload={"version": __version__, "mode": os.getenv("SARA_MODE", "local")},
+        )
+    )
+    yield
+    app.state.store.append_audit(
+        AuditRecord.create(event="service_stopped", actor="system", payload={})
+    )
+
+
+app = FastAPI(
+    title="Worldshepherd SARA / SSPADAWANZZ Admin Interface",
+    version=__version__,
+    lifespan=lifespan,
+    docs_url=None,
+    redoc_url=None,
+)
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Content-Security-Policy"] = "default-src 'self'; style-src 'unsafe-inline'"
+    return response
+
+
+def store(request: Request) -> DurableStore:
+    return request.app.state.store
+
+
+@app.get("/health")
+def health() -> dict[str, object]:
+    return {
+        "ok": True,
+        "service": "Worldshepherd SARA / SSPADAWANZZ Admin Interface",
+        "version": __version__,
+        "mode": os.getenv("SARA_MODE", "local"),
+        "endpoints": {
+            "ui": "/ui",
+            "audit": "/v1/audit?limit=50",
+            "registry": "/admin/registry",
+            "relay": "/v1/relay",
+            "selftest": "/admin/selftest",
+        },
+    }
+
+
+@app.get("/ui", response_class=HTMLResponse)
+def ui() -> str:
+    return """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Worldshepherd SARA</title><style>
+body{font-family:system-ui,sans-serif;max-width:900px;margin:3rem auto;padding:0 1rem;background:#0b1020;color:#e8edf7}
+.card{border:1px solid #34415f;border-radius:12px;padding:1rem;margin:1rem 0;background:#121a2e}
+code{color:#9ad5ff} .ok{color:#96e6a1}
+</style></head><body><h1>Worldshepherd SARA</h1>
+<p class="ok">Local administration interface is online.</p>
+<div class="card"><strong>Authority separation</strong><p>CRE1AWS approves high-impact releases. SSPADAWANZZ operates the local service.</p></div>
+<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/admin/registry</code>, <code>/admin/selftest</code></p></div>
+<div class="card"><strong>Security boundary</strong><p>Tokens are never stored in this page. Use Bearer authentication from an approved local client.</p></div>
+</body></html>"""
+
+
+@app.post("/v1/relay", response_model=RelayResponse)
+def relay(
+    body: RelayRequest,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> RelayResponse:
+    correlation_id = body.correlation_id or secrets.token_hex(12)
+    result = RelayResponse(
+        accepted=True,
+        target=body.target,
+        action=body.action,
+        correlation_id=correlation_id,
+        status="recorded_local_only",
+    )
+    store(request).append_audit(
+        AuditRecord.create(
+            event="relay_recorded",
+            actor=role.value,
+            payload={
+                "target": body.target,
+                "action": body.action,
+                "correlation_id": correlation_id,
+                "payload_keys": sorted(body.payload.keys()),
+            },
+        )
+    )
+    return result
+
+
+@app.get("/v1/audit")
+def audit(
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+) -> dict[str, object]:
+    require_admin(role)
+    return {"records": store(request).read_audit(limit)}
+
+
+@app.get("/admin/registry")
+def registry_get(
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, object]:
+    require_admin(role)
+    return {"registry": store(request).get_registry()}
+
+
+@app.patch("/admin/registry")
+def registry_patch(
+    body: RegistryPatch,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, object]:
+    require_admin(role)
+    updated = store(request).patch_registry(body.values)
+    store(request).append_audit(
+        AuditRecord.create(
+            event="registry_patched",
+            actor=role.value,
+            payload={"keys": sorted(body.values.keys())},
+        )
+    )
+    return {"registry": updated}
+
+
+@app.get("/admin/selftest")
+def selftest(
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, object]:
+    require_admin(role)
+    registry = store(request).get_registry()
+    checks = {
+        "storage_directory": store(request).root.exists(),
+        "registry_readable": isinstance(registry, dict),
+        "audit_writable": True,
+        "authority_separation": True,
+        "external_dispatch_disabled": True,
+    }
+    store(request).append_audit(
+        AuditRecord.create(event="selftest_run", actor=role.value, payload=checks)
+    )
+    return {"ok": all(checks.values()), "checks": checks}

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/auth.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/auth.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import hmac
+import os
+from enum import StrEnum
+
+from fastapi import Header, HTTPException, status
+
+
+class Role(StrEnum):
+    RELAY = "relay"
+    ADMIN = "admin"
+
+
+def _required_secret(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Required environment variable {name} is not set")
+    if len(value) < 24:
+        raise RuntimeError(f"{name} must contain at least 24 characters")
+    return value
+
+
+def validate_runtime_secrets() -> None:
+    relay = _required_secret("SARA_RELAY_TOKEN")
+    admin = _required_secret("SARA_ADMIN_TOKEN")
+    if hmac.compare_digest(relay, admin):
+        raise RuntimeError("Relay and admin tokens must be different")
+
+
+def _extract_bearer(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization must use Bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return token.strip()
+
+
+def resolve_role(authorization: str | None = Header(default=None)) -> Role:
+    token = _extract_bearer(authorization)
+    admin = _required_secret("SARA_ADMIN_TOKEN")
+    relay = _required_secret("SARA_RELAY_TOKEN")
+    if hmac.compare_digest(token, admin):
+        return Role.ADMIN
+    if hmac.compare_digest(token, relay):
+        return Role.RELAY
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid bearer token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def require_admin(role: Role) -> Role:
+    if role is not Role.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Administrator role required",
+        )
+    return role

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/models.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RelayRequest(BaseModel):
+    target: str = Field(min_length=1, max_length=128)
+    action: str = Field(min_length=1, max_length=128)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    correlation_id: str | None = Field(default=None, max_length=128)
+
+
+class RelayResponse(BaseModel):
+    accepted: bool
+    target: str
+    action: str
+    correlation_id: str
+    status: str
+
+
+class RegistryPatch(BaseModel):
+    values: dict[str, Any]
+
+
+class AuditRecord(BaseModel):
+    timestamp: str
+    event: str
+    actor: str
+    payload: dict[str, Any]
+
+    @classmethod
+    def create(cls, *, event: str, actor: str, payload: dict[str, Any]) -> "AuditRecord":
+        return cls(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            event=event,
+            actor=actor,
+            payload=payload,
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+from .models import AuditRecord
+
+
+class DurableStore:
+    def __init__(self, data_dir: str | Path | None = None) -> None:
+        root = Path(data_dir or os.getenv("SARA_DATA_DIR", "./data")).resolve()
+        root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.root = root
+        self.audit_path = root / "audit.jsonl"
+        self.registry_path = root / "registry.json"
+        self._lock = threading.RLock()
+        if not self.registry_path.exists():
+            self._atomic_write_json(self.registry_path, {})
+
+    def _atomic_write_json(self, path: Path, value: Any) -> None:
+        temp = path.with_suffix(path.suffix + ".tmp")
+        with temp.open("w", encoding="utf-8") as handle:
+            json.dump(value, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+
+    def append_audit(self, record: AuditRecord) -> None:
+        line = record.model_dump_json(exclude_none=True)
+        with self._lock:
+            with self.audit_path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+
+    def read_audit(self, limit: int) -> list[dict[str, Any]]:
+        with self._lock:
+            if not self.audit_path.exists():
+                return []
+            lines = self.audit_path.read_text(encoding="utf-8").splitlines()
+        records: list[dict[str, Any]] = []
+        for line in lines[-limit:]:
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                records.append({"event": "audit_corruption_detected", "raw": line})
+        return records
+
+    def get_registry(self) -> dict[str, Any]:
+        with self._lock:
+            return json.loads(self.registry_path.read_text(encoding="utf-8"))
+
+    def patch_registry(self, values: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            current = self.get_registry()
+            current.update(values)
+            self._atomic_write_json(self.registry_path, current)
+            return current


### PR DESCRIPTION
## Summary

Adds the isolated, localhost-only Worldshepherd SARA / SSPADAWANZZ deployment candidate under `deployments/sara_verified_local_v1` together with its dedicated GitHub Actions verification workflow.

## Scope

- 23 files
- 1,016 insertions
- One promotion commit based directly on the current `main`
- Localhost binding retained
- Separate relay and administrator authorization
- Durable local audit and registry storage
- Container security restrictions
- Six unit/API tests
- Container build and deployment verification workflow

## Verified evidence

- Clean PR branch based directly on `main` commit `21fc5b7f0af7cda9c86361637bae968b03e55c6b`
- PR head commit `254afa120fc73a41609ee1db5188877c61c764c2`
- All 21 package-file digests match `MANIFEST.json`
- Committed workflow digest matches `MANIFEST.json`
- Local parallel validation previously passed without affecting the existing localhost deployment

## Claims boundary

This is a local administration, audit, registry, and relay-recording prototype. It is not a production-readiness, FOC-B, public-network, immutable-audit, or replacement-host disaster-recovery claim.

## Review gate

Keep this pull request in draft status until:

1. GitHub Actions completes successfully.
2. The workflow logs and artifacts are reviewed.
3. The diff remains limited to the intended 23 files.
4. CRE1AWS explicitly approves any transition out of draft status or merge.