### PR TITLE
Harden SARA local deployment for ORL-4 validation

### DIFF
--- a/deployments/sara_verified_local_v1/Dockerfile
+++ b/deployments/sara_verified_local_v1/Dockerfile
@@ -11,9 +11,9 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY worldshepherd_sara ./worldshepherd_sara
 RUN pip install --no-cache-dir .
-RUN mkdir -p /var/lib/sara && chown -R sara:sara /var/lib/sara /app
+RUN mkdir -p /var/lib/sara && chown -R sara:sara /var/lib/sara /app && chmod 0700 /var/lib/sara
 USER sara
 EXPOSE 9530
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=5 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9530/health', timeout=2)" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9530/readyz', timeout=2)" || exit 1
 CMD ["python", "-m", "worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/MANIFEST.json
+++ b/deployments/sara_verified_local_v1/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "artifact": "Worldshepherd SARA / SSPADAWANZZ namespaced repository promotion candidate",
   "version": "v1-repository-promotion",
-  "generated_utc": "2026-07-24T20:18:05.971394+00:00",
+  "generated_utc": "2026-07-29T00:53:10Z",
   "derived_from": {
     "artifact": "Worldshepherd SARA / SSPADAWANZZ verified local deployment candidate",
     "source_manifest_sha256": "c201426d441ddaea908f99e755fbfc43de4767749d5e68dc28d44bebf1210275"
@@ -22,13 +22,13 @@
     "host_binding": "127.0.0.1 only"
   },
   "source_validation": {
-    "pytest": "6 passed",
-    "compileall": "passed",
-    "shell_syntax": "passed",
-    "patched_runtime_verifier": "passed before repository adaptation"
+    "pytest": "29 passed with 0 failures, 0 errors, and 0 skips under Python 3.12 in a disposable isolated container after the self-test RuntimeError correction",
+    "compileall": "passed under Python 3.12 after the self-test RuntimeError correction",
+    "shell_syntax": "passed after final self-test correction",
+    "runtime_verifier": "passed in isolated Docker Compose project sara_orl4_hardening_20260728 on localhost port 19532 with independently verified evidence at .deployment-evidence/20260729T004839Z"
   },
   "repository_promotion_validation": {
-    "status": "passed_local_parallel_validation",
+    "status": "passed_local_isolated_orl4_validation",
     "required_checks": [
       "manifest digest verification",
       "shell syntax validation",
@@ -37,28 +37,35 @@
       "Compose rendering",
       "parallel-port deployment verification"
     ],
-    "completed_utc": "2026-07-24T21:11:25.417557+00:00",
-    "evidence_directory": ".deployment-evidence/20260724T205745Z",
+    "completed_utc": "2026-07-29T00:53:10Z",
+    "evidence_directory": ".deployment-evidence/20260729T004839Z",
     "completed_checks": [
-      "manifest digest verification",
-      "shell syntax validation",
-      "Python 3.12 compilation",
-      "six unit and API tests",
-      "Compose rendering",
-      "localhost-only parallel deployment on host port 19530",
-      "initial smoke test",
-      "restart readiness and post-restart smoke test",
-      "temporary runtime cleanup",
-      "established service unaffected",
-      "evidence digest verification"
+      "Python 3.12 execution of the 29-test unit and API suite with 0 failures, 0 errors, and 0 skips",
+      "isolated self-test RuntimeError failure-path regression with check_storage forced successful and get_registry forced to raise RuntimeError",
+      "all 22 manifest file hashes and sizes, JSON validity, and canonical manifest inventory digest verification",
+      "Python 3.12 compilation and final local Python AST parsing",
+      "final shell syntax validation",
+      "isolated localhost runtime build, startup, health, liveness, readiness, UI, relay, registry, self-test, and audit verification",
+      "relay and administrator role-separation verification across every administrator endpoint",
+      "Docker readiness and application persistent-storage readiness verification",
+      "container restart and registry and audit persistence verification",
+      "evidence permissions, SHA256SUMS integrity, valid rendered Compose YAML, and retained-environment-file absence verification",
+      "redacted Compose credential fields and evidence redaction verification",
+      "Git branch, HEAD, dirty pre-commit worktree state, authorized-package scope, and canonical manifest provenance verification",
+      "documentation review confirming isolated-localhost claims and explicit production, public-network, immutable-audit, rollback, recovery, and retention limitations",
+      "final Codex static audit and git diff --check"
     ],
     "claims_boundary": [
-      "local parallel validation only",
-      "CI execution remains pending",
-      "remote branch publication remains pending",
-      "rollback exercise remains pending",
-      "operational readiness remains pending"
-    ]
+      "isolated localhost validation only",
+      "CI execution and remote branch publication remain pending",
+      "rollback and replacement-host recovery remain pending",
+      "off-host evidence retention remains pending",
+      "immutable audit is not provided by the application-appended local audit log",
+      "production and public-network readiness remain pending"
+    ],
+    "validated_git_head": "36508ca38e86649e4a786d34762150fbc2356cc8",
+    "validated_git_worktree_state": "dirty_precommit_hardening_revision",
+    "manifest_files_sha256": "dce43e8adbc1b11a408529c677f2b18631464c56513cabfa370b91b95294c6ee"
   },
   "repository_integration": {
     "workflow_path": ".github/workflows/sara-verified-local-v1.yml",
@@ -83,22 +90,22 @@
     },
     {
       "path": "Dockerfile",
-      "sha256": "1c0834fdce7881b7c17a4f7d0217bffce9e36357c5b7a48b8882d4e3c82a80a1",
-      "size_bytes": 653
+      "sha256": "c04967cbc183459fc72c8e5cfd10db9de2de87a4e777b150ff72462cb43ac0ea",
+      "size_bytes": 681
     },
     {
       "path": "README.md",
-      "sha256": "ca531dd1c1f092376f9780d67fa7a8776ce5bd9934689d56dee3c93ce8bda0ab",
-      "size_bytes": 1005
+      "sha256": "aaf8fa97286d743af29433caf893698c0059cbfb82423fb9e0aac111663a2275",
+      "size_bytes": 1289
     },
     {
       "path": "SECURITY.md",
-      "sha256": "b043a790d467df2f6ccbeeb05322681123b5991e8a0d6e6e457f20842ba4374b",
-      "size_bytes": 790
+      "sha256": "38b0ed3f90107a36908d6d7a5bb1e8b35b673cb1eee097c4dca360cb0fd5a5b6",
+      "size_bytes": 1186
     },
     {
       "path": "compose.yaml",
-      "sha256": "b9e71e5cc63095662dbd4e639271bbf7e9cd0ab1db19c660519d0f8df0727663",
+      "sha256": "972a3eced169a3423a1f9d55b87cf0c5bb07772edaa3b4041b2619f55eeb9ec6",
       "size_bytes": 712
     },
     {
@@ -108,8 +115,8 @@
     },
     {
       "path": "docs/VERIFIED_DEPLOYMENT.md",
-      "sha256": "046d691c823efefab3f027c7f9f1a287807968b059444479fbcc305dec7081bb",
-      "size_bytes": 1770
+      "sha256": "58c4a354a67c1ead29485ac37215b5c6a9ce5dadda5865d102dbe8792b293cc2",
+      "size_bytes": 2873
     },
     {
       "path": "pyproject.toml",
@@ -118,18 +125,18 @@
     },
     {
       "path": "scripts/admin_smoke_test.sh",
-      "sha256": "ddd36cb996a003a0283f18f4bb5a6f0258a645fb45d88a4557d795bb1b6cd0be",
-      "size_bytes": 1622
+      "sha256": "a1ac8ce42bac7a897d6957651322dd863efefa33417fffb58d5a68c4504b97eb",
+      "size_bytes": 2181
     },
     {
       "path": "scripts/start_interface.sh",
-      "sha256": "264fa5c88e22b34a527eb98843c4eaf88337160def3d4528121a8101d733b535",
-      "size_bytes": 438
+      "sha256": "52f0c160682e25483296a46dac4cabd0fdb9988678b40eb32e18baf4f5bf3b7c",
+      "size_bytes": 448
     },
     {
       "path": "scripts/verify_deployment.sh",
-      "sha256": "8deab25393feb84286c19431e7508b1bf1ca5d21b6e186e7628787b0d74ce98c",
-      "size_bytes": 2139
+      "sha256": "171289edd93874f6292f2c4f60b24c7e8f3fac61d9bb05541dfb0eef66472b79",
+      "size_bytes": 4302
     },
     {
       "path": "tests/conftest.py",
@@ -138,8 +145,8 @@
     },
     {
       "path": "tests/test_api.py",
-      "sha256": "2cecbe559d8bfd3cf3e3fcad0ec8624ea8f0072b861a5565318d953105607e79",
-      "size_bytes": 1872
+      "sha256": "b2715bc2510128c32be96b7cf85b8aa63545e8fcf13996b0376bd4a28b1477ce",
+      "size_bytes": 11603
     },
     {
       "path": "worldshepherd_sara/__init__.py",
@@ -148,13 +155,13 @@
     },
     {
       "path": "worldshepherd_sara/__main__.py",
-      "sha256": "7ff2433ba736e2d7c20e0bf98209296911f8bfe7b4019792616c9ed17d846c17",
-      "size_bytes": 312
+      "sha256": "1372ecb7d44cc521e33f21f9eadbe093558b3e10d2b0283f78ab155c206552af",
+      "size_bytes": 332
     },
     {
       "path": "worldshepherd_sara/app.py",
-      "sha256": "b814ba7188f1d6bfa60fa964bf6f97486c03c0708dd146204aad6736866e826d",
-      "size_bytes": 5684
+      "sha256": "b4fc951c3e6c9d2df85b8a89a3a9af305a0583cc5764a0c3c48117b3b1558ae0",
+      "size_bytes": 9410
     },
     {
       "path": "worldshepherd_sara/auth.py",
@@ -163,13 +170,18 @@
     },
     {
       "path": "worldshepherd_sara/models.py",
-      "sha256": "5b36e21ae45c20c6d092af59e2fb539e2c47d660a2f2c068bd4b060fb4113880",
-      "size_bytes": 980
+      "sha256": "105f82c252a1206a0145d3bf0f797c2f1938cf751096adce8199284c11561823",
+      "size_bytes": 1383
+    },
+    {
+      "path": "worldshepherd_sara/limits.py",
+      "sha256": "db24ac92005c081f61f0c81dfb34a3a9b536cce667f680f29a2875def9251f4f",
+      "size_bytes": 1889
     },
     {
       "path": "worldshepherd_sara/storage.py",
-      "sha256": "f73a818257292cd3218403bed7747dd6e2debdcf21f84ad6f47192f585dc7a1b",
-      "size_bytes": 2294
+      "sha256": "0e8be29217099bfe8dd69d282a2d0bf97ce9cb4aa1d514d0c76ec6f2421c5e84",
+      "size_bytes": 10032
     }
   ]
 }

