### PR TITLE
Add WS-NV-01 NVIDIA integration, proof interfaces, and review gate

### DIFF
--- a/deployments/sara_verified_local_v1/docs/NVIDIA_PARTNER_BRIEF.md
+++ b/deployments/sara_verified_local_v1/docs/NVIDIA_PARTNER_BRIEF.md
@@ -1,0 +1,101 @@
+# Worldshepherd × NVIDIA — Partner Technical Brief
+
+## Executive proposition
+
+Worldshepherd is building an evidence-governed control and validation layer for physical AI: the layer between simulation, autonomous/agentic decisions, edge execution, and operational evidence.
+
+The NVIDIA-facing question is narrow:
+
+> Can Worldshepherd provide a reusable governance, provenance, authorization, degraded-state testing, and evidence layer around NVIDIA physical-AI workflows without constraining the underlying NVIDIA runtime?
+
+WS-NV-01 is the current proof package. The software contracts are implemented and repository-tested. NVIDIA runtimes and hardware are deliberately **not** claimed as validated yet.
+
+## Why NVIDIA
+
+Current NVIDIA public material aligns directly with the workstream:
+
+- NVIDIA Inception supports startups building on the NVIDIA ecosystem, including companies that are not yet using NVIDIA GPUs or SDKs; formal membership requires official incorporation and other published eligibility criteria.
+- NVIDIA Federal positions Omniverse for training/simulation and digital twins, and Jetson for autonomous machines at the tactical edge.
+- NVIDIA's physical-AI stack spans Omniverse, Isaac, Jetson, Cosmos, accelerated computing, and partner ecosystems.
+
+Official references:
+
+- https://www.nvidia.com/en-us/startups/
+- https://www.nvidia.com/en-us/industries/government/federal/
+- https://nvidianews.nvidia.com/news/japans-robotics-and-manufacturing-leaders-build-on-nvidia-cosmos-to-advance-physical-ai-frontier
+
+## What is implemented today
+
+Repository: https://github.com/Bdavis1390/Sara_pro
+
+Review package: https://github.com/Bdavis1390/Sara_pro/pull/12
+
+### WS-NV-01 through WS-NV-01G
+
+1. **Integration manifest and claims gates** — declares Omniverse Kit, Isaac Sim/ROS 2, Jetson Platform Services, and CUDA boundaries.
+2. **Authenticated status endpoint** — read-only SARA status surface with no NVIDIA calls and no application-audit mutation.
+3. **Configuration-digested evidence envelopes** — deterministic SHA-256 digests without retaining raw runtime configuration.
+4. **Omniverse proof-of-interface contract** — versioned headless-service request/response and offline parser.
+5. **Isaac Sim ROS 2 observation contract** — captures bridge version, ROS distribution, simulation state, topics/services, and correlation.
+6. **Jetson Platform Services observation contract** — captures service identity, JetPack/JPS versions, API operations, status, and correlation.
+7. **CUDA compute observation contract** — captures driver/toolkit/device/compute-capability metadata plus workload/result digests.
+8. **Promotion-readiness gate** — complete evidence can become ready for human review, but software cannot auto-promote a capability to VALIDATED.
+
+The branch is covered by the existing SARA compile/test/Compose/deployment gate. Passing that gate validates the Worldshepherd software boundary only.
+
+## Current claims state
+
+| Surface | Worldshepherd software contract | NVIDIA runtime/hardware state |
+|---|---|---|
+| Omniverse Kit | IMPLEMENTED IN SOFTWARE | REQUIRES PARTNER VALIDATION |
+| Isaac Sim ROS 2 | IMPLEMENTED IN SOFTWARE | REQUIRES LAB VALIDATION |
+| Jetson Platform Services | IMPLEMENTED IN SOFTWARE | REQUIRES LAB VALIDATION |
+| CUDA acceleration | IMPLEMENTED IN SOFTWARE | REQUIRES LAB VALIDATION |
+
+No outbound NVIDIA client, vendor credential, GPU control path, ROS client, Jetson hardware claim, or Omniverse runtime claim is hidden inside the current implementation.
+
+## Three bounded demonstrations
+
+### NV-D1 — Simulation to Evidence
+
+Omniverse/Isaac event → bounded integration contract → SARA authorization/workflow → telemetry and decision provenance → evidence envelope → human review gate.
+
+**Partner ask:** approved Omniverse/Isaac environment plus a technical reviewer for the interface contract.
+
+### NV-D2 — Governed Edge Autonomy
+
+Jetson Platform Service event → local policy gate → telemetry/provenance → degraded-state exercise → operator override/recovery evidence.
+
+**Partner ask:** approved Jetson test environment and guidance on the most appropriate Platform Service for a first bounded demonstration.
+
+### NV-D3 — Accelerated Evidence Workload
+
+Small deterministic CUDA workload → runtime/device inventory → workload digest → execution → result digest → repeatability comparison → evidence package.
+
+**Partner ask:** approved GPU/CUDA environment and confirmation that the selected workload is a useful minimal integration proof.
+
+## Runtime validation packages already opened
+
+- LAB-NV-01 — Omniverse + Isaac runtime validation: https://github.com/Bdavis1390/Sara_pro/issues/13
+- LAB-NV-02 — Jetson + CUDA hardware validation: https://github.com/Bdavis1390/Sara_pro/issues/14
+
+## What we are asking NVIDIA for
+
+The preferred first engagement is technical routing, not investment:
+
+1. Identify the best technical owner for an Omniverse/physical-AI integration review.
+2. Confirm whether the WS-NV-01 contract boundaries are sensible for NVIDIA's current platform direction.
+3. Select one bounded runtime demonstration and an approved environment.
+4. Review the resulting evidence package before any capability claim is promoted.
+
+If the technical fit is established, subsequent discussions can address ecosystem participation, public-sector alignment, Inception eligibility after incorporation requirements are met, and broader partnership opportunities.
+
+## Governance boundary
+
+Worldshepherd follows a simple operational rule:
+
+**AI proposes → human approves → automation remains bounded → actions and evidence are logged.**
+
+For NVIDIA integration specifically:
+
+**Software completeness is not runtime validation. Runtime evidence is not claim promotion. Claim promotion requires explicit human review.**

--- a/deployments/sara_verified_local_v1/docs/NVIDIA_RUNTIME_EVIDENCE_PACKET.md
+++ b/deployments/sara_verified_local_v1/docs/NVIDIA_RUNTIME_EVIDENCE_PACKET.md
@@ -1,0 +1,169 @@
+# NVIDIA Runtime Evidence Packet — LAB-NV-01 / LAB-NV-02
+
+This packet is the minimum evidence structure for executing WS-NV-01 against real NVIDIA runtimes or hardware.
+
+It is intentionally stricter than a successful demo. A demo may prove that an interface works once; this packet is designed to establish configuration custody, reproducibility, degraded-state behavior, provenance, and explicit operator authorization.
+
+## 1. Evidence package identity
+
+Record:
+
+- package ID;
+- UTC campaign start/end;
+- operator identity/role;
+- reviewer identity/role;
+- Worldshepherd/SARA commit SHA;
+- WS-NV-01 contract digest;
+- host identifier;
+- operating system and version;
+- evidence storage location;
+- manifest digest;
+- data classification/sensitivity marking.
+
+Do not place passwords, API keys, bearer tokens, private keys, or confidential partner configuration in the package metadata.
+
+## 2. Required evidence categories
+
+Every surface must provide at least one valid evidence reference for each category before the package is eligible for human review:
+
+1. `runtime_version_inventory`
+2. `configuration_digest`
+3. `bounded_interface_test`
+4. `telemetry_and_provenance`
+5. `failure_or_degraded_behavior`
+6. `operator_authorization`
+
+WS-NV-01G evaluates completeness only. It never grants VALIDATED status.
+
+## 3. Omniverse Kit — LAB-NV-01A
+
+Capture:
+
+- Kit/runtime version;
+- enabled extension/service versions relevant to the test;
+- launch mode and headless/service configuration digest;
+- Worldshepherd request correlation ID;
+- exact WS-NV-01C request payload as an evidence object;
+- exact captured service response as an evidence object;
+- response status and latency;
+- service/application logs covering the exchange;
+- one controlled malformed/invalid request;
+- one controlled service-unavailable or dependency-failure case when safe;
+- recovery behavior;
+- operator authorization reference.
+
+Success criterion for interface evidence: an actual Omniverse-backed service accepts the bounded request contract and returns a correlation-preserving response that the offline Worldshepherd parser accepts.
+
+This is **not** sufficient by itself for claim promotion.
+
+## 4. Isaac Sim / ROS 2 — LAB-NV-01B
+
+Capture:
+
+- Isaac Sim version;
+- `isaacsim.ros2.bridge` version;
+- ROS distribution and middleware when relevant;
+- simulation/scenario identifier and configuration digest;
+- confirmation of playback state;
+- observed ROS 2 topic names and message types;
+- observed ROS 2 service names/types where practical;
+- correlation strategy between SARA evidence and simulation event;
+- timestamps and telemetry;
+- one pause/stopped-state observation demonstrating bridge behavior changes as expected;
+- one controlled invalid topic/service or unavailable dependency case when safe;
+- recovery behavior;
+- operator authorization reference.
+
+Worldshepherd must not classify bridge activity as demonstrated unless the observation came from an actual Isaac Sim runtime.
+
+## 5. Jetson Platform Services — LAB-NV-02A
+
+Capture:
+
+- exact Jetson model and module/carrier information when relevant;
+- JetPack version;
+- Jetson Platform Services version;
+- container/runtime versions;
+- service inventory;
+- selected bounded Platform Service;
+- API operation/method/path used for the test;
+- request/response status and correlation ID;
+- configuration digest;
+- service logs/telemetry;
+- resource telemetry appropriate to the workload;
+- one unavailable/degraded-service test;
+- recovery evidence;
+- operator authorization reference.
+
+Do not store bearer tokens, API keys, or credentials in request evidence. Redact sensitive headers before evidence capture.
+
+## 6. CUDA — LAB-NV-02B
+
+Capture:
+
+- GPU model;
+- NVIDIA driver version;
+- CUDA Toolkit/runtime version;
+- device compute capability;
+- selected deterministic workload description;
+- source/input/workload SHA-256 digest;
+- configuration digest;
+- execution command or bounded invocation metadata with secrets removed;
+- result/output SHA-256 digest;
+- runtime duration and relevant telemetry;
+- second execution using the same frozen workload/configuration;
+- repeatability comparison;
+- one controlled failure or incompatible-input case;
+- operator authorization reference.
+
+The first workload should be non-sensitive, deterministic, small, and easy to independently reproduce. It should prove the evidence path before performance optimization is attempted.
+
+## 7. Provenance requirements
+
+For every evidence object record, where available:
+
+- evidence ID;
+- source system;
+- producing process/tool;
+- capture timestamp in UTC;
+- correlation ID;
+- configuration/contract digest;
+- content digest;
+- parent evidence references;
+- operator/reviewer reference;
+- claims status at time of capture.
+
+Evidence should be immutable or append-only after sealing. Corrections should create a new version rather than silently rewriting a prior result.
+
+## 8. Failure/degraded-state rule
+
+A nominal success case is insufficient. Each surface must demonstrate at least one controlled failure, degraded, unavailable, paused, malformed, or incompatible condition appropriate to that runtime.
+
+Required record:
+
+- expected failure behavior;
+- observed behavior;
+- whether the Worldshepherd boundary failed closed, failed safe, or merely reported degradation;
+- whether provenance remained intact;
+- whether human intervention was required;
+- recovery procedure and result.
+
+## 9. Promotion review
+
+When all six required evidence categories are populated, run the WS-NV-01G promotion-readiness assessment.
+
+Expected software output for a complete packet:
+
+- `ready_for_human_review: true`
+- `auto_promotion_allowed: false`
+- `decision: READY_FOR_HUMAN_REVIEW`
+
+The human reviewer then determines whether evidence supports maintaining the current claim, requesting more evidence, or explicitly promoting the capability under Worldshepherd claims controls.
+
+## 10. Non-negotiable boundary
+
+No software function in WS-NV-01 is authorized to change an NVIDIA surface to VALIDATED solely because a packet is complete or a test returned success.
+
+**Evidence completeness → human review.**
+
+**Human review + sufficient reproducible evidence → possible claim promotion.**