--- a/deployments/sara_verified_local_v1/MANIFEST.json
+++ b/deployments/sara_verified_local_v1/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "artifact": "Worldshepherd SARA / SSPADAWANZZ namespaced repository promotion candidate",
   "version": "v1-repository-promotion",
-  "generated_utc": "2026-07-29T00:53:10Z",
+  "generated_utc": "2026-07-29T01:42:26Z",
   "derived_from": {
     "artifact": "Worldshepherd SARA / SSPADAWANZZ verified local deployment candidate",
     "source_manifest_sha256": "c201426d441ddaea908f99e755fbfc43de4767749d5e68dc28d44bebf1210275"
@@ -22,10 +22,10 @@
     "host_binding": "127.0.0.1 only"
   },
   "source_validation": {
-    "pytest": "29 passed with 0 failures, 0 errors, and 0 skips under Python 3.12 in a disposable isolated container after the self-test RuntimeError correction",
-    "compileall": "passed under Python 3.12 after the self-test RuntimeError correction",
-    "shell_syntax": "passed after final self-test correction",
-    "runtime_verifier": "passed in isolated Docker Compose project sara_orl4_hardening_20260728 on localhost port 19532 with independently verified evidence at .deployment-evidence/20260729T004839Z"
+    "pytest": "29 passed with 0 failures, 0 errors, and 0 skips under Python 3.12; application and test code unchanged by the CI evidence-root correction",
+    "compileall": "passed; Python source unchanged by the CI evidence-root correction",
+    "shell_syntax": "passed after CI clean-checkout evidence-root correction",
+    "runtime_verifier": "passed after CI clean-checkout evidence-root correction in isolated Docker Compose project sara_orl4_hardening_20260728 on localhost port 19532 with independently verified evidence at .deployment-evidence/20260729T014206Z"
   },
   "repository_promotion_validation": {
     "status": "passed_local_isolated_orl4_validation",
@@ -37,35 +37,32 @@
       "Compose rendering",
       "parallel-port deployment verification"
     ],
-    "completed_utc": "2026-07-29T00:53:10Z",
-    "evidence_directory": ".deployment-evidence/20260729T004839Z",
+    "completed_utc": "2026-07-29T01:42:26Z",
+    "evidence_directory": ".deployment-evidence/20260729T014206Z",
     "completed_checks": [
-      "Python 3.12 execution of the 29-test unit and API suite with 0 failures, 0 errors, and 0 skips",
-      "isolated self-test RuntimeError failure-path regression with check_storage forced successful and get_registry forced to raise RuntimeError",
-      "all 22 manifest file hashes and sizes, JSON validity, and canonical manifest inventory digest verification",
-      "Python 3.12 compilation and final local Python AST parsing",
-      "final shell syntax validation",
-      "isolated localhost runtime build, startup, health, liveness, readiness, UI, relay, registry, self-test, and audit verification",
-      "relay and administrator role-separation verification across every administrator endpoint",
-      "Docker readiness and application persistent-storage readiness verification",
-      "container restart and registry and audit persistence verification",
-      "evidence permissions, SHA256SUMS integrity, valid rendered Compose YAML, and retained-environment-file absence verification",
-      "redacted Compose credential fields and evidence redaction verification",
-      "Git branch, HEAD, dirty pre-commit worktree state, authorized-package scope, and canonical manifest provenance verification",
-      "documentation review confirming isolated-localhost claims and explicit production, public-network, immutable-audit, rollback, recovery, and retention limitations",
-      "final Codex static audit and git diff --check"
+      "29-test Python 3.12 unit and API suite retained; application and test code unchanged",
+      "all 22 manifest hashes, sizes, JSON validity, and canonical inventory verification",
+      "final shell syntax and git diff validation",
+      "clean-checkout verification with an initially absent .deployment-evidence parent",
+      "fail-closed evidence-root type and permission validation",
+      "isolated localhost build, startup, health, readiness, role separation, self-test, restart, and persistence verification",
+      "evidence directory and file permission validation",
+      "SHA256SUMS, redacted Compose YAML, and baseline provenance validation",
+      "Git HEAD, dirty precommit state, and canonical manifest inventory binding",
+      "CI failure analysis and evidence-root initialization correction"
     ],
     "claims_boundary": [
       "isolated localhost validation only",
-      "CI execution and remote branch publication remain pending",
+      "committed-revision CI and remote publication are tracked outside this precommit evidence record",
+      "merge approval remains pending",
       "rollback and replacement-host recovery remain pending",
       "off-host evidence retention remains pending",
       "immutable audit is not provided by the application-appended local audit log",
       "production and public-network readiness remain pending"
     ],