--- a/deployments/sara_verified_local_v1/docs/WS_NV_01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NV_01.md
@@ -1,0 +1,63 @@
+# WS-NV-01 — NVIDIA Physical-AI Integration Contract
+
+Status: **IMPLEMENTED IN SOFTWARE — CONTRACT ONLY**  
+NVIDIA runtime status: **NOT VERIFIED**  
+External network execution: **DISABLED BY DEFAULT**
+
+## Purpose
+
+WS-NV-01 defines the evidence-governed boundary between Worldshepherd SARA and selected NVIDIA physical-AI surfaces. It intentionally does not claim that CUDA, Jetson, Isaac Sim, Omniverse, or NVIDIA hardware is installed, connected, benchmarked, or validated.
+
+The initial contract maps four integration surfaces:
+
+| Surface | Boundary | Intended use | Current claim |
+|---|---|---|---|
+| Omniverse Kit | headless app / microservice | digital twins and simulation events | REQUIRES PARTNER VALIDATION |
+| Isaac Sim | ROS 2 bridge | robotics simulation, synthetic data, control-loop exchange | REQUIRES LAB VALIDATION |
+| Jetson Platform Services | API services | edge-AI orchestration and telemetry | REQUIRES LAB VALIDATION |
+| CUDA | future compute backend | approved accelerated workloads | REQUIRES LAB VALIDATION |
+
+## Why these boundaries
+
+NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. Isaac Sim exposes a ROS 2 bridge for robotics integration. Jetson Platform Services provides modular API-driven services for edge AI. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
+
+Official references:
+
+- https://docs.omniverse.nvidia.com/dev-guide/latest/kit-architecture.html
+- https://docs.isaacsim.omniverse.nvidia.com/latest/ros2_tutorials/ros2_landing_page.html
+- https://developer.nvidia.com/embedded/jetpack/jetson-platform-services-get-started
+
+## Promotion gate
+
+No NVIDIA capability is promoted to VALIDATED until the evidence package contains, at minimum:
+
+1. Runtime and SDK version inventory.
+2. Reproducible configuration digest.
+3. Successful bounded interface test.
+4. Telemetry and decision-provenance capture.
+5. Failure and degraded-state behavior.
+6. Operator authorization record.
+
+## Planned demonstrations
+
+### NV-D1 — Simulation-to-Evidence
+
+Omniverse/Isaac simulation event -> bounded adapter -> SARA workflow -> authorization -> provenance -> evidence record.
+
+### NV-D2 — Governed Edge Autonomy
+
+Jetson service event -> local policy gate -> telemetry/provenance -> degraded-state test -> operator override/recovery evidence.
+
+### NV-D3 — Mission Digital Twin
+
+Distributed simulated sensors/autonomous nodes -> digital-twin state -> decision-support workflow -> configuration custody -> after-action evidence.
+
+## Next implementation increments
+
+- WS-NV-01A: expose a read-only SARA integration-status endpoint.
+- WS-NV-01B: add signed/config-digested evidence envelopes for simulation events.
+- WS-NV-01C: create an Omniverse Kit headless adapter proof-of-interface.
+- WS-NV-01D: create an Isaac Sim ROS 2 bridge proof-of-interface.
+- WS-NV-01E: create a Jetson Platform Services proof-of-interface on approved hardware.
+
+Until those increments are executed and verified, the integration remains a contract scaffold rather than a demonstrated NVIDIA runtime capability.

--- a/deployments/sara_verified_local_v1/docs/WS_NV_01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NV_01.md
@@ -1,6 +1,6 @@
 # WS-NV-01 — NVIDIA Physical-AI Integration Contract
 
-Status: **IMPLEMENTED IN SOFTWARE — CONTRACT + STATUS/EVIDENCE PRIMITIVES**  
+Status: **IMPLEMENTED IN SOFTWARE — CONTRACT + STATUS/EVIDENCE + OMNIVERSE INTERFACE PRIMITIVES**  
 NVIDIA runtime status: **NOT VERIFIED**  
 External network execution: **DISABLED BY DEFAULT**
 
@@ -19,11 +19,12 @@ The initial contract maps four integration surfaces:
 
 ## Why these boundaries
 
-NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. Isaac Sim exposes a ROS 2 bridge for robotics integration. Jetson Platform Services provides modular API-driven services for edge AI. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
+NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. The current Omniverse services stack uses Kit and exposes standards-oriented service primitives around FastAPI/OpenAPI and Pydantic. Isaac Sim exposes a ROS 2 bridge for robotics integration. Jetson Platform Services provides modular API-driven services for edge AI. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
 
 Official references:
 
 - https://docs.omniverse.nvidia.com/dev-guide/latest/kit-architecture.html
+- https://docs.omniverse.nvidia.com/services/latest/core/index.html
 - https://docs.isaacsim.omniverse.nvidia.com/latest/ros2_tutorials/ros2_landing_page.html
 - https://developer.nvidia.com/embedded/jetpack/jetson-platform-services-get-started
 
@@ -48,6 +49,18 @@ The integration package can create evidence envelopes for declared NVIDIA surfac
 The raw configuration is deliberately not stored in the envelope. Creating an envelope does not validate a runtime and cannot silently promote a surface claim.
 
 **Current limitation:** envelopes are configuration-digested but not cryptographically signed. Signing remains a future custody/integrity increment and must not be claimed as implemented.
+
+### WS-NV-01C — Omniverse headless proof-of-interface
+
+Worldshepherd now defines a versioned request/response contract for a future headless Omniverse Kit service. The contract specifies:
+
+- a bounded `interface_probe` request with correlation ID and requested capabilities;
+- a structured response with service identity, Kit version, service state, extension versions, and observed capabilities;
+- offline parsing and correlation checks;
+- creation of a configuration-digested evidence envelope after parsing;
+- explicit preservation of `REQUIRES_PARTNER_VALIDATION` even when a captured response parses successfully.
+
+No SARA network client is implemented in this increment. No Omniverse service is implemented in this repository. A conforming captured JSON payload therefore proves only interface compatibility, not provenance or a functioning NVIDIA runtime.
 
 ## Promotion gate
 
@@ -76,9 +89,9 @@ Distributed simulated sensors/autonomous nodes -> digital-twin state -> decision
 
 ## Next implementation increments
 
-- WS-NV-01C: create an Omniverse Kit headless proof-of-interface without promoting runtime validation.
 - WS-NV-01D: create an Isaac Sim ROS 2 bridge proof-of-interface.
 - WS-NV-01E: create a Jetson Platform Services proof-of-interface on approved hardware.
 - WS-NV-01F: add evidence-envelope signing and verification with explicit key-custody rules.
+- WS-NV-01G: implement an outbound Omniverse service client only after endpoint authentication, transport security, allowlisting, failure semantics, and operator approval are defined.
 
-Until runtime-specific increments are executed against an actual NVIDIA runtime and reproducible evidence is captured, NVIDIA capability remains unverified even though the Worldshepherd integration contract, authenticated status surface, and evidence-envelope primitives are implemented in software.
+Until runtime-specific increments are executed against an actual NVIDIA runtime and reproducible evidence is captured, NVIDIA capability remains unverified even though the Worldshepherd integration contract, authenticated status surface, evidence-envelope primitives, and Omniverse wire contract are implemented in software.

--- a/deployments/sara_verified_local_v1/docs/WS_NV_01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NV_01.md
@@ -1,6 +1,6 @@
 # WS-NV-01 — NVIDIA Physical-AI Integration Contract
 
-Status: **IMPLEMENTED IN SOFTWARE — CONTRACT + STATUS/EVIDENCE + OMNIVERSE INTERFACE PRIMITIVES**  
+Status: **IMPLEMENTED IN SOFTWARE — CONTRACT + STATUS/EVIDENCE + VENDOR INTERFACE PRIMITIVES**  
 NVIDIA runtime status: **NOT VERIFIED**  
 External network execution: **DISABLED BY DEFAULT**
 
@@ -19,14 +19,15 @@ The initial contract maps four integration surfaces:
 
 ## Why these boundaries
 
-NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. The current Omniverse services stack uses Kit and exposes standards-oriented service primitives around FastAPI/OpenAPI and Pydantic. Isaac Sim exposes a ROS 2 bridge for robotics integration. Jetson Platform Services provides modular API-driven services for edge AI. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
+NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. The current Omniverse services stack uses Kit and exposes standards-oriented service primitives around FastAPI/OpenAPI and Pydantic. Isaac Sim exposes a ROS 2 bridge for robotics integration, with publishers, subscribers, and services active during simulation playback. Jetson Platform Services provides modular, API-driven services for edge AI, including REST-based AI-service operations. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
 
 Official references:
 
 - https://docs.omniverse.nvidia.com/dev-guide/latest/kit-architecture.html
 - https://docs.omniverse.nvidia.com/services/latest/core/index.html
-- https://docs.isaacsim.omniverse.nvidia.com/latest/ros2_tutorials/ros2_landing_page.html
+- https://docs.isaacsim.omniverse.nvidia.com/latest/py/source/extensions/isaacsim.ros2.bridge/docs/index.html
 - https://developer.nvidia.com/embedded/jetpack/jetson-platform-services-get-started
+- https://docs.nvidia.com/moj/inference-services/overview.html
 
 ## Implemented increments
 
@@ -52,15 +53,19 @@ The raw configuration is deliberately not stored in the envelope. Creating an en
 
 ### WS-NV-01C — Omniverse headless proof-of-interface
 
-Worldshepherd now defines a versioned request/response contract for a future headless Omniverse Kit service. The contract specifies:
+Worldshepherd defines a versioned request/response contract for a future headless Omniverse Kit service. It includes a bounded `interface_probe` request, structured response metadata, offline parsing and correlation checks, and evidence-envelope creation. A captured response that parses successfully remains `REQUIRES_PARTNER_VALIDATION`; no SARA network client or Omniverse service is implemented by this increment.
 
-- a bounded `interface_probe` request with correlation ID and requested capabilities;
-- a structured response with service identity, Kit version, service state, extension versions, and observed capabilities;
-- offline parsing and correlation checks;
-- creation of a configuration-digested evidence envelope after parsing;
-- explicit preservation of `REQUIRES_PARTNER_VALIDATION` even when a captured response parses successfully.
+### WS-NV-01D — Isaac Sim ROS 2 proof-of-interface
 