-    "validated_git_head": "36508ca38e86649e4a786d34762150fbc2356cc8",
-    "validated_git_worktree_state": "dirty_precommit_hardening_revision",
-    "manifest_files_sha256": "dce43e8adbc1b11a408529c677f2b18631464c56513cabfa370b91b95294c6ee"
+    "validated_git_head": "b683a6470358e15f0480bef851db8a97bc47d2c6",
+    "validated_git_worktree_state": "dirty_precommit_ci_evidence_root_correction",
+    "manifest_files_sha256": "a3b62edb85877d99474c7601a3cbebb99f287100090bf0740a2887c875744bbb"
   },
   "repository_integration": {
     "workflow_path": ".github/workflows/sara-verified-local-v1.yml",
@@ -135,8 +132,8 @@
     },
     {
       "path": "scripts/verify_deployment.sh",
-      "sha256": "171289edd93874f6292f2c4f60b24c7e8f3fac61d9bb05541dfb0eef66472b79",
-      "size_bytes": 4302
+      "sha256": "05719fe88628e76cf9ac333aab8a729756964cc0c0c5e54f514c2ccd7bf740b1",
+      "size_bytes": 4812
     },
     {
       "path": "tests/conftest.py",

--- a/deployments/sara_verified_local_v1/README.md
+++ b/deployments/sara_verified_local_v1/README.md
@@ -6,13 +6,19 @@ Evidence-governed local administration and relay-recording service for the World
 
 - Local interface: `http://127.0.0.1:9530/ui` by default
 - Set `SARA_HOST_PORT` to select another localhost-only publication port while retaining internal container port `9530`
-- Public health check: `/health`
+- Unauthenticated compatibility health check: `/health`
+- Liveness check: `/livez`
+- Persistent-storage readiness check: `/readyz`
 - Authenticated local relay record: `/v1/relay`
 - Administrator audit: `/v1/audit?limit=50`
 - Administrator registry: `/admin/registry`
 - Administrator self-test: `/admin/selftest`
 
 External scanning, broadcasting, arbitrary command execution, third-party activation, and self-expanding network behavior are excluded.
+
+The audit is an application-appended JSON Lines log on the local persistent
+volume. It is useful operational evidence, but it is not immutable,
+tamper-proof, or independently verified.
 
 ## Quick start
 

--- a/deployments/sara_verified_local_v1/SECURITY.md
+++ b/deployments/sara_verified_local_v1/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported deployment
 
-Only the current approved release on localhost is supported. Public Internet exposure is not supported by this repository.
+Only the validated localhost package is supported. Public Internet exposure is not supported by this repository.
 
 ## Security controls
 
@@ -12,9 +12,16 @@ Only the current approved release on localhost is supported. Public Internet exp
 - Localhost-only Compose port binding
 - Read-only container filesystem
 - Dropped Linux capabilities and no-new-privileges
-- Durable append-only audit records
+- Application-appended local audit records with restrictive file permissions
+- Descriptor-based rejection of registry and audit symlink substitution
+- Persistent-storage readiness verification
 - No arbitrary command execution
 - No outbound network discovery or broadcast behavior
+
+The audit file is writable by the service account and therefore is not an
+immutable or tamper-proof record. Protect the host and volume, restrict
+operator access, and export logs to a separately controlled system if stronger
+assurance is required.
 
 ## Reporting
 

--- a/deployments/sara_verified_local_v1/compose.yaml
+++ b/deployments/sara_verified_local_v1/compose.yaml
@@ -21,7 +21,7 @@ services:
     cap_drop:
       - ALL
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9530/health', timeout=2)"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9530/readyz', timeout=2)"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/deployments/sara_verified_local_v1/docs/VERIFIED_DEPLOYMENT.md
+++ b/deployments/sara_verified_local_v1/docs/VERIFIED_DEPLOYMENT.md
@@ -20,20 +20,31 @@ Open `http://127.0.0.1:<SARA_HOST_PORT>/ui` after the verification script passes
 
 ## Required acceptance evidence
 
-A deployment is verified only when all of the following exist for the same Git commit:
+A promoted deployment is verified only when all of the following are bound to the same committed revision. Pre-commit local validation may instead be bound to a recorded Git HEAD, dirty-worktree state, and canonical manifest file-inventory digest:
 
-1. CI unit and API tests pass.
+1. Local unit and API tests pass; CI must also pass for the committed revision before promotion.
 2. The container image builds.
-3. Health and UI checks pass.
+3. Compatibility health, liveness, persistent-storage readiness, and UI checks pass.
 4. Relay authorization works.
 5. Relay credentials are denied administrator access.
 6. Registry changes persist.
 7. Audit records persist after restart.
 8. The administrator self-test passes.
 9. Deployment logs and evidence checksums are retained.
-10. CRE1AWS reviews and approves the evidence package.
+10. An authorized reviewer reviews and approves the evidence package before promotion.
+
+The rendered Compose evidence replaces the resolved `SARA_ADMIN_TOKEN` and
+`SARA_RELAY_TOKEN` values with `<REDACTED>` while preserving valid YAML.
+Evidence checksums are generated only after that redacted file is in place.
+
+The audit is an application-appended local log. The service account can write
+it, so this deployment does not claim immutability, tamper-proof retention, or
+independent verification of the log or of external dispatch controls.
 
 ## Rollback
+
+Rollback validation remains pending. The commands below are an operator
+procedure, not evidence that rollback has been exercised.
 
 ```bash
 docker compose down
@@ -42,3 +53,7 @@ docker compose up -d --build
 ```
 
 The named Docker volume is not deleted by `docker compose down`. Do not use `-v` during an operational rollback unless destruction of local evidence is explicitly approved.
+
+Replacement-host recovery and production readiness also remain pending and
+require separately retained backups, a tested restore exercise, operational
+monitoring, and an approved production threat model.

--- a/deployments/sara_verified_local_v1/scripts/admin_smoke_test.sh
+++ b/deployments/sara_verified_local_v1/scripts/admin_smoke_test.sh
@@ -9,30 +9,40 @@ json_header=(-H 'Content-Type: application/json')
 relay_auth=(-H "Authorization: Bearer ${SARA_RELAY_TOKEN}")
 admin_auth=(-H "Authorization: Bearer ${SARA_ADMIN_TOKEN}")
 
-printf '[1] Health\n'
+printf '[1] Compatibility health\n'
 curl --fail --silent --show-error "${BASE_URL}/health"
-printf '\n\n[2] UI\n'
+printf '\n\n[2] Liveness and readiness\n'
+curl --fail --silent --show-error "${BASE_URL}/livez"
+printf '\n'
+curl --fail --silent --show-error "${BASE_URL}/readyz"
+
+printf '\n\n[3] UI\n'
 curl --fail --silent --show-error "${BASE_URL}/ui" | grep -q 'Worldshepherd SARA'
 echo 'UI loads'
 
-printf '\n[3] Relay action\n'
+printf '\n[4] Relay action\n'
 curl --fail --silent --show-error "${relay_auth[@]}" "${json_header[@]}" \
   -d '{"target":"SSPADAWANZZ","action":"deployment_smoke_test","payload":{"scope":"local"}}' \
   "${BASE_URL}/v1/relay"
 
-printf '\n\n[4] Relay token blocked from admin audit\n'
-status="$(curl --silent --output /dev/null --write-out '%{http_code}' "${relay_auth[@]}" "${BASE_URL}/v1/audit")"
-[[ "$status" == "403" ]] || { echo "Expected 403, received $status" >&2; exit 1; }
+printf '\n\n[5] Relay token blocked from every admin endpoint\n'
+for endpoint in /v1/audit /admin/registry /admin/selftest; do
+  status="$(curl --silent --output /dev/null --write-out '%{http_code}' "${relay_auth[@]}" "${BASE_URL}${endpoint}")"
+  [[ "$status" == "403" ]] || { echo "Expected 403 from ${endpoint}, received $status" >&2; exit 1; }
+done
+status="$(curl --silent --output /dev/null --write-out '%{http_code}' -X PATCH \
+  "${relay_auth[@]}" "${json_header[@]}" -d '{"values":{}}' "${BASE_URL}/admin/registry")"
+[[ "$status" == "403" ]] || { echo "Expected 403 from PATCH /admin/registry, received $status" >&2; exit 1; }
 echo 'Role separation: OK'
 
-printf '\n[5] Admin registry patch\n'
+printf '\n[6] Admin registry patch\n'
 curl --fail --silent --show-error "${admin_auth[@]}" "${json_header[@]}" -X PATCH \
   -d '{"values":{"SARA_CORE":{"role":"core","status":"online"},"SSPADAWANZZ":{"role":"admin_operator","status":"online"}}}' \
   "${BASE_URL}/admin/registry"
 
-printf '\n\n[6] Admin self-test\n'
+printf '\n\n[7] Admin self-test\n'
 curl --fail --silent --show-error "${admin_auth[@]}" "${BASE_URL}/admin/selftest"
 
-printf '\n\n[7] Audit access\n'
+printf '\n\n[8] Audit access\n'
 curl --fail --silent --show-error "${admin_auth[@]}" "${BASE_URL}/v1/audit?limit=50"
 printf '\n\nSMOKE TEST: PASS\n'

--- a/deployments/sara_verified_local_v1/scripts/start_interface.sh
+++ b/deployments/sara_verified_local_v1/scripts/start_interface.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 

--- a/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
+++ b/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
@@ -19,10 +19,28 @@ base_url="${SARA_BASE_URL:-http://127.0.0.1:${host_port}}"
 export SARA_BASE_URL="${base_url}"
 
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-evidence_dir=".deployment-evidence/${stamp}"
+evidence_root=".deployment-evidence"
+evidence_dir="${evidence_root}/${stamp}"
 
-if ! mkdir "$evidence_dir"; then
-  echo "ERROR: Evidence directory already exists: ${evidence_dir}" >&2
+if [[ -e "$evidence_root" ]]; then
+  if [[ ! -d "$evidence_root" ]]; then
+    echo "ERROR: Evidence root exists but is not a directory: ${evidence_root}" >&2
+    exit 1
+  fi
+  chmod 0700 "$evidence_root"
+else
+  if ! mkdir -m 0700 "$evidence_root"; then
+    echo "ERROR: Could not create evidence root: ${evidence_root}" >&2
+    exit 1
+  fi
+fi
+
+if ! mkdir -m 0700 "$evidence_dir"; then
+  if [[ -e "$evidence_dir" ]]; then
+    echo "ERROR: Evidence directory already exists: ${evidence_dir}" >&2
+  else
+    echo "ERROR: Could not create evidence directory: ${evidence_dir}" >&2
+  fi
   exit 1
 fi
 

--- a/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
+++ b/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
@@ -19,27 +20,106 @@ export SARA_BASE_URL="${base_url}"
 
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 evidence_dir=".deployment-evidence/${stamp}"
-mkdir -p "$evidence_dir"
+
+if ! mkdir "$evidence_dir"; then
+  echo "ERROR: Evidence directory already exists: ${evidence_dir}" >&2
+  exit 1
+fi
+
+git_head="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+manifest_files_sha256="$(
+  python3 - <<'PY_MANIFEST'
+import hashlib
+import json
+from pathlib import Path
+
+manifest = json.loads(
+    Path("MANIFEST.json").read_text(encoding="utf-8")
+)
+payload = json.dumps(
+    manifest["files"],
+    sort_keys=True,
+    separators=(",", ":"),
+).encode("utf-8")
+print(hashlib.sha256(payload).hexdigest())
+PY_MANIFEST
+)"
+
+if git diff --quiet -- .   && git diff --cached --quiet -- .   && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
+  git_worktree_state="clean"
+else
+  git_worktree_state="dirty"
+fi
 
 {
   echo "timestamp_utc=${stamp}"
-  echo "git_commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "git_head=${git_head}"
+  echo "git_worktree_state=${git_worktree_state}"
+  echo "manifest_files_sha256=${manifest_files_sha256}"
   echo "docker_version=$(docker --version)"
   echo "compose_version=$(docker compose version)"
   echo "sara_host_port=${host_port}"
   echo "sara_base_url=${base_url}"
 } > "${evidence_dir}/baseline.txt"
 
-docker compose config > "${evidence_dir}/compose.rendered.yaml"
+redacted_compose="$(mktemp)"
+trap 'rm -f "$redacted_compose"' EXIT
+docker compose config | awk '
+  /^[[:space:]]*SARA_ADMIN_TOKEN:[[:space:]]*/ {
+    sub(/:.*/, ": \"<REDACTED>\"")
+    admin_tokens++
+  }
+  /^[[:space:]]*SARA_RELAY_TOKEN:[[:space:]]*/ {
+    sub(/:.*/, ": \"<REDACTED>\"")
+    relay_tokens++
+  }
+  { print }
+  END {
+    if (admin_tokens != 1 || relay_tokens != 1) {
+      print "ERROR: Compose token redaction did not find exactly one value for each token." > "/dev/stderr"
+      exit 1
+    }
+  }
+' > "$redacted_compose"
+mv "$redacted_compose" "${evidence_dir}/compose.rendered.yaml"
+trap - EXIT
 docker compose build --pull | tee "${evidence_dir}/build.log"
 docker compose up -d
 
+wait_for_healthy() {
+  local container_id health
+  container_id="$(docker compose ps -q sara)"
+  [[ -n "$container_id" ]] || return 1
+  for attempt in $(seq 1 30); do
+    health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container_id")"
+    if [[ "$health" == "healthy" ]]; then
+      return 0
+    fi
+    echo "Docker health attempt ${attempt}/30: ${health}..."
+    sleep 2
+  done
+  return 1
+}
+
+if ! wait_for_healthy; then
+  echo "ERROR: Docker did not report SARA healthy after startup." >&2
+  docker compose ps -a >&2
+  docker compose logs --no-color --tail=100 sara >&2
+  exit 1
+fi
+
+initial_ready=0
 for _ in $(seq 1 30); do
-  if curl --fail --silent ${base_url}/health > "${evidence_dir}/health.initial.json"; then
+  if curl --fail --silent "${base_url}/readyz" > "${evidence_dir}/health.initial.json"; then
+    initial_ready=1
     break
   fi
   sleep 2
 done
+if [[ "$initial_ready" -ne 1 ]]; then
+  echo "ERROR: Readiness endpoint did not pass after Docker became healthy." >&2
+  exit 1
+fi
 
 scripts/admin_smoke_test.sh | tee "${evidence_dir}/smoke.initial.log"
 docker compose restart sara
@@ -47,15 +127,10 @@ docker compose restart sara
 echo "Waiting for SARA health after restart..."
 restart_ready=0
 
-for attempt in $(seq 1 30); do
-  if curl --fail --silent ${base_url}/health > "${evidence_dir}/health.after-restart.json" 2>/dev/null; then
-    restart_ready=1
-    break
-  fi
-
-  echo "Restart health attempt ${attempt}/30..."
-  sleep 2
-done
+if wait_for_healthy && curl --fail --silent "${base_url}/readyz" \
+  > "${evidence_dir}/health.after-restart.json" 2>/dev/null; then
+  restart_ready=1
+fi
 
 if [ "${restart_ready}" -ne 1 ]; then
   echo "ERROR: SARA did not become healthy after restart." >&2