-No SARA network client is implemented in this increment. No Omniverse service is implemented in this repository. A conforming captured JSON payload therefore proves only interface compatibility, not provenance or a functioning NVIDIA runtime.
+Worldshepherd defines a captured-observation contract for the Isaac Sim ROS 2 bridge. The record includes bridge version, ROS distribution, simulation state, observed topics, observed services, and correlation ID. The assessment only marks bridge activity as observed when simulation state is `playing` and at least one topic or service is present. It still returns `runtime_validated: false` and retains `REQUIRES_LAB_VALIDATION`.
+
+No ROS client is implemented and no Isaac Sim runtime is claimed present.
+
+### WS-NV-01E — Jetson Platform Services proof-of-interface
+
+Worldshepherd defines an offline observation contract for a future Jetson Platform Services integration. The record captures service identity/type, JetPack version, Platform Services version, containerization state, service status, observed API operations, and correlation ID. Captured API metadata can be parsed and wrapped in a configuration-digested evidence envelope, but this does not validate Jetson hardware or software.
+
+No outbound REST client is implemented and no Jetson device is claimed present. Hardware-backed proof remains required before the Jetson surface can move beyond `REQUIRES_LAB_VALIDATION`.
 
 ## Promotion gate
 
@@ -89,9 +94,9 @@ Distributed simulated sensors/autonomous nodes -> digital-twin state -> decision
 
 ## Next implementation increments
 
-- WS-NV-01D: create an Isaac Sim ROS 2 bridge proof-of-interface.
-- WS-NV-01E: create a Jetson Platform Services proof-of-interface on approved hardware.
 - WS-NV-01F: add evidence-envelope signing and verification with explicit key-custody rules.
-- WS-NV-01G: implement an outbound Omniverse service client only after endpoint authentication, transport security, allowlisting, failure semantics, and operator approval are defined.
+- WS-NV-01G: define a CUDA compute-backend proof contract without importing CUDA or claiming GPU availability.
+- WS-NV-01H: implement outbound vendor clients only after endpoint authentication, transport security, allowlisting, bounded failure semantics, and operator approval are defined.
+- LAB-NV-01: execute the contracts against approved Omniverse/Isaac and Jetson environments and collect reproducible evidence.
 
-Until runtime-specific increments are executed against an actual NVIDIA runtime and reproducible evidence is captured, NVIDIA capability remains unverified even though the Worldshepherd integration contract, authenticated status surface, evidence-envelope primitives, and Omniverse wire contract are implemented in software.
+Until runtime-specific increments are executed against actual NVIDIA runtimes and reproducible evidence is captured, NVIDIA capability remains unverified even though the Worldshepherd integration contracts, authenticated status surface, evidence-envelope primitives, and vendor wire contracts are implemented in software.

--- a/deployments/sara_verified_local_v1/docs/WS_NV_01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NV_01.md
@@ -1,6 +1,6 @@
 # WS-NV-01 — NVIDIA Physical-AI Integration Contract
 
-Status: **IMPLEMENTED IN SOFTWARE — CONTRACT ONLY**  
+Status: **IMPLEMENTED IN SOFTWARE — CONTRACT + STATUS/EVIDENCE PRIMITIVES**  
 NVIDIA runtime status: **NOT VERIFIED**  
 External network execution: **DISABLED BY DEFAULT**
 
@@ -26,6 +26,28 @@ Official references:
 - https://docs.omniverse.nvidia.com/dev-guide/latest/kit-architecture.html
 - https://docs.isaacsim.omniverse.nvidia.com/latest/ros2_tutorials/ros2_landing_page.html
 - https://developer.nvidia.com/embedded/jetpack/jetson-platform-services-get-started
+
+## Implemented increments
+
+### WS-NV-01A — Authenticated read-only status
+
+SARA exposes `GET /v1/integrations/nvidia/status` behind existing bearer-token authentication. Relay and admin roles can read the endpoint. The endpoint performs no NVIDIA calls and does not append to the application audit store.
+
+The returned status includes:
+
+- integration and architecture version;
+- explicit `runtime_verified: false` and `network_calls_enabled: false` values;
+- current claim status for each NVIDIA surface;
+- deterministic SHA-256 digest of the integration contract;
+- evidence-envelope schema version.
+
+### WS-NV-01B — Configuration-digested evidence envelopes
+
+The integration package can create evidence envelopes for declared NVIDIA surfaces. An envelope records the integration ID, surface, inherited claim state, evidence references, optional operator-authorization reference, timestamp, and deterministic SHA-256 digest of a JSON-compatible configuration.
+
+The raw configuration is deliberately not stored in the envelope. Creating an envelope does not validate a runtime and cannot silently promote a surface claim.
+
+**Current limitation:** envelopes are configuration-digested but not cryptographically signed. Signing remains a future custody/integrity increment and must not be claimed as implemented.
 
 ## Promotion gate
 
@@ -54,10 +76,9 @@ Distributed simulated sensors/autonomous nodes -> digital-twin state -> decision
 
 ## Next implementation increments
 
-- WS-NV-01A: expose a read-only SARA integration-status endpoint.
-- WS-NV-01B: add signed/config-digested evidence envelopes for simulation events.
-- WS-NV-01C: create an Omniverse Kit headless adapter proof-of-interface.
+- WS-NV-01C: create an Omniverse Kit headless proof-of-interface without promoting runtime validation.
 - WS-NV-01D: create an Isaac Sim ROS 2 bridge proof-of-interface.
 - WS-NV-01E: create a Jetson Platform Services proof-of-interface on approved hardware.
+- WS-NV-01F: add evidence-envelope signing and verification with explicit key-custody rules.
 
-Until those increments are executed and verified, the integration remains a contract scaffold rather than a demonstrated NVIDIA runtime capability.
+Until runtime-specific increments are executed against an actual NVIDIA runtime and reproducible evidence is captured, NVIDIA capability remains unverified even though the Worldshepherd integration contract, authenticated status surface, and evidence-envelope primitives are implemented in software.

--- a/deployments/sara_verified_local_v1/docs/WS_NV_01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NV_01.md
@@ -19,7 +19,7 @@ The initial contract maps four integration surfaces:
 
 ## Why these boundaries
 
-NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. The current Omniverse services stack uses Kit and exposes standards-oriented service primitives around FastAPI/OpenAPI and Pydantic. Isaac Sim exposes a ROS 2 bridge for robotics integration, with publishers, subscribers, and services active during simulation playback. Jetson Platform Services provides modular, API-driven services for edge AI, including REST-based AI-service operations. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
+NVIDIA documents Omniverse Kit as a modular SDK that can support headless microservices as well as full applications. The current Omniverse services stack uses Kit and exposes standards-oriented service primitives around FastAPI/OpenAPI and Pydantic. Isaac Sim exposes a ROS 2 bridge for robotics integration, with publishers, subscribers, and services active during simulation playback. Jetson Platform Services provides modular, API-driven services for edge AI, including REST-based AI-service operations. CUDA compatibility depends on runtime/driver identity, device identity, and compute capability. Those interfaces allow SARA governance, authorization, telemetry provenance, and evidence capture to remain separate from vendor-specific runtime execution.
 
 Official references:
 
@@ -28,6 +28,8 @@ Official references:
 - https://docs.isaacsim.omniverse.nvidia.com/latest/py/source/extensions/isaacsim.ros2.bridge/docs/index.html
 - https://developer.nvidia.com/embedded/jetpack/jetson-platform-services-get-started
 - https://docs.nvidia.com/moj/inference-services/overview.html
+- https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/compute-capabilities.html
+- https://docs.nvidia.com/cuda/cuda-programming-guide/01-introduction/cuda-platform.html
 
 ## Implemented increments
 
@@ -35,13 +37,7 @@ Official references:
 
 SARA exposes `GET /v1/integrations/nvidia/status` behind existing bearer-token authentication. Relay and admin roles can read the endpoint. The endpoint performs no NVIDIA calls and does not append to the application audit store.
 
-The returned status includes:
-
-- integration and architecture version;
-- explicit `runtime_verified: false` and `network_calls_enabled: false` values;
-- current claim status for each NVIDIA surface;
-- deterministic SHA-256 digest of the integration contract;
-- evidence-envelope schema version.
+The returned status includes integration and architecture version, explicit runtime/network-disabled state, current claim status for each surface, deterministic SHA-256 contract digest, proof-contract inventory, and evidence-envelope schema version.
 
 ### WS-NV-01B — Configuration-digested evidence envelopes
 
@@ -67,6 +63,12 @@ Worldshepherd defines an offline observation contract for a future Jetson Platfo
 
 No outbound REST client is implemented and no Jetson device is claimed present. Hardware-backed proof remains required before the Jetson surface can move beyond `REQUIRES_LAB_VALIDATION`.
 
+### WS-NV-01F — CUDA compute-backend proof contract
+
+Worldshepherd defines an offline captured-compute contract containing driver version, CUDA Toolkit version, device identity, compute capability, workload identity, workload SHA-256 digest, optional result SHA-256 digest, execution state, and correlation ID.
+
+A captured record may establish that an evidence payload is structurally consistent with the Worldshepherd CUDA contract. Even a record marked `success` does not validate the GPU or CUDA runtime by itself; provenance, hardware inventory, reproducible execution, and independent evidence remain required. No CUDA library is imported, no GPU discovery is performed, and no workload is launched by this increment.
+
 ## Promotion gate
 
 No NVIDIA capability is promoted to VALIDATED until the evidence package contains, at minimum:
@@ -77,6 +79,8 @@ No NVIDIA capability is promoted to VALIDATED until the evidence package contain
 4. Telemetry and decision-provenance capture.
 5. Failure and degraded-state behavior.
 6. Operator authorization record.
+
+For CUDA, the package additionally requires device identity, compute capability, workload digest, result digest, and reproducible execution evidence.
 
 ## Planned demonstrations
 
@@ -92,11 +96,15 @@ Jetson service event -> local policy gate -> telemetry/provenance -> degraded-st
 
 Distributed simulated sensors/autonomous nodes -> digital-twin state -> decision-support workflow -> configuration custody -> after-action evidence.
 
+### NV-D4 — Reproducible Accelerated Workload
+
+Approved deterministic workload -> CUDA-capable lab host -> device/runtime inventory -> input/workload digest -> execution -> result digest -> evidence envelope -> independent rerun comparison.
+
 ## Next implementation increments
 
-- WS-NV-01F: add evidence-envelope signing and verification with explicit key-custody rules.
-- WS-NV-01G: define a CUDA compute-backend proof contract without importing CUDA or claiming GPU availability.
+- WS-NV-01G: add evidence-envelope signing and verification with explicit key-custody rules.
 - WS-NV-01H: implement outbound vendor clients only after endpoint authentication, transport security, allowlisting, bounded failure semantics, and operator approval are defined.
-- LAB-NV-01: execute the contracts against approved Omniverse/Isaac and Jetson environments and collect reproducible evidence.
+- LAB-NV-01: execute Omniverse/Isaac contracts against an approved NVIDIA runtime and collect reproducible evidence.
+- LAB-NV-02: execute Jetson and CUDA contracts on approved hardware and collect reproducible evidence.
 
 Until runtime-specific increments are executed against actual NVIDIA runtimes and reproducible evidence is captured, NVIDIA capability remains unverified even though the Worldshepherd integration contracts, authenticated status surface, evidence-envelope primitives, and vendor wire contracts are implemented in software.