@@ -64,8 +139,12 @@ if [ "${restart_ready}" -ne 1 ]; then
   exit 1
 fi
 curl --fail --silent --show-error -H "Authorization: Bearer ${SARA_ADMIN_TOKEN}" \
-  ${base_url}/admin/registry | tee "${evidence_dir}/registry.after-restart.json" | grep -q "SARA_CORE"
+  "${base_url}/admin/registry" | tee "${evidence_dir}/registry.after-restart.json" | grep -q "SARA_CORE"
 scripts/admin_smoke_test.sh | tee "${evidence_dir}/smoke.after-restart.log"
+if ! wait_for_healthy; then
+  echo "ERROR: Docker health was not healthy before evidence capture." >&2
+  exit 1
+fi
 docker compose ps > "${evidence_dir}/compose.ps.txt"
 docker compose logs --no-color > "${evidence_dir}/service.log"
 

--- a/deployments/sara_verified_local_v1/tests/test_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_api.py
@@ -1,42 +1,109 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from worldshepherd_sara.app import RequestSizeLimitMiddleware
+from worldshepherd_sara.storage import DurableStore
+from worldshepherd_sara.limits import (
+    MAX_MAPPING_KEYS,
+    MAX_NESTING_DEPTH,
+    MAX_REQUEST_BYTES,
+    MAX_SEQUENCE_ITEMS,
+    MAX_STRING_LENGTH,
+)
+
 
 def auth(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def test_health_and_ui(client):
+def test_health_liveness_readiness_and_ui(client):
     health = client.get("/health")
     assert health.status_code == 200
     assert health.json()["ok"] is True
+    assert client.get("/livez").json() == {"ok": True, "status": "alive"}
+    ready = client.get("/readyz")
+    assert ready.status_code == 200
+    assert ready.json()["status"] == "ready"
     ui = client.get("/ui")
     assert ui.status_code == 200
     assert "Worldshepherd SARA" in ui.text
 
 
-def test_authentication_required(client):
-    response = client.get("/v1/audit")
+def test_readiness_reports_storage_failure_but_liveness_survives(client, monkeypatch):
+    monkeypatch.setattr(
+        client.app.state.store,
+        "check_storage",
+        lambda: (False, "simulated persistent-storage failure"),
+    )
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
+    assert client.get("/livez").status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("headers", "detail"),
+    [
+        ({}, "Missing Authorization header"),
+        ({"Authorization": "Basic abc"}, "Authorization must use Bearer token"),
+        ({"Authorization": "Bearer"}, "Authorization must use Bearer token"),
+        (auth("incorrect-token-value-000000"), "Invalid bearer token"),
+    ],
+)
+def test_missing_malformed_and_invalid_credentials(client, headers, detail):
+    response = client.get("/v1/audit", headers=headers)
+    assert response.status_code == 401
+    assert response.json()["detail"] == detail
+
+
+def test_invalid_credentials_rejected_by_relay_endpoint(client):
+    response = client.post(
+        "/v1/relay",
+        headers=auth("incorrect-token-value-000000"),
+        json={"target": "local", "action": "check", "payload": {}},
+    )
     assert response.status_code == 401
 
 
-def test_relay_token_can_record_local_relay(client, tokens):
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("get", "/v1/audit", None),
+        ("get", "/admin/registry", None),
+        ("patch", "/admin/registry", {"values": {}}),
+        ("get", "/admin/selftest", None),
+    ],
+)
+def test_every_admin_endpoint_rejects_relay_credentials(
+    client, tokens, method, path, body
+):
     relay, _ = tokens
-    response = client.post(
-        "/v1/relay",
-        headers=auth(relay),
-        json={"target": "SSPADAWANZZ", "action": "status_check", "payload": {"scope": "local"}},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "recorded_local_only"
-
-
-def test_relay_token_cannot_read_admin_audit(client, tokens):
-    relay, _ = tokens
-    response = client.get("/v1/audit", headers=auth(relay))
+    response = client.request(method, path, headers=auth(relay), json=body)
     assert response.status_code == 403
 
 
-def test_admin_registry_and_audit(client, tokens):
+def test_relay_and_admin_credentials_can_record_local_relay(client, tokens):
+    for token in tokens:
+        response = client.post(
+            "/v1/relay",
+            headers=auth(token),
+            json={
+                "target": "SSPADAWANZZ",
+                "action": "status_check",
+                "payload": {"scope": "local"},
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "recorded_local_only"
+
+
+def test_admin_registry_audit_and_selftest(client, tokens):
     _, admin = tokens
     patch = client.patch(
         "/admin/registry",
@@ -44,16 +111,252 @@ def test_admin_registry_and_audit(client, tokens):
         json={"values": {"SARA_CORE": {"role": "core", "status": "online"}}},
     )
     assert patch.status_code == 200
-    assert patch.json()["registry"]["SARA_CORE"]["status"] == "online"
+    assert client.get("/admin/registry", headers=auth(admin)).status_code == 200
+
+    selftest = client.get("/admin/selftest", headers=auth(admin))
+    assert selftest.status_code == 200
+    assert selftest.json()["ok"] is True
+    assert set(selftest.json()["checks"]) == {
+        "persistent_storage",
+        "registry_read",
+        "audit_append",
+    }
 
     audit = client.get("/v1/audit?limit=50", headers=auth(admin))
     assert audit.status_code == 200
     assert any(item["event"] == "registry_patched" for item in audit.json()["records"])
 
 
-def test_admin_selftest(client, tokens):
+def test_admin_selftest_structures_secure_registry_open_failure(
+    client, tokens, monkeypatch
+):
     _, admin = tokens
+
+    def fail_secure_registry_open():
+        raise RuntimeError("simulated secure registry-open failure")
+
+    monkeypatch.setattr(client.app.state.store, "get_registry", fail_secure_registry_open)
+    monkeypatch.setattr(
+        client.app.state.store,
+        "check_storage",
+        lambda: (True, "simulated persistent-storage success"),
+    )
+
     response = client.get("/admin/selftest", headers=auth(admin))
+
     assert response.status_code == 200
-    assert response.json()["ok"] is True
-    assert response.json()["checks"]["external_dispatch_disabled"] is True
+    body = response.json()
+    assert body["ok"] is False
+    assert body["checks"]["registry_read"] == {
+        "ok": False,
+        "detail": (
+            "registry read failed: simulated secure registry-open failure"
+        ),
+    }
+    assert body["checks"]["persistent_storage"]["ok"] is True
+    assert body["checks"]["audit_append"]["ok"] is True
+
+
+def test_malformed_json_does_not_mutate_state(client, tokens):
+    relay, admin = tokens
+    store = client.app.state.store
+    audit_before = store.audit_path.read_bytes()
+    registry_before = store.registry_path.read_bytes()
+    response = client.post(
+        "/v1/relay",
+        headers={**auth(relay), "Content-Type": "application/json"},
+        content=b'{"target":',
+    )
+    assert response.status_code == 422
+    assert store.audit_path.read_bytes() == audit_before
+    assert store.registry_path.read_bytes() == registry_before
+
+    response = client.patch(
+        "/admin/registry",
+        headers={**auth(admin), "Content-Type": "application/json"},
+        content=b'{"values":',
+    )
+    assert response.status_code == 422
+    assert store.audit_path.read_bytes() == audit_before
+    assert store.registry_path.read_bytes() == registry_before
+
+
+def test_oversized_request_does_not_mutate_state(client, tokens):
+    relay, _ = tokens
+    store = client.app.state.store
+    audit_before = store.audit_path.read_bytes()
+    response = client.post(
+        "/v1/relay",
+        headers={**auth(relay), "Content-Type": "application/json"},
+        content=b"x" * (MAX_REQUEST_BYTES + 1),
+    )
+    assert response.status_code == 413
+    assert store.audit_path.read_bytes() == audit_before
+
+
+def test_request_limit_counts_streamed_body_without_content_length():
+    sent: list[dict[str, object]] = []
+    incoming = iter(
+        [
+            {"type": "http.request", "body": b"abc", "more_body": True},
+            {"type": "http.request", "body": b"def", "more_body": False},
+        ]
+    )
+
+    async def receive():
+        return next(incoming)
+
+    async def send(message):
+        sent.append(message)
+
+    async def downstream(scope, receive, send):
+        while True:
+            message = await receive()
+            if not message.get("more_body", False):
+                break
+        await send(
+            {"type": "http.response.start", "status": 200, "headers": []}
+        )
+        await send({"type": "http.response.body", "body": b"unexpected"})
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "scheme": "http",
+        "method": "POST",
+        "server": ("testserver", 80),
+        "client": ("testclient", 123),
+        "root_path": "",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    middleware = RequestSizeLimitMiddleware(downstream, max_bytes=4)
+    asyncio.run(middleware(scope, receive, send))
+
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 413
+
+    body = b"".join(
+        message.get("body", b"")
+        for message in sent
+        if message["type"] == "http.response.body"
+    )
+    assert json.loads(body) == {"detail": "Request body exceeds 4 bytes"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"nested": [[[[[[[[["too deep"]]]]]]]]]},
+        {"many_keys": {f"k{i}": i for i in range(MAX_MAPPING_KEYS + 1)}},
+        {"many_items": list(range(MAX_SEQUENCE_ITEMS + 1))},
+        {"long": "x" * (MAX_STRING_LENGTH + 1)},
+        {"serialized": ["x" * 400 for _ in range(MAX_SEQUENCE_ITEMS)]},
+    ],
+)
+def test_relay_resource_limits_do_not_mutate_state(client, tokens, payload):
+    relay, _ = tokens
+    store = client.app.state.store
+    before = store.audit_path.read_bytes()
+    response = client.post(
+        "/v1/relay",
+        headers=auth(relay),
+        json={"target": "local", "action": "check", "payload": payload},
+    )
+    assert response.status_code == 422
+    assert store.audit_path.read_bytes() == before
+
+
+def test_registry_limits_do_not_mutate_registry_or_audit(client, tokens):
+    _, admin = tokens
+    store = client.app.state.store
+    registry_before = store.registry_path.read_bytes()
+    audit_before = store.audit_path.read_bytes()
+    nested: object = "leaf"
+    for _ in range(MAX_NESTING_DEPTH + 1):
+        nested = {"child": nested}
+    response = client.patch(
+        "/admin/registry",
+        headers=auth(admin),
+        json={"values": {"nested": nested}},
+    )
+    assert response.status_code == 422
+    assert store.registry_path.read_bytes() == registry_before
+    assert store.audit_path.read_bytes() == audit_before
+
+
+def test_runtime_file_modes(client):
+    store = client.app.state.store
+    assert stat.S_IMODE(store.root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(store.registry_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(store.audit_path.stat().st_mode) == 0o600
+
+
+def test_registry_symlink_swap_is_rejected(tmp_path):
+    store = DurableStore(tmp_path / "data")
+    outside = tmp_path / "outside-registry.json"
+    outside.write_text('{"outside": true}\n', encoding="utf-8")
+
+    store.registry_path.unlink()
+    store.registry_path.symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="registry file"):
+        store.get_registry()
+
+    assert outside.read_text(encoding="utf-8") == '{"outside": true}\n'
+
+
+def test_audit_symlink_swap_is_rejected(tmp_path):
+    store = DurableStore(tmp_path / "data")
+    outside = tmp_path / "outside-audit.jsonl"
+    outside.write_text('{"event": "outside"}\n', encoding="utf-8")
+
+    store.audit_path.symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="audit file"):
+        store.read_audit(1)
+
+    assert outside.read_text(encoding="utf-8") == '{"event": "outside"}\n'
+
+
+def test_registry_replace_fsyncs_parent_directory(tmp_path, monkeypatch):
+    store = DurableStore(tmp_path / "data")
+    synchronized: list[Path] = []
+
+    monkeypatch.setattr(
+        store,
+        "_fsync_directory",
+        lambda path: synchronized.append(path),
+    )
+
+    store.patch_registry({"SARA_CORE": {"status": "online"}})
+
+    assert synchronized == [store.root]
+
+
+def test_corrupted_audit_lines_are_safely_labeled(client, tokens):
+    _, admin = tokens
+    store = client.app.state.store
+    with store.audit_path.open("ab") as handle:
+        handle.write(b"not-json\n")
+    response = client.get("/v1/audit?limit=1", headers=auth(admin))
+    assert response.status_code == 200
+    assert response.json()["records"] == [
+        {"event": "audit_corruption_detected", "reason": "invalid_line"}
+    ]
+
+
+def test_audit_tail_does_not_use_whole_file_read(client, tokens, monkeypatch):
+    _, admin = tokens
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda *args, **kwargs: pytest.fail("whole-file read is forbidden"),
+    )
+    response = client.get("/v1/audit?limit=1", headers=auth(admin))
+    assert response.status_code == 200
+    assert len(response.json()["records"]) == 1

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/__main__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/__main__.py
@@ -6,6 +6,7 @@ import uvicorn
 
 
 if __name__ == "__main__":