--- a/deployments/sara_verified_local_v1/tests/test_cuda_interface.py
+++ b/deployments/sara_verified_local_v1/tests/test_cuda_interface.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from worldshepherd_sara.integrations.cuda_backend import (
+    assess_cuda_observation,
+    cuda_interface_contract,
+)
+from worldshepherd_sara.integrations.nvidia import ClaimStatus
+
+
+SHA_A = "sha256:" + "a" * 64
+SHA_B = "sha256:" + "b" * 64
+
+
+def test_cuda_contract_preserves_lab_validation_gate():
+    contract = cuda_interface_contract()
+
+    assert contract["increment"] == "WS-NV-01F"
+    assert contract["version_inventory_required"] is True
+    assert contract["compute_capability_required"] is True
+    assert contract["workload_and_result_digests_required"] is True
+    assert contract["cuda_client_implemented"] is False
+    assert contract["gpu_discovery_implemented"] is False
+    assert contract["runtime_validated"] is False
+    assert contract["claim_status"] == ClaimStatus.REQUIRES_LAB_VALIDATION
+
+
+def test_captured_cuda_success_does_not_validate_runtime():
+    proof = assess_cuda_observation(
+        observation={
+            "schema_version": "1.0",
+            "integration_id": "WS-NV-01",
+            "correlation_id": "cuda-00000001",
+            "driver_version": "unverified-example",
+            "toolkit_version": "unverified-example",
+            "device_name": "unverified-example",
+            "compute_capability": "0.0",
+            "workload_id": "fixture-workload",
+            "workload_digest": SHA_A,
+            "result_digest": SHA_B,
+            "execution_status": "success",
+        },
+        expected_correlation_id="cuda-00000001",
+        configuration={"source": "fixture", "network": False},
+    )
+
+    assert proof.execution_observed is True
+    assert proof.runtime_validated is False
+    assert proof.claim_status == ClaimStatus.REQUIRES_LAB_VALIDATION
+    assert proof.evidence.claim_status == ClaimStatus.REQUIRES_LAB_VALIDATION.value
+
+
+def test_cuda_not_run_is_not_execution_evidence():
+    proof = assess_cuda_observation(
+        observation={
+            "schema_version": "1.0",
+            "integration_id": "WS-NV-01",
+            "correlation_id": "cuda-00000002",
+            "driver_version": "unverified-example",
+            "toolkit_version": "unverified-example",
+            "device_name": "unverified-example",
+            "compute_capability": "0.0",
+            "workload_id": "fixture-workload",
+            "workload_digest": SHA_A,
+            "result_digest": None,
+            "execution_status": "not_run",
+        },
+        expected_correlation_id="cuda-00000002",
+        configuration={"source": "fixture", "network": False},
+    )
+
+    assert proof.execution_observed is False
+    assert proof.runtime_validated is False