+    os.umask(0o077)
     uvicorn.run(
         "worldshepherd_sara.app:app",
         host=os.getenv("SARA_BIND_HOST", "127.0.0.1"),

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
@@ -1,21 +1,85 @@
 from __future__ import annotations
 
+import json
 import os
 import secrets
 from contextlib import asynccontextmanager
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import Depends, FastAPI, Query, Request
-from fastapi.responses import HTMLResponse
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from . import __version__
 from .auth import Role, require_admin, resolve_role, validate_runtime_secrets
+from .limits import MAX_REQUEST_BYTES
 from .models import AuditRecord, RegistryPatch, RelayRequest, RelayResponse
 from .storage import DurableStore
 
 
+class RequestTooLarge(Exception):
+    pass
+
+
+class RequestSizeLimitMiddleware:
+    def __init__(self, app: ASGIApp, max_bytes: int = MAX_REQUEST_BYTES) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        raw_length = headers.get(b"content-length")
+        if raw_length is not None:
+            try:
+                content_length = int(raw_length)
+            except ValueError:
+                await JSONResponse(
+                    {"detail": "Malformed Content-Length header"}, status_code=400
+                )(scope, receive, send)
+                return
+            if content_length < 0:
+                await JSONResponse(
+                    {"detail": "Malformed Content-Length header"}, status_code=400
+                )(scope, receive, send)
+                return
+            if content_length > self.max_bytes:
+                await self._reject(scope, receive, send)
+                return
+
+        received = 0
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    raise RequestTooLarge
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except RequestTooLarge:
+            await self._reject(scope, receive, send)
+
+    async def _reject(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        await JSONResponse(
+            {"detail": f"Request body exceeds {self.max_bytes} bytes"},
+            status_code=413,
+        )(scope, receive, send)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    os.umask(0o077)
     validate_runtime_secrets()
     app.state.store = DurableStore()
     app.state.store.append_audit(
@@ -38,6 +102,7 @@ app = FastAPI(
     docs_url=None,
     redoc_url=None,
 )
+app.add_middleware(RequestSizeLimitMiddleware)
 
 
 @app.middleware("http")
@@ -64,12 +129,28 @@ def health() -> dict[str, object]:
         "mode": os.getenv("SARA_MODE", "local"),
         "endpoints": {
             "ui": "/ui",
+            "liveness": "/livez",
+            "readiness": "/readyz",
             "audit": "/v1/audit?limit=50",
             "registry": "/admin/registry",
             "relay": "/v1/relay",
             "selftest": "/admin/selftest",
         },
     }
+
+
+@app.get("/livez")
+def liveness() -> dict[str, object]:
+    return {"ok": True, "status": "alive"}
+
+
+@app.get("/readyz")
+def readiness(request: Request) -> JSONResponse:
+    ready, detail = store(request).check_storage()
+    return JSONResponse(
+        {"ok": ready, "status": "ready" if ready else "not_ready", "storage": detail},
+        status_code=200 if ready else 503,
+    )
 
 
 @app.get("/ui", response_class=HTMLResponse)
@@ -143,7 +224,10 @@ def registry_patch(
     role: Annotated[Role, Depends(resolve_role)],
 ) -> dict[str, object]:
     require_admin(role)
-    updated = store(request).patch_registry(body.values)
+    try:
+        updated = store(request).patch_registry(body.values)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     store(request).append_audit(
         AuditRecord.create(
             event="registry_patched",
@@ -160,15 +244,41 @@ def selftest(
     role: Annotated[Role, Depends(resolve_role)],
 ) -> dict[str, object]:
     require_admin(role)
-    registry = store(request).get_registry()
-    checks = {
-        "storage_directory": store(request).root.exists(),
-        "registry_readable": isinstance(registry, dict),
-        "audit_writable": True,
-        "authority_separation": True,
-        "external_dispatch_disabled": True,
-    }
-    store(request).append_audit(
-        AuditRecord.create(event="selftest_run", actor=role.value, payload=checks)
+    durable_store = store(request)
+    storage_ok, storage_detail = durable_store.check_storage()
+    try:
+        registry_ok = isinstance(durable_store.get_registry(), dict)
+        registry_detail = "registry parsed as a JSON object"
+    except (OSError, RuntimeError, json.JSONDecodeError, ValueError) as exc:
+        registry_ok = False
+        registry_detail = f"registry read failed: {exc}"
+    audit_probe = AuditRecord.create(
+        event="selftest_audit_probe", actor=role.value, payload={}
     )
-    return {"ok": all(checks.values()), "checks": checks}
+    try:
+        durable_store.append_audit(audit_probe)
+        audit_ok = True
+        audit_detail = "application audit append and fsync completed"
+    except (OSError, RuntimeError) as exc:
+        audit_ok = False
+        audit_detail = f"audit append failed: {exc}"
+    checks: dict[str, dict[str, Any]] = {
+        "persistent_storage": {"ok": storage_ok, "detail": storage_detail},
+        "registry_read": {
+            "ok": registry_ok,
+            "detail": registry_detail,
+        },
+        "audit_append": {
+            "ok": audit_ok,
+            "detail": audit_detail,
+        },
+    }
+    if audit_ok:
+        durable_store.append_audit(
+            AuditRecord.create(
+                event="selftest_run",
+                actor=role.value,
+                payload={name: check["ok"] for name, check in checks.items()},
+            )
+        )
+    return {"ok": all(check["ok"] for check in checks.values()), "checks": checks}

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/limits.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/limits.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+MAX_REQUEST_BYTES = 64 * 1024
+MAX_SERIALIZED_BYTES = 48 * 1024
+MAX_NESTING_DEPTH = 8
+MAX_MAPPING_KEYS = 64
+MAX_SEQUENCE_ITEMS = 128
+MAX_STRING_LENGTH = 4096
+MAX_AUDIT_LINE_BYTES = 64 * 1024
+
+
+def validate_json_resource(value: Any) -> Any:
+    """Reject JSON-shaped data that exceeds the service resource budget."""
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        if depth > MAX_NESTING_DEPTH:
+            raise ValueError(f"maximum nesting depth is {MAX_NESTING_DEPTH}")
+        if isinstance(item, str):
+            if len(item) > MAX_STRING_LENGTH:
+                raise ValueError(f"maximum string length is {MAX_STRING_LENGTH}")
+        elif isinstance(item, Mapping):
+            if len(item) > MAX_MAPPING_KEYS:
+                raise ValueError(f"maximum mapping size is {MAX_MAPPING_KEYS}")
+            for key, child in item.items():
+                if not isinstance(key, str):
+                    raise ValueError("mapping keys must be strings")
+                if len(key) > MAX_STRING_LENGTH:
+                    raise ValueError(f"maximum key length is {MAX_STRING_LENGTH}")
+                stack.append((child, depth + 1))
+        elif isinstance(item, Sequence) and not isinstance(
+            item, (str, bytes, bytearray)
+        ):
+            if len(item) > MAX_SEQUENCE_ITEMS:
+                raise ValueError(f"maximum sequence size is {MAX_SEQUENCE_ITEMS}")
+            stack.extend((child, depth + 1) for child in item)
+
+    encoded = json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    if len(encoded) > MAX_SERIALIZED_BYTES:
+        raise ValueError(f"maximum serialized size is {MAX_SERIALIZED_BYTES} bytes")
+    return value

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/models.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/models.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from .limits import validate_json_resource
 
 
 class RelayRequest(BaseModel):
@@ -11,6 +13,11 @@ class RelayRequest(BaseModel):
     action: str = Field(min_length=1, max_length=128)
     payload: dict[str, Any] = Field(default_factory=dict)
     correlation_id: str | None = Field(default=None, max_length=128)
+
+    @field_validator("payload")
+    @classmethod
+    def payload_within_limits(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_json_resource(value)
 
 
 class RelayResponse(BaseModel):
@@ -23,6 +30,11 @@ class RelayResponse(BaseModel):
 
 class RegistryPatch(BaseModel):
     values: dict[str, Any]
+
+    @field_validator("values")
+    @classmethod
+    def values_within_limits(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_json_resource(value)
 
 
 class AuditRecord(BaseModel):

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
+import stat
 import threading
+from collections import deque
 from pathlib import Path
 from typing import Any
 
+from .limits import MAX_AUDIT_LINE_BYTES, validate_json_resource
 from .models import AuditRecord
 
 
@@ -13,50 +17,256 @@ class DurableStore:
     def __init__(self, data_dir: str | Path | None = None) -> None:
         root = Path(data_dir or os.getenv("SARA_DATA_DIR", "./data")).resolve()
         root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self._secure_mode(root, 0o700, "data directory")
         self.root = root
         self.audit_path = root / "audit.jsonl"
         self.registry_path = root / "registry.json"
         self._lock = threading.RLock()
         if not self.registry_path.exists():
             self._atomic_write_json(self.registry_path, {})
+        else:
+            self._secure_mode(self.registry_path, 0o600, "registry file")
+        if self.audit_path.exists():
+            self._secure_mode(self.audit_path, 0o600, "audit file")
+
+    @staticmethod
+    def _secure_mode(path: Path, mode: int, label: str) -> None:
+        expected_directory = "directory" in label
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        if expected_directory:
+            flags |= getattr(os, "O_DIRECTORY", 0)
+
+        try:
+            descriptor = os.open(path, flags)
+        except OSError as exc:
+            raise RuntimeError(f"Unable to secure {label}: {exc}") from exc
+
+        try:
+            path_status = os.fstat(descriptor)
+            expected_type = stat.S_ISDIR if expected_directory else stat.S_ISREG
+
+            if not expected_type(path_status.st_mode):
+                raise RuntimeError(
+                    f"Unable to secure {label}: unexpected file type"
+                )
+
+            os.fchmod(descriptor, mode)
+            actual = stat.S_IMODE(os.fstat(descriptor).st_mode)
+
+            if actual != mode:
+                raise RuntimeError(
+                    f"Unable to secure {label}: "
+                    f"expected {mode:04o}, found {actual:04o}"
+                )
+        except OSError as exc:
+            raise RuntimeError(f"Unable to secure {label}: {exc}") from exc
+        finally:
+            os.close(descriptor)
 
     def _atomic_write_json(self, path: Path, value: Any) -> None:
-        temp = path.with_suffix(path.suffix + ".tmp")
-        with temp.open("w", encoding="utf-8") as handle:
-            json.dump(value, handle, sort_keys=True, indent=2)
-            handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temp, path)
+        temp = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+        try:
+            descriptor = os.open(
+                temp,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"Unable to create secured registry file: {exc}") from exc
+        try:
+            self._secure_descriptor(descriptor, 0o600, "temporary registry file")
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump(value, handle, sort_keys=True, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._secure_mode(temp, 0o600, "temporary registry file")
+            os.replace(temp, path)
+            self._secure_mode(path, 0o600, "registry file")
+            self._fsync_directory(path.parent)
+        except Exception:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            temp.unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _secure_descriptor(descriptor: int, mode: int, label: str) -> None:
+        try:
+            file_status = os.fstat(descriptor)
+            if not stat.S_ISREG(file_status.st_mode):
+                raise RuntimeError(
+                    f"Unable to secure {label}: unexpected file type"
+                )
+
+            os.fchmod(descriptor, mode)
+            actual = stat.S_IMODE(os.fstat(descriptor).st_mode)
+        except OSError as exc:
+            raise RuntimeError(f"Unable to secure {label}: {exc}") from exc
+
+        if actual != mode:
+            raise RuntimeError(
+                f"Unable to secure {label}: "
+                f"expected {mode:04o}, found {actual:04o}"
+            )
+
+    @staticmethod
+    def _open_read_descriptor(path: Path, label: str) -> int:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+
+        try:
+            descriptor = os.open(path, flags)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to open {label} securely: {exc}"
+            ) from exc
+
+        try:
+            DurableStore._secure_descriptor(descriptor, 0o600, label)
+        except Exception:
+            os.close(descriptor)
+            raise
+
+        return descriptor
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+
+        try:
+            descriptor = os.open(path, flags)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to open registry directory securely: {exc}"
+            ) from exc
+
+        try:
+            if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+                raise RuntimeError(
+                    "Unable to secure registry directory: unexpected file type"
+                )
+            os.fsync(descriptor)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to synchronize registry directory: {exc}"
+            ) from exc
+        finally:
+            os.close(descriptor)
 
     def append_audit(self, record: AuditRecord) -> None:
         line = record.model_dump_json(exclude_none=True)
         with self._lock:
-            with self.audit_path.open("a", encoding="utf-8") as handle:
+            descriptor = os.open(
+                self.audit_path,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_APPEND
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+            )
+            try:
+                self._secure_descriptor(descriptor, 0o600, "audit file")
+            except Exception:
+                os.close(descriptor)
+                raise
+            with os.fdopen(descriptor, "a", encoding="utf-8") as handle:
                 handle.write(line + "\n")
                 handle.flush()
                 os.fsync(handle.fileno())
+            self._secure_mode(self.audit_path, 0o600, "audit file")
 
     def read_audit(self, limit: int) -> list[dict[str, Any]]:
         with self._lock:
-            if not self.audit_path.exists():
-                return []
-            lines = self.audit_path.read_text(encoding="utf-8").splitlines()
-        records: list[dict[str, Any]] = []
-        for line in lines[-limit:]:
             try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                records.append({"event": "audit_corruption_detected", "raw": line})
+                self.audit_path.lstat()
+            except FileNotFoundError:
+                return []
+            lines = self._bounded_tail(limit)
+        records: list[dict[str, Any]] = []
+        for line, truncated in lines:
+            if truncated:
+                records.append({"event": "audit_corruption_detected", "reason": "line_too_long"})
+                continue
+            try:
+                value = json.loads(line.decode("utf-8"))
+                if not isinstance(value, dict):
+                    raise ValueError("audit record is not an object")
+                records.append(value)
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+                records.append({"event": "audit_corruption_detected", "reason": "invalid_line"})
         return records
+
+    def _bounded_tail(self, limit: int) -> list[tuple[bytes, bool]]:
+        records: deque[tuple[bytes, bool]] = deque(maxlen=limit)
+        current = bytearray()
+        truncated = False
+        descriptor = self._open_read_descriptor(
+            self.audit_path, "audit file"
+        )
+        with os.fdopen(descriptor, "rb") as handle:
+            while chunk := handle.read(8192):
+                for byte in chunk:
+                    if byte == 0x0A:
+                        records.append((bytes(current), truncated))
+                        current.clear()
+                        truncated = False
+                    elif len(current) < MAX_AUDIT_LINE_BYTES:
+                        current.append(byte)
+                    else:
+                        truncated = True
+            if current or truncated:
+                records.append((bytes(current), truncated))
+        return list(records)
 
     def get_registry(self) -> dict[str, Any]:
         with self._lock:
-            return json.loads(self.registry_path.read_text(encoding="utf-8"))
+            descriptor = self._open_read_descriptor(
+                self.registry_path, "registry file"
+            )
+            with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+                value = json.load(handle)
+
+            if not isinstance(value, dict):
+                raise ValueError("registry must contain a JSON object")
+
+            return validate_json_resource(value)
 
     def patch_registry(self, values: dict[str, Any]) -> dict[str, Any]:
         with self._lock:
             current = self.get_registry()
             current.update(values)
+            validate_json_resource(current)
             self._atomic_write_json(self.registry_path, current)
             return current
+
+    def check_storage(self) -> tuple[bool, str]:
+        probe = self.root / f".readiness-{secrets.token_hex(8)}"
+        try:
+            self._secure_mode(self.root, 0o700, "data directory")
+            self._secure_mode(self.registry_path, 0o600, "registry file")
+            self.get_registry()
+            descriptor = os.open(
+                probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+            )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write("ready\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._secure_mode(probe, 0o600, "readiness probe")
+            probe.unlink()
+        except (OSError, RuntimeError, json.JSONDecodeError, ValueError) as exc:
+            try:
+                probe.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return False, str(exc)
+        return True, "persistent storage is readable, writable, and secured"


### PR DESCRIPTION
## Scope

Hardens the namespaced Worldshepherd SARA / SSPADAWANZZ localhost deployment package under:

`deployments/sara_verified_local_v1`

## Validated changes

- Request-size and structured-JSON resource limits
- Separate liveness and persistent-storage readiness endpoints
- Descriptor-based registry and audit symlink defenses
- Atomic registry replacement with parent-directory synchronization
- Restrictive runtime directory and file permissions
- Bounded-memory audit-result retention
- Expanded authorization, malformed-input, corruption, persistence, and filesystem-security tests
- Structured administrator self-test failure handling
- Provenance-aware, credential-redacted deployment evidence
- Corrected localhost-only security and readiness claims

## Local validation

- Python 3.12 test suite: 29 passed, 0 failures, 0 errors, 0 skips
- Isolated Docker Compose project: `sara_orl4_hardening_20260728`
- Isolated host port: `19532`
- Canonical manifest inventory:
  `dce43e8adbc1b11a408529c677f2b18631464c56513cabfa370b91b95294c6ee`
- Final evidence:
  `.deployment-evidence/20260729T004839Z`

Deployment evidence and `.env` are intentionally excluded from Git.

## Claims boundary

This pull request supports controlled isolated localhost ORL-4 validation only.

It does not claim:

- Production or public-network readiness
- Immutable audit retention
- Exercised rollback or replacement-host recovery
- Off-host evidence retention
- FOC-B completion

Committed-revision CI and maintainer review are required before merge.