--- a/deployments/sara_verified_local_v1/tests/test_isaac_jetson_interfaces.py
+++ b/deployments/sara_verified_local_v1/tests/test_isaac_jetson_interfaces.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from worldshepherd_sara.integrations.isaac_ros2 import (
+    assess_ros2_observation,
+    isaac_ros2_interface_contract,
+)
+from worldshepherd_sara.integrations.jetson import (
+    assess_jetson_observation,
+    jetson_interface_contract,
+)
+from worldshepherd_sara.integrations.nvidia import ClaimStatus
+
+
+def test_isaac_ros2_contract_preserves_lab_validation_gate():
+    contract = isaac_ros2_interface_contract()
+
+    assert contract["increment"] == "WS-NV-01D"
+    assert contract["simulation_playback_required_for_bridge_activity"] is True
+    assert contract["network_calls_enabled"] is False
+    assert contract["runtime_validated"] is False
+    assert contract["claim_status"] == ClaimStatus.REQUIRES_LAB_VALIDATION
+
+
+def test_isaac_activity_requires_playback_and_observed_ros_surface():
+    active = assess_ros2_observation(
+        observation={
+            "schema_version": "1.0",
+            "integration_id": "WS-NV-01",
+            "correlation_id": "isaac-00000001",
+            "bridge_version": "unverified-example",
+            "ros_distro": "unverified-example",
+            "simulation_state": "playing",
+            "observed_topics": ["/clock"],
+            "observed_services": [],
+        },
+        expected_correlation_id="isaac-00000001",
+        configuration={"source": "fixture", "network": False},
+    )
+    paused = assess_ros2_observation(
+        observation={
+            "schema_version": "1.0",
+            "integration_id": "WS-NV-01",
+            "correlation_id": "isaac-00000002",
+            "bridge_version": "unverified-example",
+            "ros_distro": "unverified-example",
+            "simulation_state": "paused",
+            "observed_topics": ["/clock"],
+            "observed_services": [],
+        },
+        expected_correlation_id="isaac-00000002",
+        configuration={"source": "fixture", "network": False},
+    )
+
+    assert active.bridge_activity_observed is True
+    assert paused.bridge_activity_observed is False
+    assert active.runtime_validated is False
+    assert active.evidence.claim_status == ClaimStatus.REQUIRES_LAB_VALIDATION.value
+
+
+def test_jetson_contract_preserves_lab_validation_gate():
+    contract = jetson_interface_contract()
+
+    assert contract["increment"] == "WS-NV-01E"
+    assert contract["transport_boundary"] == "rest_api_service"
+    assert contract["network_calls_enabled"] is False
+    assert contract["runtime_validated"] is False
+    assert contract["claim_status"] == ClaimStatus.REQUIRES_LAB_VALIDATION
+
+
+def test_jetson_captured_api_surface_does_not_validate_runtime():
+    proof = assess_jetson_observation(
+        observation={
+            "schema_version": "1.0",
+            "integration_id": "WS-NV-01",
+            "correlation_id": "jetson-00000001",
+            "service_id": "fixture-service",
+            "service_kind": "ai_service_fixture",
+            "jetpack_version": "unverified-example",
+            "platform_services_version": "unverified-example",
+            "service_status": "ready",
+            "observed_api_operations": ["fixture://status"],
+            "containerized": True,
+        },
+        expected_correlation_id="jetson-00000001",
+        configuration={"source": "fixture", "network": False},
+    )
+
+    assert proof.api_surface_observed is True
+    assert proof.runtime_validated is False
+    assert proof.claim_status == ClaimStatus.REQUIRES_LAB_VALIDATION
+    assert proof.evidence.claim_status == ClaimStatus.REQUIRES_LAB_VALIDATION.value

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+
+def auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_nvidia_status_requires_authentication(client):
+    response = client.get("/v1/integrations/nvidia/status")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing Authorization header"
+
+
+def test_nvidia_status_accepts_relay_and_admin_without_mutating_audit(client, tokens):
+    relay, admin = tokens
+    audit_before = client.app.state.store.audit_path.read_bytes()
+
+    for token in (relay, admin):
+        response = client.get(
+            "/v1/integrations/nvidia/status",
+            headers=auth(token),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["integration_id"] == "WS-NV-01"
+        assert body["status"] == "contract_ready_runtime_unverified"
+        assert body["runtime_verified"] is False
+        assert body["network_calls_enabled"] is False
+        assert body["contract_digest"].startswith("sha256:")
+
+    assert client.app.state.store.audit_path.read_bytes() == audit_before
+
+
+def test_health_advertises_nvidia_status_endpoint(client):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["endpoints"]["nvidia_status"] == (
+        "/v1/integrations/nvidia/status"
+    )

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_api.py
@@ -24,10 +24,17 @@ def test_nvidia_status_accepts_relay_and_admin_without_mutating_audit(client, to
         assert response.status_code == 200
         body = response.json()
         assert body["integration_id"] == "WS-NV-01"
-        assert body["status"] == "contract_ready_runtime_unverified"
+        assert body["status"] == "proof_contracts_ready_runtime_unverified"
         assert body["runtime_verified"] is False
         assert body["network_calls_enabled"] is False
         assert body["contract_digest"].startswith("sha256:")
+        assert len(body["implemented_increments"]) == 7
+        assert set(body["proof_contracts"]) == {
+            "omniverse_kit",
+            "isaac_sim_ros2",
+            "jetson_platform_services",
+            "cuda_acceleration",
+        }
 
     assert client.app.state.store.audit_path.read_bytes() == audit_before
 

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_api.py
@@ -28,7 +28,9 @@ def test_nvidia_status_accepts_relay_and_admin_without_mutating_audit(client, to
         assert body["runtime_verified"] is False
         assert body["network_calls_enabled"] is False
         assert body["contract_digest"].startswith("sha256:")
-        assert len(body["implemented_increments"]) == 7
+        assert len(body["implemented_increments"]) == 8
+        assert body["promotion_gate"]["auto_promotion_allowed"] is False
+        assert body["promotion_gate"]["human_review_required"] is True
         assert set(body["proof_contracts"]) == {
             "omniverse_kit",
             "isaac_sim_ros2",

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from worldshepherd_sara.integrations.nvidia import (
+    ClaimStatus,
+    IntegrationState,
+    SURFACES,
+    integration_manifest,
+)
+
+
+def test_ws_nv_01_is_non_executing_by_default():
+    manifest = integration_manifest()
+
+    assert manifest["integration_id"] == "WS-NV-01"
+    assert manifest["vendor"] == "NVIDIA"
+    assert manifest["execution_mode"] == "scaffold_only"
+    assert manifest["network_calls_enabled"] is False
+    assert manifest["contract_claim"] == ClaimStatus.IMPLEMENTED_IN_SOFTWARE
+    assert manifest["vendor_capability_claim"] == ClaimStatus.REQUIRES_PARTNER_VALIDATION
+
+
+def test_no_nvidia_surface_is_silently_promoted_to_validated():
+    assert SURFACES
+    assert all(surface.state != IntegrationState.VALIDATED for surface in SURFACES)
+    assert all(surface.network_calls_enabled is False for surface in SURFACES)
+
+
+def test_required_nvidia_surfaces_are_declared():
+    names = {surface.name for surface in SURFACES}
+
+    assert names == {
+        "omniverse_kit",
+        "isaac_sim_ros2",
+        "jetson_platform_services",
+        "cuda_acceleration",
+    }
+
+
+def test_evidence_gate_covers_runtime_provenance_and_failure_behavior():
+    required = set(integration_manifest()["evidence_required"])
+
+    assert "runtime and SDK version inventory" in required
+    assert "reproducible configuration digest" in required
+    assert "telemetry and decision-provenance capture" in required
+    assert "failure and degraded-state behavior" in required
+    assert "operator authorization record" in required

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
@@ -18,8 +18,9 @@ def test_ws_nv_01_is_non_executing_by_default():
 
     assert manifest["integration_id"] == "WS-NV-01"
     assert manifest["vendor"] == "NVIDIA"
-    assert manifest["execution_mode"] == "scaffold_only"
+    assert manifest["execution_mode"] == "contract_and_offline_evidence_only"
     assert manifest["network_calls_enabled"] is False
+    assert manifest["runtime_verified"] is False
     assert manifest["contract_claim"] == ClaimStatus.IMPLEMENTED_IN_SOFTWARE
     assert manifest["vendor_capability_claim"] == ClaimStatus.REQUIRES_PARTNER_VALIDATION
 
@@ -51,10 +52,30 @@ def test_evidence_gate_covers_runtime_provenance_and_failure_behavior():
     assert "operator authorization record" in required
 
 
+def test_manifest_reports_all_current_proof_contract_increments():
+    manifest = integration_manifest()
+
+    assert manifest["implemented_increments"] == [
+        "WS-NV-01",
+        "WS-NV-01A",
+        "WS-NV-01B",
+        "WS-NV-01C",
+        "WS-NV-01D",
+        "WS-NV-01E",
+        "WS-NV-01F",
+    ]
+    assert set(manifest["proof_contracts"]) == {
+        "omniverse_kit",
+        "isaac_sim_ros2",
+        "jetson_platform_services",
+        "cuda_acceleration",
+    }
+
+
 def test_status_exposes_digest_without_promoting_runtime():
     status = integration_status()
 
-    assert status["status"] == "contract_ready_runtime_unverified"
+    assert status["status"] == "proof_contracts_ready_runtime_unverified"
     assert status["runtime_verified"] is False
     assert status["network_calls_enabled"] is False
     assert status["surface_count"] == 4

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
+from worldshepherd_sara.integrations.evidence import canonical_config_digest
 from worldshepherd_sara.integrations.nvidia import (
     ClaimStatus,
     IntegrationState,
     SURFACES,
+    build_evidence_envelope,
     integration_manifest,
+    integration_status,
 )
 
 
@@ -44,3 +49,47 @@ def test_evidence_gate_covers_runtime_provenance_and_failure_behavior():
     assert "telemetry and decision-provenance capture" in required
     assert "failure and degraded-state behavior" in required
     assert "operator authorization record" in required
+
+
+def test_status_exposes_digest_without_promoting_runtime():
+    status = integration_status()
+
+    assert status["status"] == "contract_ready_runtime_unverified"
+    assert status["runtime_verified"] is False
+    assert status["network_calls_enabled"] is False
+    assert status["surface_count"] == 4
+    assert str(status["contract_digest"]).startswith("sha256:")
+    assert len(str(status["contract_digest"])) == len("sha256:") + 64
+    assert all(item["state"] != IntegrationState.VALIDATED for item in status["surfaces"])
+
+
+def test_configuration_digest_is_canonical_and_deterministic():
+    left = canonical_config_digest({"b": 2, "a": {"z": 3, "y": 4}})
+    right = canonical_config_digest({"a": {"y": 4, "z": 3}, "b": 2})
+
+    assert left == right
+    assert left.startswith("sha256:")
+
+
+def test_evidence_envelope_records_digest_not_raw_config_and_preserves_claim():
+    config = {"sdk": "unverified", "mode": "simulation", "network": False}
+    envelope = build_evidence_envelope(
+        surface_name="isaac_sim_ros2",
+        config=config,
+        evidence_refs=["test://bounded-interface-001"],
+        operator_authorization_ref="auth://CRE1AWS/example",
+    )
+    body = envelope.to_dict()
+
+    assert body["integration_id"] == "WS-NV-01"
+    assert body["surface"] == "isaac_sim_ros2"
+    assert body["claim_status"] == ClaimStatus.REQUIRES_LAB_VALIDATION.value
+    assert body["config_digest"] == canonical_config_digest(config)
+    assert "config" not in body
+    assert body["evidence_refs"] == ("test://bounded-interface-001",)
+    assert body["operator_authorization_ref"] == "auth://CRE1AWS/example"
+
+
+def test_unknown_surface_cannot_receive_nvidia_evidence_envelope():
+    with pytest.raises(ValueError, match="Unknown NVIDIA integration surface"):
+        build_evidence_envelope(surface_name="invented_runtime", config={})

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_integration.py
@@ -63,7 +63,20 @@ def test_manifest_reports_all_current_proof_contract_increments():
         "WS-NV-01D",
         "WS-NV-01E",
         "WS-NV-01F",
+        "WS-NV-01G",
     ]
+    assert manifest["promotion_gate"] == {
+        "required_categories": [
+            "runtime_version_inventory",
+            "configuration_digest",
+            "bounded_interface_test",
+            "telemetry_and_provenance",
+            "failure_or_degraded_behavior",
+            "operator_authorization",
+        ],
+        "auto_promotion_allowed": False,
+        "human_review_required": True,
+    }
     assert set(manifest["proof_contracts"]) == {
         "omniverse_kit",
         "isaac_sim_ros2",

--- a/deployments/sara_verified_local_v1/tests/test_nvidia_promotion.py
+++ b/deployments/sara_verified_local_v1/tests/test_nvidia_promotion.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from worldshepherd_sara.integrations.promotion import (
+    REQUIRED_EVIDENCE_CATEGORIES,
+    assess_promotion_readiness,
+)
+
+
+def test_incomplete_package_is_not_ready_and_never_auto_promotes():
+    result = assess_promotion_readiness(
+        surface="isaac_sim_ros2",
+        submitted_claim_status="REQUIRES_LAB_VALIDATION",
+        evidence_by_category={
+            "runtime_version_inventory": ["evidence://versions/001"],
+            "configuration_digest": ["evidence://config/001"],
+        },
+    )
+
+    assert result.ready_for_human_review is False
+    assert result.auto_promotion_allowed is False
+    assert result.decision == "INCOMPLETE_EVIDENCE_PACKAGE"
+    assert "operator_authorization" in result.missing_categories
+
+
+def test_complete_package_only_becomes_ready_for_human_review():
+    package = {
+        category: [f"evidence://{category}/001"]
+        for category in REQUIRED_EVIDENCE_CATEGORIES
+    }
+
+    result = assess_promotion_readiness(
+        surface="omniverse_kit",
+        submitted_claim_status="REQUIRES_PARTNER_VALIDATION",
+        evidence_by_category=package,
+    )
+
+    assert result.ready_for_human_review is True
+    assert result.auto_promotion_allowed is False
+    assert result.missing_categories == ()
+    assert result.evidence_ref_count == len(REQUIRED_EVIDENCE_CATEGORIES)
+    assert result.decision == "READY_FOR_HUMAN_REVIEW"
+    assert result.submitted_claim_status == "REQUIRES_PARTNER_VALIDATION"

--- a/deployments/sara_verified_local_v1/tests/test_omniverse_interface.py
+++ b/deployments/sara_verified_local_v1/tests/test_omniverse_interface.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.integrations.nvidia import ClaimStatus
+from worldshepherd_sara.integrations.omniverse import (
+    assess_probe_response,
+    build_probe_request,
+    omniverse_interface_contract,
+)
+
+
+def test_omniverse_interface_contract_is_non_executing_and_unvalidated():
+    contract = omniverse_interface_contract()
+
+    assert contract["increment"] == "WS-NV-01C"
+    assert contract["surface"] == "omniverse_kit"
+    assert contract["network_calls_enabled"] is False
+    assert contract["sara_network_client_implemented"] is False
+    assert contract["omniverse_service_implemented"] is False
+    assert contract["runtime_validated"] is False
+    assert contract["claim_status"] == ClaimStatus.REQUIRES_PARTNER_VALIDATION
+
+
+def test_probe_request_defines_expected_wire_payload():
+    request = build_probe_request(correlation_id="corr-00000001")
+    body = request.model_dump(mode="json")
+
+    assert body == {
+        "schema_version": "1.0",
+        "integration_id": "WS-NV-01",
+        "correlation_id": "corr-00000001",
+        "operation": "interface_probe",
+        "requested_capabilities": ["kit_runtime", "services_core"],
+    }
+
+
+def test_captured_probe_response_can_be_parsed_without_runtime_promotion():
+    proof = assess_probe_response(
+        response={
+            "schema_version": "1.0",
+            "integration_id": "WS-NV-01",
+            "correlation_id": "corr-00000002",
+            "service_id": "partner-captured-example",
+            "kit_version": "unverified-example",
+            "service_status": "ready",
+            "extension_versions": {"omni.services.core": "unverified-example"},
+            "observed_capabilities": ["kit_runtime", "services_core"],
+        },
+        expected_correlation_id="corr-00000002",
+        configuration={"source": "captured-fixture", "network": False},
+        evidence_refs=["test://omniverse-interface-fixture"],
+    )
+    body = proof.to_dict()
+
+    assert body["interface_parsed"] is True
+    assert body["runtime_validated"] is False
+    assert body["claim_status"] == ClaimStatus.REQUIRES_PARTNER_VALIDATION
+    assert body["evidence"]["claim_status"] == (
+        ClaimStatus.REQUIRES_PARTNER_VALIDATION.value
+    )
+    assert "configuration" not in body["evidence"]
+
+
+def test_probe_response_correlation_mismatch_is_rejected():
+    with pytest.raises(ValueError, match="correlation_id mismatch"):
+        assess_probe_response(
+            response={
+                "schema_version": "1.0",
+                "integration_id": "WS-NV-01",
+                "correlation_id": "corr-00000003",
+                "service_id": "fixture",
+                "kit_version": "unverified-example",
+                "service_status": "degraded",
+            },
+            expected_correlation_id="corr-00000004",
+            configuration={},
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
@@ -12,6 +12,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from . import __version__
 from .auth import Role, require_admin, resolve_role, validate_runtime_secrets
+from .integrations.nvidia import integration_status
 from .limits import MAX_REQUEST_BYTES
 from .models import AuditRecord, RegistryPatch, RelayRequest, RelayResponse
 from .storage import DurableStore
@@ -134,6 +135,7 @@ def health() -> dict[str, object]:
             "audit": "/v1/audit?limit=50",
             "registry": "/admin/registry",
             "relay": "/v1/relay",
+            "nvidia_status": "/v1/integrations/nvidia/status",
             "selftest": "/admin/selftest",
         },
     }
@@ -153,6 +155,14 @@ def readiness(request: Request) -> JSONResponse:
     )
 
 
+@app.get("/v1/integrations/nvidia/status")
+def nvidia_integration_status(
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, object]:
+    del role
+    return integration_status()
+
+
 @app.get("/ui", response_class=HTMLResponse)
 def ui() -> str:
     return """<!doctype html>
@@ -164,7 +174,7 @@ code{color:#9ad5ff} .ok{color:#96e6a1}
 </style></head><body><h1>Worldshepherd SARA</h1>
 <p class="ok">Local administration interface is online.</p>
 <div class="card"><strong>Authority separation</strong><p>CRE1AWS approves high-impact releases. SSPADAWANZZ operates the local service.</p></div>
-<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/admin/registry</code>, <code>/admin/selftest</code></p></div>
+<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/admin/registry</code>, <code>/v1/integrations/nvidia/status</code>, <code>/admin/selftest</code></p></div>
 <div class="card"><strong>Security boundary</strong><p>Tokens are never stored in this page. Use Bearer authentication from an approved local client.</p></div>
 </body></html>"""
 

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
@@ -6,9 +6,17 @@ validated unless the module explicitly reports that state.
 """
 
 from .nvidia import build_evidence_envelope, integration_manifest, integration_status
+from .omniverse import (
+    assess_probe_response,
+    build_probe_request,
+    omniverse_interface_contract,
+)
 
 __all__ = [
+    "assess_probe_response",
     "build_evidence_envelope",
+    "build_probe_request",
     "integration_manifest",
     "integration_status",
+    "omniverse_interface_contract",
 ]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
@@ -1,0 +1,10 @@
+"""Vendor integration contracts for Worldshepherd SARA.
+
+Integration modules in this package define bounded interfaces and evidence gates.
+They do not imply that an external vendor runtime is installed, connected, or
+validated unless the module explicitly reports that state.
+"""
+
+from .nvidia import integration_manifest
+
+__all__ = ["integration_manifest"]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
@@ -5,6 +5,7 @@ They do not imply that an external vendor runtime is installed, connected, or
 validated unless the module explicitly reports that state.
 """
 
+from .cuda_backend import assess_cuda_observation, cuda_interface_contract
 from .isaac_ros2 import assess_ros2_observation, isaac_ros2_interface_contract
 from .jetson import assess_jetson_observation, jetson_interface_contract
 from .nvidia import build_evidence_envelope, integration_manifest, integration_status
@@ -15,11 +16,13 @@ from .omniverse import (
 )
 
 __all__ = [
+    "assess_cuda_observation",
     "assess_jetson_observation",
     "assess_probe_response",
     "assess_ros2_observation",
     "build_evidence_envelope",
     "build_probe_request",
+    "cuda_interface_contract",
     "integration_manifest",
     "integration_status",
     "isaac_ros2_interface_contract",

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
@@ -5,6 +5,10 @@ They do not imply that an external vendor runtime is installed, connected, or
 validated unless the module explicitly reports that state.
 """
 
-from .nvidia import integration_manifest
+from .nvidia import build_evidence_envelope, integration_manifest, integration_status
 
-__all__ = ["integration_manifest"]
+__all__ = [
+    "build_evidence_envelope",
+    "integration_manifest",
+    "integration_status",
+]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/__init__.py
@@ -5,6 +5,8 @@ They do not imply that an external vendor runtime is installed, connected, or
 validated unless the module explicitly reports that state.
 """
 
+from .isaac_ros2 import assess_ros2_observation, isaac_ros2_interface_contract
+from .jetson import assess_jetson_observation, jetson_interface_contract
 from .nvidia import build_evidence_envelope, integration_manifest, integration_status
 from .omniverse import (
     assess_probe_response,
@@ -13,10 +15,14 @@ from .omniverse import (
 )
 
 __all__ = [
+    "assess_jetson_observation",
     "assess_probe_response",
+    "assess_ros2_observation",
     "build_evidence_envelope",
     "build_probe_request",
     "integration_manifest",
     "integration_status",
+    "isaac_ros2_interface_contract",
+    "jetson_interface_contract",
     "omniverse_interface_contract",
 ]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/cuda_backend.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/cuda_backend.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from pydantic import BaseModel, Field
+
+from .evidence import EvidenceEnvelope
+from .nvidia import ClaimStatus, build_evidence_envelope
+
+
+class CudaComputeObservation(BaseModel):
+    schema_version: Literal["1.0"] = "1.0"
+    integration_id: Literal["WS-NV-01"] = "WS-NV-01"
+    correlation_id: str = Field(min_length=8, max_length=128)
+    driver_version: str = Field(min_length=1, max_length=128)
+    toolkit_version: str = Field(min_length=1, max_length=128)
+    device_name: str = Field(min_length=1, max_length=256)
+    compute_capability: str = Field(min_length=3, max_length=32)
+    workload_id: str = Field(min_length=1, max_length=128)
+    workload_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    result_digest: str | None = Field(
+        default=None,
+        pattern=r"^sha256:[0-9a-f]{64}$",
+    )
+    execution_status: Literal["success", "failed", "not_run"]
+
+
+@dataclass(frozen=True)
+class CudaInterfaceProof:
+    observation: CudaComputeObservation
+    evidence: EvidenceEnvelope
+    execution_observed: bool
+    runtime_validated: bool = False
+    claim_status: ClaimStatus = ClaimStatus.REQUIRES_LAB_VALIDATION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "observation": self.observation.model_dump(mode="json"),
+            "evidence": self.evidence.to_dict(),
+            "execution_observed": self.execution_observed,
+            "runtime_validated": self.runtime_validated,
+            "claim_status": self.claim_status,
+        }
+
+
+def cuda_interface_contract() -> dict[str, object]:
+    return {
+        "increment": "WS-NV-01F",
+        "surface": "cuda_acceleration",
+        "transport_boundary": "future_compute_backend",
+        "version_inventory_required": True,
+        "compute_capability_required": True,
+        "workload_and_result_digests_required": True,
+        "cuda_client_implemented": False,
+        "gpu_discovery_implemented": False,
+        "runtime_validated": False,
+        "claim_status": ClaimStatus.REQUIRES_LAB_VALIDATION,
+    }
+
+
+def assess_cuda_observation(
+    *,
+    observation: Mapping[str, Any],
+    expected_correlation_id: str,
+    configuration: Mapping[str, Any],
+    evidence_refs: Sequence[str] = (),
+    operator_authorization_ref: str | None = None,
+) -> CudaInterfaceProof:
+    """Parse captured CUDA execution metadata without importing or invoking CUDA."""
+
+    parsed = CudaComputeObservation.model_validate(observation)
+    if parsed.correlation_id != expected_correlation_id:
+        raise ValueError("CUDA observation correlation_id mismatch")
+
+    execution_observed = (
+        parsed.execution_status == "success" and parsed.result_digest is not None
+    )
+    envelope = build_evidence_envelope(
+        surface_name="cuda_acceleration",
+        config=configuration,
+        evidence_refs=evidence_refs,
+        operator_authorization_ref=operator_authorization_ref,
+    )
+    return CudaInterfaceProof(
+        observation=parsed,
+        evidence=envelope,
+        execution_observed=execution_observed,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/evidence.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/evidence.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+EVIDENCE_ENVELOPE_SCHEMA_VERSION = "1.0"
+
+
+def canonical_config_digest(config: Mapping[str, Any]) -> str:
+    """Return a deterministic SHA-256 digest for JSON-compatible configuration.
+
+    The configuration itself is not retained in the evidence envelope. This keeps
+    the primitive suitable for provenance without encouraging secrets or runtime
+    credentials to be copied into evidence records.
+    """
+
+    encoded = json.dumps(
+        config,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class EvidenceEnvelope:
+    schema_version: str
+    integration_id: str
+    surface: str
+    claim_status: str
+    config_digest: str
+    evidence_refs: tuple[str, ...]
+    operator_authorization_ref: str | None
+    created_at: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        integration_id: str,
+        surface: str,
+        claim_status: str,
+        config: Mapping[str, Any],
+        evidence_refs: Sequence[str] = (),
+        operator_authorization_ref: str | None = None,
+    ) -> "EvidenceEnvelope":
+        if not integration_id.strip():
+            raise ValueError("integration_id must not be empty")
+        if not surface.strip():
+            raise ValueError("surface must not be empty")
+        if not claim_status.strip():
+            raise ValueError("claim_status must not be empty")
+
+        refs = tuple(ref.strip() for ref in evidence_refs if ref.strip())
+        auth_ref = (
+            operator_authorization_ref.strip()
+            if operator_authorization_ref and operator_authorization_ref.strip()
+            else None
+        )
+        return cls(
+            schema_version=EVIDENCE_ENVELOPE_SCHEMA_VERSION,
+            integration_id=integration_id,
+            surface=surface,
+            claim_status=claim_status,
+            config_digest=canonical_config_digest(config),
+            evidence_refs=refs,
+            operator_authorization_ref=auth_ref,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/isaac_ros2.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/isaac_ros2.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from pydantic import BaseModel, Field
+
+from .evidence import EvidenceEnvelope
+from .nvidia import ClaimStatus, build_evidence_envelope
+
+
+class IsaacRos2Observation(BaseModel):
+    schema_version: Literal["1.0"] = "1.0"
+    integration_id: Literal["WS-NV-01"] = "WS-NV-01"
+    correlation_id: str = Field(min_length=8, max_length=128)
+    bridge_version: str = Field(min_length=1, max_length=128)
+    ros_distro: str = Field(min_length=1, max_length=64)
+    simulation_state: Literal["playing", "paused", "stopped"]
+    observed_topics: tuple[str, ...] = ()
+    observed_services: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class IsaacRos2InterfaceProof:
+    observation: IsaacRos2Observation
+    evidence: EvidenceEnvelope
+    bridge_activity_observed: bool
+    runtime_validated: bool = False
+    claim_status: ClaimStatus = ClaimStatus.REQUIRES_LAB_VALIDATION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "observation": self.observation.model_dump(mode="json"),
+            "evidence": self.evidence.to_dict(),
+            "bridge_activity_observed": self.bridge_activity_observed,
+            "runtime_validated": self.runtime_validated,
+            "claim_status": self.claim_status,
+        }
+
+
+def isaac_ros2_interface_contract() -> dict[str, object]:
+    return {
+        "increment": "WS-NV-01D",
+        "surface": "isaac_sim_ros2",
+        "transport_boundary": "ros2_topics_and_services",
+        "simulation_playback_required_for_bridge_activity": True,
+        "ros_client_implemented": False,
+        "isaac_runtime_implemented": False,
+        "network_calls_enabled": False,
+        "runtime_validated": False,
+        "claim_status": ClaimStatus.REQUIRES_LAB_VALIDATION,
+    }
+
+
+def assess_ros2_observation(
+    *,
+    observation: Mapping[str, Any],
+    expected_correlation_id: str,
+    configuration: Mapping[str, Any],
+    evidence_refs: Sequence[str] = (),
+    operator_authorization_ref: str | None = None,
+) -> IsaacRos2InterfaceProof:
+    """Parse captured Isaac/ROS 2 metadata without performing ROS communication."""
+
+    parsed = IsaacRos2Observation.model_validate(observation)
+    if parsed.correlation_id != expected_correlation_id:
+        raise ValueError("Isaac ROS 2 correlation_id mismatch")
+
+    activity = (
+        parsed.simulation_state == "playing"
+        and bool(parsed.observed_topics or parsed.observed_services)
+    )
+    envelope = build_evidence_envelope(
+        surface_name="isaac_sim_ros2",
+        config=configuration,
+        evidence_refs=evidence_refs,
+        operator_authorization_ref=operator_authorization_ref,
+    )
+    return IsaacRos2InterfaceProof(
+        observation=parsed,
+        evidence=envelope,
+        bridge_activity_observed=activity,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/jetson.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/jetson.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from pydantic import BaseModel, Field
+
+from .evidence import EvidenceEnvelope
+from .nvidia import ClaimStatus, build_evidence_envelope
+
+
+class JetsonServiceObservation(BaseModel):
+    schema_version: Literal["1.0"] = "1.0"
+    integration_id: Literal["WS-NV-01"] = "WS-NV-01"
+    correlation_id: str = Field(min_length=8, max_length=128)
+    service_id: str = Field(min_length=1, max_length=128)
+    service_kind: str = Field(min_length=1, max_length=128)
+    jetpack_version: str = Field(min_length=1, max_length=128)
+    platform_services_version: str = Field(min_length=1, max_length=128)
+    service_status: Literal["ready", "degraded", "unavailable"]
+    observed_api_operations: tuple[str, ...] = ()
+    containerized: bool
+
+
+@dataclass(frozen=True)
+class JetsonInterfaceProof:
+    observation: JetsonServiceObservation
+    evidence: EvidenceEnvelope
+    api_surface_observed: bool
+    runtime_validated: bool = False
+    claim_status: ClaimStatus = ClaimStatus.REQUIRES_LAB_VALIDATION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "observation": self.observation.model_dump(mode="json"),
+            "evidence": self.evidence.to_dict(),
+            "api_surface_observed": self.api_surface_observed,
+            "runtime_validated": self.runtime_validated,
+            "claim_status": self.claim_status,
+        }
+
+
+def jetson_interface_contract() -> dict[str, object]:
+    return {
+        "increment": "WS-NV-01E",
+        "surface": "jetson_platform_services",
+        "transport_boundary": "rest_api_service",
+        "intended_deployment": "containerized_edge_service",
+        "sara_network_client_implemented": False,
+        "jetson_runtime_implemented": False,
+        "network_calls_enabled": False,
+        "runtime_validated": False,
+        "claim_status": ClaimStatus.REQUIRES_LAB_VALIDATION,
+    }
+
+
+def assess_jetson_observation(
+    *,
+    observation: Mapping[str, Any],
+    expected_correlation_id: str,
+    configuration: Mapping[str, Any],
+    evidence_refs: Sequence[str] = (),
+    operator_authorization_ref: str | None = None,
+) -> JetsonInterfaceProof:
+    """Parse captured Jetson service metadata without performing REST calls."""
+
+    parsed = JetsonServiceObservation.model_validate(observation)
+    if parsed.correlation_id != expected_correlation_id:
+        raise ValueError("Jetson service correlation_id mismatch")
+
+    api_surface_observed = bool(parsed.observed_api_operations)
+    envelope = build_evidence_envelope(
+        surface_name="jetson_platform_services",
+        config=configuration,
+        evidence_refs=evidence_refs,
+        operator_authorization_ref=operator_authorization_ref,
+    )
+    return JetsonInterfaceProof(
+        observation=parsed,
+        evidence=envelope,
+        api_surface_observed=api_surface_observed,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Final
+
+
+class IntegrationState(StrEnum):
+    CONTRACT_DEFINED = "contract_defined"
+    RUNTIME_NOT_VERIFIED = "runtime_not_verified"
+    VALIDATED = "validated"
+
+
+class ClaimStatus(StrEnum):
+    IMPLEMENTED_IN_SOFTWARE = "IMPLEMENTED_IN_SOFTWARE"
+    REQUIRES_LAB_VALIDATION = "REQUIRES_LAB_VALIDATION"
+    REQUIRES_PARTNER_VALIDATION = "REQUIRES_PARTNER_VALIDATION"
+
+
+@dataclass(frozen=True)
+class NvidiaSurfaceContract:
+    name: str
+    transport: str
+    purpose: str
+    state: IntegrationState
+    capability_claim: ClaimStatus
+    network_calls_enabled: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+SURFACES: Final[tuple[NvidiaSurfaceContract, ...]] = (
+    NvidiaSurfaceContract(
+        name="omniverse_kit",
+        transport="headless_app_or_microservice_boundary",
+        purpose="digital-twin and simulation event exchange",
+        state=IntegrationState.RUNTIME_NOT_VERIFIED,
+        capability_claim=ClaimStatus.REQUIRES_PARTNER_VALIDATION,
+    ),
+    NvidiaSurfaceContract(
+        name="isaac_sim_ros2",
+        transport="ros2_bridge_boundary",
+        purpose="robotics simulation, synthetic data, and control-loop exchange",
+        state=IntegrationState.RUNTIME_NOT_VERIFIED,
+        capability_claim=ClaimStatus.REQUIRES_LAB_VALIDATION,
+    ),
+    NvidiaSurfaceContract(
+        name="jetson_platform_services",
+        transport="api_service_boundary",
+        purpose="edge-AI service orchestration and telemetry exchange",
+        state=IntegrationState.RUNTIME_NOT_VERIFIED,
+        capability_claim=ClaimStatus.REQUIRES_LAB_VALIDATION,
+    ),
+    NvidiaSurfaceContract(
+        name="cuda_acceleration",
+        transport="future_compute_backend",
+        purpose="optional accelerated compute for approved workloads",
+        state=IntegrationState.RUNTIME_NOT_VERIFIED,
+        capability_claim=ClaimStatus.REQUIRES_LAB_VALIDATION,
+    ),
+)
+
+
+def integration_manifest() -> dict[str, object]:
+    """Return the non-executing WS-NV-01 integration contract.
+
+    This function deliberately performs no vendor imports, network calls, device
+    discovery, or hardware claims. It describes the interfaces Worldshepherd
+    intends to validate and the evidence gates that still remain.
+    """
+
+    return {
+        "integration_id": "WS-NV-01",
+        "vendor": "NVIDIA",
+        "architecture_version": "0.1",
+        "execution_mode": "scaffold_only",
+        "network_calls_enabled": False,
+        "contract_claim": ClaimStatus.IMPLEMENTED_IN_SOFTWARE,
+        "vendor_capability_claim": ClaimStatus.REQUIRES_PARTNER_VALIDATION,
+        "promotion_rule": (
+            "No NVIDIA runtime capability may be promoted beyond its current "
+            "claim state without reproducible lab or partner evidence."
+        ),
+        "evidence_required": [
+            "runtime and SDK version inventory",
+            "reproducible configuration digest",
+            "successful bounded interface test",
+            "telemetry and decision-provenance capture",
+            "failure and degraded-state behavior",
+            "operator authorization record",
+        ],
+        "surfaces": [surface.to_dict() for surface in SURFACES],
+    }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
@@ -68,6 +68,25 @@ SURFACES: Final[tuple[NvidiaSurfaceContract, ...]] = (
 )
 
 
+IMPLEMENTED_INCREMENTS: Final[tuple[str, ...]] = (
+    "WS-NV-01",
+    "WS-NV-01A",
+    "WS-NV-01B",
+    "WS-NV-01C",
+    "WS-NV-01D",
+    "WS-NV-01E",
+    "WS-NV-01F",
+)
+
+
+PROOF_CONTRACTS: Final[dict[str, str]] = {
+    "omniverse_kit": "interface_contract_only",
+    "isaac_sim_ros2": "captured_observation_contract_only",
+    "jetson_platform_services": "captured_observation_contract_only",
+    "cuda_acceleration": "captured_compute_observation_contract_only",
+}
+
+
 def integration_manifest() -> dict[str, object]:
     """Return the non-executing WS-NV-01 integration contract.
 
@@ -79,11 +98,14 @@ def integration_manifest() -> dict[str, object]:
     return {
         "integration_id": "WS-NV-01",
         "vendor": "NVIDIA",
-        "architecture_version": "0.2",
-        "execution_mode": "scaffold_only",
+        "architecture_version": "0.6",
+        "execution_mode": "contract_and_offline_evidence_only",
         "network_calls_enabled": False,
+        "runtime_verified": False,
         "contract_claim": ClaimStatus.IMPLEMENTED_IN_SOFTWARE,
         "vendor_capability_claim": ClaimStatus.REQUIRES_PARTNER_VALIDATION,
+        "implemented_increments": list(IMPLEMENTED_INCREMENTS),
+        "proof_contracts": dict(PROOF_CONTRACTS),
         "promotion_rule": (
             "No NVIDIA runtime capability may be promoted beyond its current "
             "claim state without reproducible lab or partner evidence."
@@ -108,13 +130,15 @@ def integration_status() -> dict[str, object]:
         "integration_id": manifest["integration_id"],
         "vendor": manifest["vendor"],
         "architecture_version": manifest["architecture_version"],
-        "status": "contract_ready_runtime_unverified",
+        "status": "proof_contracts_ready_runtime_unverified",
         "execution_mode": manifest["execution_mode"],
         "network_calls_enabled": False,
         "runtime_verified": False,
         "surface_count": len(SURFACES),
         "contract_claim": manifest["contract_claim"],
         "vendor_capability_claim": manifest["vendor_capability_claim"],
+        "implemented_increments": manifest["implemented_increments"],
+        "proof_contracts": manifest["proof_contracts"],
         "contract_digest": canonical_config_digest(manifest),
         "evidence_envelope_schema_version": EVIDENCE_ENVELOPE_SCHEMA_VERSION,
         "surfaces": [

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from enum import StrEnum
-from typing import Final
+from typing import Any, Final, Mapping, Sequence
+
+from .evidence import (
+    EVIDENCE_ENVELOPE_SCHEMA_VERSION,
+    EvidenceEnvelope,
+    canonical_config_digest,
+)
 
 
 class IntegrationState(StrEnum):
@@ -73,7 +79,7 @@ def integration_manifest() -> dict[str, object]:
     return {
         "integration_id": "WS-NV-01",
         "vendor": "NVIDIA",
-        "architecture_version": "0.1",
+        "architecture_version": "0.2",
         "execution_mode": "scaffold_only",
         "network_calls_enabled": False,
         "contract_claim": ClaimStatus.IMPLEMENTED_IN_SOFTWARE,
@@ -92,3 +98,61 @@ def integration_manifest() -> dict[str, object]:
         ],
         "surfaces": [surface.to_dict() for surface in SURFACES],
     }
+
+
+def integration_status() -> dict[str, object]:
+    """Return an authenticated-read-safe status snapshot for WS-NV-01."""
+
+    manifest = integration_manifest()
+    return {
+        "integration_id": manifest["integration_id"],
+        "vendor": manifest["vendor"],
+        "architecture_version": manifest["architecture_version"],
+        "status": "contract_ready_runtime_unverified",
+        "execution_mode": manifest["execution_mode"],
+        "network_calls_enabled": False,
+        "runtime_verified": False,
+        "surface_count": len(SURFACES),
+        "contract_claim": manifest["contract_claim"],
+        "vendor_capability_claim": manifest["vendor_capability_claim"],
+        "contract_digest": canonical_config_digest(manifest),
+        "evidence_envelope_schema_version": EVIDENCE_ENVELOPE_SCHEMA_VERSION,
+        "surfaces": [
+            {
+                "name": surface.name,
+                "state": surface.state,
+                "capability_claim": surface.capability_claim,
+                "network_calls_enabled": surface.network_calls_enabled,
+            }
+            for surface in SURFACES
+        ],
+    }
+
+
+def build_evidence_envelope(
+    *,
+    surface_name: str,
+    config: Mapping[str, Any],
+    evidence_refs: Sequence[str] = (),
+    operator_authorization_ref: str | None = None,
+) -> EvidenceEnvelope:
+    """Build a configuration-digested evidence envelope for one declared surface.
+
+    Creating an envelope does not validate the runtime or promote the claim. The
+    envelope inherits the surface's current claim status until separate evidence
+    justifies an explicit promotion through a future controlled workflow.
+    """
+
+    try:
+        surface = next(item for item in SURFACES if item.name == surface_name)
+    except StopIteration as exc:
+        raise ValueError(f"Unknown NVIDIA integration surface: {surface_name}") from exc
+
+    return EvidenceEnvelope.create(
+        integration_id="WS-NV-01",
+        surface=surface.name,
+        claim_status=surface.capability_claim.value,
+        config=config,
+        evidence_refs=evidence_refs,
+        operator_authorization_ref=operator_authorization_ref,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/nvidia.py
@@ -9,6 +9,7 @@ from .evidence import (
     EvidenceEnvelope,
     canonical_config_digest,
 )
+from .promotion import REQUIRED_EVIDENCE_CATEGORIES, assess_promotion_readiness
 
 
 class IntegrationState(StrEnum):
@@ -76,6 +77,7 @@ IMPLEMENTED_INCREMENTS: Final[tuple[str, ...]] = (
     "WS-NV-01D",
     "WS-NV-01E",
     "WS-NV-01F",
+    "WS-NV-01G",
 )
 
 
@@ -98,7 +100,7 @@ def integration_manifest() -> dict[str, object]:
     return {
         "integration_id": "WS-NV-01",
         "vendor": "NVIDIA",
-        "architecture_version": "0.6",
+        "architecture_version": "0.7",
         "execution_mode": "contract_and_offline_evidence_only",
         "network_calls_enabled": False,
         "runtime_verified": False,
@@ -106,9 +108,14 @@ def integration_manifest() -> dict[str, object]:
         "vendor_capability_claim": ClaimStatus.REQUIRES_PARTNER_VALIDATION,
         "implemented_increments": list(IMPLEMENTED_INCREMENTS),
         "proof_contracts": dict(PROOF_CONTRACTS),
+        "promotion_gate": {
+            "required_categories": list(REQUIRED_EVIDENCE_CATEGORIES),
+            "auto_promotion_allowed": False,
+            "human_review_required": True,
+        },
         "promotion_rule": (
             "No NVIDIA runtime capability may be promoted beyond its current "
-            "claim state without reproducible lab or partner evidence."
+            "claim state without reproducible evidence and explicit human review."
         ),
         "evidence_required": [
             "runtime and SDK version inventory",
@@ -139,6 +146,7 @@ def integration_status() -> dict[str, object]:
         "vendor_capability_claim": manifest["vendor_capability_claim"],
         "implemented_increments": manifest["implemented_increments"],
         "proof_contracts": manifest["proof_contracts"],
+        "promotion_gate": manifest["promotion_gate"],
         "contract_digest": canonical_config_digest(manifest),
         "evidence_envelope_schema_version": EVIDENCE_ENVELOPE_SCHEMA_VERSION,
         "surfaces": [
@@ -180,3 +188,22 @@ def build_evidence_envelope(
         evidence_refs=evidence_refs,
         operator_authorization_ref=operator_authorization_ref,
     )
+
+
+def assess_surface_promotion_readiness(
+    *,
+    surface_name: str,
+    evidence_by_category: Mapping[str, Sequence[str]],
+) -> dict[str, object]:
+    """Assess completeness for human review without changing any claim state."""
+
+    try:
+        surface = next(item for item in SURFACES if item.name == surface_name)
+    except StopIteration as exc:
+        raise ValueError(f"Unknown NVIDIA integration surface: {surface_name}") from exc
+
+    return assess_promotion_readiness(
+        surface=surface.name,
+        submitted_claim_status=surface.capability_claim.value,
+        evidence_by_category=evidence_by_category,
+    ).to_dict()

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/omniverse.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/omniverse.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from pydantic import BaseModel, Field
+
+from .evidence import EvidenceEnvelope
+from .nvidia import ClaimStatus, build_evidence_envelope
+
+
+OMNIVERSE_PROOF_SCHEMA_VERSION = "1.0"
+
+
+class OmniverseProbeRequest(BaseModel):
+    schema_version: Literal["1.0"] = "1.0"
+    integration_id: Literal["WS-NV-01"] = "WS-NV-01"
+    correlation_id: str = Field(min_length=8, max_length=128)
+    operation: Literal["interface_probe"] = "interface_probe"
+    requested_capabilities: tuple[str, ...] = (
+        "kit_runtime",
+        "services_core",
+    )
+
+
+class OmniverseProbeResponse(BaseModel):
+    schema_version: Literal["1.0"] = "1.0"
+    integration_id: Literal["WS-NV-01"] = "WS-NV-01"
+    correlation_id: str = Field(min_length=8, max_length=128)
+    service_id: str = Field(min_length=1, max_length=128)
+    kit_version: str = Field(min_length=1, max_length=128)
+    service_status: Literal["ready", "degraded", "unavailable"]
+    extension_versions: dict[str, str] = Field(default_factory=dict)
+    observed_capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OmniverseInterfaceProof:
+    response: OmniverseProbeResponse
+    evidence: EvidenceEnvelope
+    interface_parsed: bool = True
+    runtime_validated: bool = False
+    claim_status: ClaimStatus = ClaimStatus.REQUIRES_PARTNER_VALIDATION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "response": self.response.model_dump(mode="json"),
+            "evidence": self.evidence.to_dict(),
+            "interface_parsed": self.interface_parsed,
+            "runtime_validated": self.runtime_validated,
+            "claim_status": self.claim_status,
+        }
+
+
+def omniverse_interface_contract() -> dict[str, object]:
+    """Describe the WS-NV-01C wire contract without executing it."""
+
+    return {
+        "increment": "WS-NV-01C",
+        "surface": "omniverse_kit",
+        "proof_schema_version": OMNIVERSE_PROOF_SCHEMA_VERSION,
+        "transport_boundary": "http_openapi_compatible_service",
+        "intended_runtime": "headless_omniverse_kit_service",
+        "sara_network_client_implemented": False,
+        "omniverse_service_implemented": False,
+        "network_calls_enabled": False,
+        "runtime_validated": False,
+        "claim_status": ClaimStatus.REQUIRES_PARTNER_VALIDATION,
+    }
+
+
+def build_probe_request(*, correlation_id: str) -> OmniverseProbeRequest:
+    """Build the request payload a future Omniverse service must accept."""
+
+    return OmniverseProbeRequest(correlation_id=correlation_id)
+
+
+def assess_probe_response(
+    *,
+    response: Mapping[str, Any],
+    expected_correlation_id: str,
+    configuration: Mapping[str, Any],
+    evidence_refs: Sequence[str] = (),
+    operator_authorization_ref: str | None = None,
+) -> OmniverseInterfaceProof:
+    """Parse a captured service response and wrap it in evidence without promotion.
+
+    This function performs no network I/O. A syntactically valid response proves
+    only that the captured payload conforms to the WS-NV-01C interface contract.
+    It does not prove that Omniverse Kit produced the response or that a runtime is
+    operational; provenance for that must be established separately.
+    """
+
+    parsed = OmniverseProbeResponse.model_validate(response)
+    if parsed.correlation_id != expected_correlation_id:
+        raise ValueError("Omniverse probe correlation_id mismatch")
+
+    envelope = build_evidence_envelope(
+        surface_name="omniverse_kit",
+        config=configuration,
+        evidence_refs=evidence_refs,
+        operator_authorization_ref=operator_authorization_ref,
+    )
+    return OmniverseInterfaceProof(response=parsed, evidence=envelope)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/promotion.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/integrations/promotion.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping, Sequence
+
+
+REQUIRED_EVIDENCE_CATEGORIES: tuple[str, ...] = (
+    "runtime_version_inventory",
+    "configuration_digest",
+    "bounded_interface_test",
+    "telemetry_and_provenance",
+    "failure_or_degraded_behavior",
+    "operator_authorization",
+)
+
+
+@dataclass(frozen=True)
+class PromotionReadinessAssessment:
+    surface: str
+    submitted_claim_status: str
+    ready_for_human_review: bool
+    auto_promotion_allowed: bool
+    missing_categories: tuple[str, ...]
+    evidence_ref_count: int
+    decision: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def assess_promotion_readiness(
+    *,
+    surface: str,
+    submitted_claim_status: str,
+    evidence_by_category: Mapping[str, Sequence[str]],
+) -> PromotionReadinessAssessment:
+    """Assess whether an NVIDIA evidence package is complete enough for human review.
+
+    This function never promotes a capability and never treats completeness as
+    validation. It only determines whether all required evidence categories have
+    at least one non-empty reference. Explicit human/authority review is always
+    required after this gate.
+    """
+
+    if not surface.strip():
+        raise ValueError("surface must not be empty")
+    if not submitted_claim_status.strip():
+        raise ValueError("submitted_claim_status must not be empty")
+
+    normalized: dict[str, tuple[str, ...]] = {}
+    for category in REQUIRED_EVIDENCE_CATEGORIES:
+        refs = evidence_by_category.get(category, ())
+        normalized[category] = tuple(ref.strip() for ref in refs if ref.strip())
+
+    missing = tuple(
+        category for category in REQUIRED_EVIDENCE_CATEGORIES if not normalized[category]
+    )
+    ref_count = sum(len(refs) for refs in normalized.values())
+    ready = not missing
+
+    return PromotionReadinessAssessment(
+        surface=surface.strip(),
+        submitted_claim_status=submitted_claim_status.strip(),
+        ready_for_human_review=ready,
+        auto_promotion_allowed=False,
+        missing_categories=missing,
+        evidence_ref_count=ref_count,
+        decision=(
+            "READY_FOR_HUMAN_REVIEW"
+            if ready
+            else "INCOMPLETE_EVIDENCE_PACKAGE"
+        ),
+    )


### PR DESCRIPTION
## What changed

This draft PR establishes the Worldshepherd software-side NVIDIA integration boundary without claiming NVIDIA runtime or hardware validation.

### Implemented increments

- **WS-NV-01** — bounded NVIDIA integration manifest and claims gates.
- **WS-NV-01A** — authenticated read-only SARA status endpoint at `/v1/integrations/nvidia/status`.
- **WS-NV-01B** — deterministic SHA-256 configuration-digested evidence envelopes that omit raw configuration.
- **WS-NV-01C** — Omniverse Kit headless service request/response proof contract and offline parser.
- **WS-NV-01D** — Isaac Sim ROS 2 captured-observation contract with playback-state gating.
- **WS-NV-01E** — Jetson Platform Services captured API-observation contract.
- **WS-NV-01F** — CUDA compute-backend captured-observation contract with driver/toolkit/device/compute-capability and workload/result digests.
- **WS-NV-01G** — promotion-readiness assessment: complete evidence can become `READY_FOR_HUMAN_REVIEW`, but `auto_promotion_allowed` is always false.

### Partner and lab packages

- `docs/NVIDIA_PARTNER_BRIEF.md` — concise technical proposition, current claim state, three bounded demonstrations, and partner asks.
- `docs/NVIDIA_RUNTIME_EVIDENCE_PACKET.md` — minimum reproducible evidence package for Omniverse/Isaac, Jetson, and CUDA runtime validation.
- #13 `LAB-NV-01 — Omniverse + Isaac runtime validation`
- #14 `LAB-NV-02 — Jetson + CUDA hardware validation`
- #15 `NVIDIA Inception readiness — eligibility and application package`

## Safety and claims control

- No NVIDIA SDK, ROS, JetPack, CUDA, GPU, or Omniverse runtime is imported or invoked by these contracts.
- No outbound vendor network client is implemented.
- NVIDIA runtime capability remains `REQUIRES_PARTNER_VALIDATION` or `REQUIRES_LAB_VALIDATION`.
- Parsing a captured response or observation never promotes `runtime_validated` to true.
- The read-only NVIDIA status endpoint accepts authenticated relay/admin roles and is tested not to mutate the SARA audit store.
- Evidence envelopes store deterministic configuration digests rather than raw configuration.
- Evidence completeness is only a gate to human review; software cannot self-promote a claim.

## Validation

The current A-G head passed the existing `SARA Verified Local v1 Gate` end-to-end after one narrow regression fix to stale test expectations:

- package installation/compilation: PASS
- unit and API tests: PASS
- Compose validation: PASS
- patched deployment verifier: PASS
- cleanup: PASS

The temporary failing run was caused only by two tests that still expected seven increments after WS-NV-01G was added. Those expectations were updated; no runtime logic rollback or claims-control weakening was required.

Passing CI validates Worldshepherd software behavior only. It does **not** validate any NVIDIA runtime, SDK installation, GPU, Jetson device, Isaac Sim instance, or Omniverse service.

## Runtime evidence still required

Before any NVIDIA surface can be promoted, collect reproducible runtime/SDK versions, configuration digest, bounded interface evidence, telemetry/provenance, degraded/failure behavior, operator authorization, and surface-specific hardware/runtime evidence. A complete packet must still receive explicit human review.

This PR remains **draft** while runtime/partner validation is pending.