### PR TITLE
PRE: ingest Release-5 demand and add qualification schema

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -43,21 +43,25 @@ jobs:
       - name: Run unit and API tests
         run: pytest
 
-      - name: Compile PRE qualification evidence
+      - name: Compile PRE full-bloom qualification evidence
         run: |
           rm -rf qualification_evidence_ci
-          python -m worldshepherd_sara.pre_cli \
+          python -m worldshepherd_sara.pre_bloom_cli \
             --fixtures fixtures \
             --out qualification_evidence_ci \
             --software-commit "$GITHUB_SHA" \
             --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --operator "github-actions"
           test -s qualification_evidence_ci/qualification_index.json
+          test -s qualification_evidence_ci/capability_readiness_ledger.json
+          test -s qualification_evidence_ci/capability_horizons.json
+          test -s qualification_evidence_ci/software_provenance.json
+          test -d qualification_evidence_ci/echo_store
 
       - name: Upload PRE qualification evidence
         uses: actions/upload-artifact@v4
         with:
-          name: pre-qualification-evidence
+          name: pre-full-bloom-qualification-evidence
           path: deployments/sara_verified_local_v1/qualification_evidence_ci
           if-no-files-found: error
 

--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Run unit and API tests
         run: pytest
 
+      - name: Compile PRE qualification evidence
+        run: |
+          rm -rf qualification_evidence_ci
+          python -m worldshepherd_sara.pre_cli \
+            --fixtures fixtures \
+            --out qualification_evidence_ci \
+            --software-commit "$GITHUB_SHA" \
+            --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --operator "github-actions"
+          test -s qualification_evidence_ci/qualification_index.json
+
+      - name: Upload PRE qualification evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: pre-qualification-evidence
+          path: deployments/sara_verified_local_v1/qualification_evidence_ci
+          if-no-files-found: error
+
       - name: Create ephemeral CI environment
         run: |
           printf 'SARA_RELAY_TOKEN=%s\nSARA_ADMIN_TOKEN=%s\nSARA_PORT=9530\nSARA_HOST_PORT=19530\n' \

--- a/PRE_RELEASE5_INGEST_WAVE2_2026-08-26.md
+++ b/PRE_RELEASE5_INGEST_WAVE2_2026-08-26.md
@@ -1,0 +1,87 @@
+# PRE Release-5 Ingest — Wave 2 — 2026-08-26
+
+Claims-controlled requirement ingest for reusable Worldshepherd capability development. Operative proposal requirements remain subject to direct solicitation/DSIP freeze review.
+
+## PRE-RD-2026-0006 — Dynamic open mission enclave
+- Demand: CONFIRMED_DEMAND
+- Topic: DAF26BZ05-DV033 — Dynamic Open Systems Enclave
+- Source status: OFFICIAL_SOURCE_VERIFIED subject to final proposal-package review
+- Horizon: 0-90D
+- Requirement signal: legacy platforms need a modular high-speed computing enclave that can accept new processing/sensor/software capability without redesigning the host platform.
+- Existing WS capability: SARA service orchestration; ECHO provenance; PRIME authorization; OVERWATCH health/replay — IMPLEMENTED IN SOFTWARE where retained evidence exists.
+- Missing: aircraft/mission-platform integration, flight-qualified compute, airworthiness, operational BLOS evidence.
+- Build now: Common Services / Dynamic Mission Enclave with adapter boundary, identity, configuration custody, SBOM, telemetry, policy, health, rollback and replay.
+- Evidence target: same bounded service module deployed through two synthetic platform adapters with preserved configuration/provenance and rollback evidence.
+
+## PRE-RD-2026-0007 — Parallel sensor fusion qualification
+- Demand: CONFIRMED_DEMAND
+- Topic: DON26BZ05-NV077 — Multi-Core Parallel Processing for Sensor Fusion Architecture
+- Source status: OFFICIAL_SOURCE_VERIFIED subject to final proposal-package review
+- Horizon: 0-90D
+- Requirement signal: parallel spatial alignment, temporal correlation and attribute fusion while reducing latency without losing track integrity.
+- Existing WS capability: provenance/observability/orchestration architecture — IMPLEMENTED IN SOFTWARE.
+- Missing: validated multi-sensor fusion engine, representative NAVAIR data, aircraft processor validation.
+- Build now: synthetic multi-sensor truth set + parallel stage benchmark + source/track lineage.
+- Evidence target: latency, throughput, track-retention, association accuracy, CPU/core utilization and failure/degradation results.
+
+## PRE-RD-2026-0008 — Task-aware radar data compression
+- Demand: CONFIRMED_DEMAND
+- Topic: OSW26BZ05-DV018 — AI/ML-Based Radar Data Compression
+- Source status: OFFICIAL_SOURCE_VERIFIED subject to final proposal-package review
+- Horizon: 0-90D / 3-12M
+- Requirement signal: compress raw/complex radar data while preserving downstream imaging/detection/track utility; later move to embedded resource-constrained hardware.
+- Existing WS capability: experiment governance/provenance patterns — IMPLEMENTED IN SOFTWARE.
+- Missing: representative radar dataset, trained compression model, task-fidelity benchmark, embedded implementation.
+- Build now: generic Sensor Compression Qualification Harness.
+- Evidence target: compression ratio, reconstruction error, downstream task fidelity, latency, RAM, bandwidth and power/resource estimates.
+
+## PRE-RD-2026-0009 — Semantic reduction under DDIL and low SWaP
+- Demand: CONFIRMED_DEMAND
+- Topic: DPA26BZ05-DV019 — Semantically-Aware ISR
+- Source status: OFFICIAL_SOURCE_VERIFIED subject to final proposal-package review
+- Horizon: 0-90D / 3-12M
+- Requirement signal: preserve mission-relevant information while reducing transmission load under degraded communications and edge power constraints; retain confidence/uncertainty and traceability.
+- Existing WS capability: ECHO provenance/confidence architecture, SARA workflow, PRIME governance — IMPLEMENTED IN SOFTWARE where evidenced.
+- Missing: semantic encoder, representative ISR data, measured reduction/fidelity, edge-power benchmark, UAS integration.
+- Build now: semantic reduction benchmark using public/synthetic sensor data and task-aware utility metrics.
+- Evidence target: reduction ratio, mission-task fidelity, confidence calibration, latency, memory, watts/joules, packet-loss robustness.
+
+## PRE-RD-2026-0010 — CMMC/NIST 800-171 recurring delivery gate
+- Demand: CONFIRMED_DEMAND
+- Source: recurring Navy/DoW Release-5 cybersecurity clauses
+- Source status: OFFICIAL_SOURCE_VERIFIED at topic level; exact contract requirement remains topic/award specific
+- Horizon: 0-90D
+- Requirement signal: CMMC/NIST 800-171 readiness recurs across software, autonomy, RF, C2 and digital-twin opportunities.
+- Existing WS capability: local role separation, audit, configuration and bounded administration — IMPLEMENTED IN SOFTWARE.
+- Missing: documentary SSP/POA&M, assessment status, complete control evidence, SPRS/CMMC state.
+- Build now: fail-closed compliance-evidence layer with UNKNOWN default for unverified status.
+- Evidence target: machine-readable mapping from internal control evidence to readiness gaps without claiming compliance/certification.
+
+## PRE-RD-2026-0011 — Interpretable RF classification on modest compute
+- Demand: CONFIRMED_DEMAND
+- Topic: OSW26BZ05-DV022 — Signal Classification and Anomaly Detection in Contested Spectral Environments
+- Source status: OFFICIAL_SOURCE_VERIFIED subject to final proposal-package review
+- Horizon: 3-12M
+- Requirement signal: transparent/modular RF classification, anomaly detection, CPU-class deployment, containerization and continuous updateability.
+- Existing WS capability: governance/container/evidence architecture — IMPLEMENTED IN SOFTWARE.
+- Missing: labeled RF datasets, trained classifiers, benchmarked accuracy/anomaly detection, explainability and resource measurements.
+- Build now: RF Classification Lab with strong classical baselines and synthetic/public data only until representative partner data exists.
+- Evidence target: accuracy, unknown-class detection, calibration, inference latency, CPU/RAM, explanation artifact, model/version lineage and OOD performance.
+
+## Cross-wave architecture conclusion
+The recurring requirement family is now:
+
+`legacy source/platform -> adapter -> common services -> bounded algorithm -> confidence/provenance -> human/policy gate -> qualification evidence -> replay`
+
+Priority reusable modules:
+1. Qualification Evidence Compiler
+2. Evidence Graph Service
+3. DDIL/fault-injection harness
+4. Dynamic Mission Enclave/Common Services
+5. Sensor Fusion Qualification Harness
+6. Sensor Compression Qualification Harness
+7. Edge/SWaP Benchmark Harness
+8. CMMC/NIST readiness evidence layer
+9. RF Classification Lab
+
+No module acquires platform, compliance, certification, physical or operational validity merely through this ingest.

--- a/deployments/sara_verified_local_v1/README.md
+++ b/deployments/sara_verified_local_v1/README.md
@@ -1,6 +1,6 @@
 # Worldshepherd SARA / SSPADAWANZZ
 
-Evidence-governed local administration and relay-recording service for the Worldshepherd stack.
+Evidence-governed local administration, relay-recording, and predictive-requirements qualification service for the Worldshepherd stack.
 
 ## Verified boundary
 
@@ -16,11 +16,9 @@ Evidence-governed local administration and relay-recording service for the World
 
 External scanning, broadcasting, arbitrary command execution, third-party activation, and self-expanding network behavior are excluded.
 
-The audit is an application-appended JSON Lines log on the local persistent
-volume. It is useful operational evidence, but it is not immutable,
-tamper-proof, or independently verified.
+The audit is an application-appended JSON Lines log on the local persistent volume. It is useful operational evidence, but it is not immutable, tamper-proof, or independently verified.
 
-## Quick start
+## Quick start — SARA local service
 
 ```bash
 python -m venv .venv
@@ -32,3 +30,21 @@ cp .env.example .env
 ```
 
 For the Docker-based acceptance sequence, see [`docs/VERIFIED_DEPLOYMENT.md`](docs/VERIFIED_DEPLOYMENT.md).
+
+## Quick start — PRE full-bloom qualification compiler
+
+After installing the package, compile the current frozen internal qualification evidence with:
+
+```bash
+rm -rf qualification_evidence
+ws-pre-bloom \
+  --fixtures fixtures \
+  --out qualification_evidence \
+  --software-commit "$(git rev-parse HEAD)" \
+  --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --operator "$(whoami)"
+```
+
+The compiler exits nonzero if a qualification record fails or ECHO-style custody verification fails. Expected outputs include `qualification_index.json`, domain qualification bundles, `capability_readiness_ledger.json`, `capability_horizons.json`, `software_provenance.json`, and the local hash-addressed `echo_store/`.
+
+See [`docs/PRE_FULL_BLOOM.md`](docs/PRE_FULL_BLOOM.md) for operation and evidence interpretation, and [`docs/COMPLIANCE_BOUNDARY.md`](docs/COMPLIANCE_BOUNDARY.md) for the exact distinction between internal software conformance and external regulatory, contractual, physical, partner, and government validation.

--- a/deployments/sara_verified_local_v1/docs/COMPLIANCE_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/docs/COMPLIANCE_BOUNDARY.md
@@ -1,0 +1,70 @@
+# Worldshepherd SARA / PRE Compliance Boundary
+
+## Status vocabulary
+
+This project distinguishes **internal software conformance** from **external compliance, certification, eligibility, or operational validation**.
+
+A green CI run means the repository's bounded software/test/deployment gate passed for the tested commit. It does not mean any external framework has been certified.
+
+## Internally testable and currently gateable
+
+The repository can directly test and retain evidence for:
+
+- Python compilation and unit/API tests;
+- deterministic frozen-fixture qualification behavior;
+- claims-boundary assertions;
+- local ECHO-style digest verification;
+- local configuration and registry custody behavior;
+- fail-closed evidence rules;
+- Docker Compose syntax and ephemeral local deployment;
+- local health/readiness/self-test behavior;
+- bounded authorization/policy logic;
+- synthetic DDIL fault and reconciliation behavior;
+- internal software provenance records;
+- machine-readable readiness and PRE horizon records.
+
+These are software conformance claims only unless a specific evidence package establishes more.
+
+## External gates that cannot be self-certified by this repository
+
+| Gate | Current default status | Evidence required to close |
+|---|---|---|
+| CMMC | NOT CERTIFIED / UNVERIFIED | Applicable CMMC assessment/certificate or authoritative program evidence |
+| NIST SP 800-171 organizational conformity | UNVERIFIED | scoped system boundary, SSP, control implementation evidence, assessment results and required POA&M/SPR S evidence |
+| SPRS | UNVERIFIED | authoritative SPRS assessment/score evidence when applicable |
+| SAM / UEI / CAGE | UNVERIFIED in software | authoritative entity records |
+| SBIR/STTR eligibility | UNVERIFIED | formation, ownership/control, size, registry, PI and solicitation-specific documentary evidence |
+| ITAR/EAR | REQUIRES LEGAL/EXPORT REVIEW | export classification, access/control analysis and required registrations/authorizations |
+| FOCI / foreign influence constraints | UNVERIFIED / REQUIRES REVIEW | ownership/control/influence analysis under applicable solicitation/security rules |
+| Security clearance / facility clearance | NOT CLAIMED | authoritative personnel/facility clearance evidence |
+| Government ATO / RMF authorization | NOT CLAIMED | customer-authorized RMF package and authorization decision |
+| Government interoperability certification | NOT CLAIMED | designated authority/test-facility conformance evidence |
+| Physical hardware performance | NOT CLAIMED unless separate evidence exists | controlled physical test with configuration, instrumentation, calibration and retained results |
+| Operational effectiveness | NOT CLAIMED | representative operational evaluation with agreed metrics and customer/independent evidence |
+| Qualified aerospace/material process | NOT CLAIMED | coupon/process qualification, repeatability, standards/certification evidence and appropriate authority acceptance |
+
+## Claims-control rule
+
+Do not use `PASS`, `green`, `verified`, `qualified`, `compliant`, or similar language without naming the scope. Preferred forms are:
+
+- `INTERNALLY TESTED SOFTWARE BEHAVIOR: PASS`
+- `CI/LOCAL DEPLOYMENT GATE: PASS`
+- `SYNTHETIC QUALIFICATION FIXTURE: PASS`
+- `EXTERNAL CMMC STATUS: UNVERIFIED`
+- `PHYSICAL PERFORMANCE: REQUIRES LAB/PARTNER VALIDATION`
+
+## Release usability gate
+
+A commit may be called **internally usable** when all of the following hold for that commit:
+
+1. required GitHub Actions gate is green;
+2. `pytest` passes;
+3. full-bloom qualification compiler exits zero;
+4. required qualification outputs are generated;
+5. ECHO-style custody verification is all true;
+6. Docker Compose validates;
+7. ephemeral deployment verifier passes;
+8. documented CLI/quick-start path matches the tested path;
+9. no known high-severity unresolved defect invalidates the tested scope.
+
+This is an internal engineering release criterion only. External contractual or regulatory compliance remains governed by the applicable authority and evidence package.

--- a/deployments/sara_verified_local_v1/docs/PRE_FULL_BLOOM.md
+++ b/deployments/sara_verified_local_v1/docs/PRE_FULL_BLOOM.md
@@ -1,0 +1,72 @@
+# PRE Full-Bloom Qualification Compiler
+
+## Purpose
+
+The full-bloom compiler turns frozen Worldshepherd synthetic/internal fixtures into machine-readable Qualification Evidence while preserving a strict claims boundary. It is intended for repeatable engineering readiness, regression testing, opportunity preparation, and evidence custody. It is not a government certification system and does not promote synthetic evidence into physical or operational claims.
+
+## Run
+
+From `deployments/sara_verified_local_v1` after `python -m pip install -e '.[test]'`:
+
+```bash
+rm -rf qualification_evidence
+ws-pre-bloom \
+  --fixtures fixtures \
+  --out qualification_evidence \
+  --software-commit "$(git rev-parse HEAD)" \
+  --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --operator "$(whoami)"
+```
+
+Equivalent module entry point:
+
+```bash
+python -m worldshepherd_sara.pre_bloom_cli --fixtures fixtures --out qualification_evidence --software-commit "$(git rev-parse HEAD)" --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+## Exit behavior
+
+Exit code `0` means every compiled Qualification Evidence record passed its frozen bounded test and every object in the local ECHO-style evidence store passed digest verification. A nonzero exit means the build must not be represented as qualification-pass evidence.
+
+## Core outputs
+
+- `qualification_index.json`: top-level bundle digests, failures, custody state, claims boundary, and Bloom extension summary.
+- `*_qualification_bundle.json`: domain-specific frozen evidence bundles.
+- `capability_readiness_ledger.json`: non-inheriting readiness rungs; a lower rung never implies a higher one.
+- `capability_horizons.json`: 0–90 day, 3–12 month, and 12–24+ month preparation targets.
+- `software_provenance.json`: source/build/output provenance. Current attestation is explicitly internal and unsigned.
+- `echo_store/`: local hash-addressed custody objects with verification support.
+
+## Current evidence domains
+
+The compiler currently covers bounded internal software evidence for APNT operational-awareness logic, MBSE reconstruction benchmarking, IETM transformation, interpretable automated algorithm-discovery experiments, post-mission replay/proposal generation, multi-sensor fusion, RF simulation-to-measurement discrepancy accounting using synthetic data, CBM+/digital-twin health-state logic, manufacturing digital-thread lineage, DDIL transport fault campaigns, DDIL partition/rejoin conflict handling, and host-specific edge-runtime benchmarking.
+
+Each domain retains its own claims boundary. Passing software tests do not establish Navy/DARPA/DoD acceptance, platform integration, hardware performance, material properties, RF performance, operational effectiveness, certification, clearance, CMMC status, NIST SP 800-171 conformity, or legal eligibility.
+
+## Evidence interpretation rule
+
+Use four separate questions:
+
+1. **Source fact:** Is an external requirement verified by an authoritative source?
+2. **Software behavior:** Did the bounded internal test execute and pass?
+3. **Physical/partner evidence:** Has representative hardware, operational data, a partner system, or a controlled lab test produced evidence?
+4. **External acceptance:** Has the relevant customer, assessor, regulator, lab, or certification authority accepted the evidence?
+
+A YES to one question never supplies YES to another.
+
+## CI contract
+
+The repository workflow installs the package, compiles Python, runs the complete pytest suite, invokes `pre_bloom_cli`, verifies required output files and the ECHO store, uploads the qualification artifact, validates Docker Compose configuration, launches the ephemeral service, and executes the deployment verifier. A branch is not internally release-ready while this gate is red.
+
+## Reproduction
+
+For meaningful comparison, preserve:
+
+- git commit SHA;
+- fixture digests;
+- exact output artifact;
+- Python/runtime environment identity;
+- execution timestamp and operator label;
+- CI run identifier where applicable.
+
+The compiler records the source commit and output digests. Current provenance is `INTERNAL_UNSIGNED`; external signing and independent reproduction remain separate future evidence gates.

--- a/deployments/sara_verified_local_v1/fixtures/ade_symbolic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/ade_symbolic_v1.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "WS-ADE-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic symbolic-regression benchmark only.",
+    "Does not establish state-of-the-art algorithm discovery, novelty, scientific discovery, or DARPA SPEED DIAL Direct-to-Phase-II eligibility."
+  ],
+  "problem": {
+    "name": "shifted_square",
+    "samples": [
+      [-3, 4],
+      [-2, 1],
+      [-1, 0],
+      [0, 1],
+      [1, 4],
+      [2, 9],
+      [3, 16]
+    ],
+    "baseline": "x",
+    "target_description": "Discover an interpretable expression matching y=(x+1)^2 without providing that expression to the search engine."
+  },
+  "search": {
+    "constants": [-2, -1, 0, 1, 2],
+    "max_depth": 2,
+    "beam_width": 256
+  },
+  "expected": {
+    "mse_max": 0.0,
+    "human_interpretable": true,
+    "must_improve_over_baseline": true
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/apnt_destroyer_strait_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/apnt_destroyer_strait_v1.json
@@ -1,0 +1,67 @@
+{
+  "fixture_id": "WS-APNT-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic scenario only.",
+    "Not derived from Navy platform data.",
+    "Does not validate GPNTS, ASPN, pntOS, sensor accuracy, shipboard integration, or operator performance."
+  ],
+  "scenario": {
+    "name": "surface_transit_gnss_degradation",
+    "description": "Synthetic surface-platform transit through a progressively degraded GNSS region with independent inertial and alternate-PNT-like sources.",
+    "operator_objective": "Maintain awareness of navigation confidence, understand degradation, and select a bounded recovery action."
+  },
+  "sources": [
+    {"source_id": "gnss_primary", "kind": "GNSS", "units": "normalized", "synthetic": true},
+    {"source_id": "ins_primary", "kind": "INS", "units": "normalized", "synthetic": true},
+    {"source_id": "alt_pnt_1", "kind": "ALTERNATE_PNT", "units": "normalized", "synthetic": true}
+  ],
+  "timeline": [
+    {
+      "t_seconds": 0,
+      "source_state": {
+        "gnss_primary": {"health": "NOMINAL", "confidence": 0.98},
+        "ins_primary": {"health": "NOMINAL", "confidence": 0.92},
+        "alt_pnt_1": {"health": "AVAILABLE", "confidence": 0.80}
+      },
+      "expected_operational_state": "NORMAL"
+    },
+    {
+      "t_seconds": 60,
+      "source_state": {
+        "gnss_primary": {"health": "DEGRADED", "confidence": 0.55, "indicator": "interference_suspected"},
+        "ins_primary": {"health": "NOMINAL", "confidence": 0.90},
+        "alt_pnt_1": {"health": "AVAILABLE", "confidence": 0.82}
+      },
+      "expected_operational_state": "DEGRADED_PNT",
+      "expected_recovery_options": ["weight_ins_more", "enable_alt_pnt_cross_check", "alert_operator"]
+    },
+    {
+      "t_seconds": 120,
+      "source_state": {
+        "gnss_primary": {"health": "UNTRUSTED", "confidence": 0.15, "indicator": "persistent_interference"},
+        "ins_primary": {"health": "DRIFT_RISK", "confidence": 0.72},
+        "alt_pnt_1": {"health": "AVAILABLE", "confidence": 0.84}
+      },
+      "expected_operational_state": "GNSS_DENIED",
+      "expected_recovery_options": ["exclude_gnss", "fuse_ins_alt_pnt", "request_operator_approval"]
+    },
+    {
+      "t_seconds": 240,
+      "source_state": {
+        "gnss_primary": {"health": "RECOVERING", "confidence": 0.60},
+        "ins_primary": {"health": "DRIFT_RISK", "confidence": 0.68},
+        "alt_pnt_1": {"health": "AVAILABLE", "confidence": 0.83}
+      },
+      "expected_operational_state": "RECOVERY",
+      "expected_recovery_options": ["cross_validate_gnss_before_reentry", "retain_alt_pnt", "operator_review"]
+    }
+  ],
+  "qualification_metrics": [
+    "source_lineage_complete",
+    "degradation_detected",
+    "confidence_state_reproducible",
+    "recovery_action_requires_policy_gate",
+    "mission_replay_complete"
+  ]
+}

--- a/deployments/sara_verified_local_v1/fixtures/cbm_twin_synthetic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/cbm_twin_synthetic_v1.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "WS-CBM-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic telemetry only.",
+    "No NAVAIR platform, real component, predictive-maintenance, remaining-useful-life, or fleet-effectiveness claim."
+  ],
+  "asset_id": "synthetic-pump-1",
+  "expected_envelopes": [
+    {"metric": "temperature_c", "minimum": 20.0, "maximum": 80.0, "units": "C"},
+    {"metric": "vibration_rms", "minimum": 0.0, "maximum": 4.0, "units": "mm/s"}
+  ],
+  "telemetry": [
+    {"sample_id": "T1", "asset_id": "synthetic-pump-1", "metric": "temperature_c", "value": 60.0, "t_seconds": 0.0, "source_ref": "synthetic://temp"},
+    {"sample_id": "T2", "asset_id": "synthetic-pump-1", "metric": "vibration_rms", "value": 2.0, "t_seconds": 0.0, "source_ref": "synthetic://vibration"},
+    {"sample_id": "T3", "asset_id": "synthetic-pump-1", "metric": "temperature_c", "value": 91.0, "t_seconds": 10.0, "source_ref": "synthetic://temp"},
+    {"sample_id": "T4", "asset_id": "synthetic-pump-1", "metric": "vibration_rms", "value": 5.0, "t_seconds": 10.0, "source_ref": "synthetic://vibration"}
+  ],
+  "expected": {
+    "finding_statuses": ["NOMINAL", "NOMINAL", "HIGH", "HIGH"],
+    "anomaly_count": 2,
+    "all_findings_traceable": true
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/ietm_synthetic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/ietm_synthetic_v1.json
@@ -1,0 +1,39 @@
+{
+  "fixture_id": "WS-IETM-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic technical-data fixture only.",
+    "Distribution marking is fictitious test data.",
+    "Does not establish S1000D, MIL-STD-3001-1, MIL-DTL-81310, Navy viewer, or production conversion compliance."
+  ],
+  "manual": {
+    "manual_id": "SYN-TM-001",
+    "title": "Synthetic Cooling Pump Inspection",
+    "distribution_marking": "SYNTHETIC DISTRIBUTION MARKING - TEST ONLY",
+    "revision": "A",
+    "sections": [
+      {
+        "section_id": "1",
+        "title": "Safety",
+        "steps": [
+          {"step_id": "1.1", "text": "Verify test power is isolated."},
+          {"step_id": "1.2", "text": "Confirm synthetic pressure indicator reads zero."}
+        ]
+      },
+      {
+        "section_id": "2",
+        "title": "Inspection",
+        "steps": [
+          {"step_id": "2.1", "text": "Inspect the synthetic pump housing for visible damage."},
+          {"step_id": "2.2", "text": "Record the synthetic inspection result."}
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "section_count": 2,
+    "step_count": 4,
+    "marking_preserved": true,
+    "manual_id_preserved": true
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/manufacturing_thread_synthetic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/manufacturing_thread_synthetic_v1.json
@@ -1,0 +1,49 @@
+{
+  "fixture_id": "WS-MFG-THREAD-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic manufacturing lineage only.",
+    "No physical coupon, alloy property, process qualification, machine calibration, or production acceptance claim."
+  ],
+  "thread": {
+    "thread_id": "THREAD-001",
+    "material_lots": [
+      {"lot_id": "LOT-1", "material_designation": "Synthetic Al-Ti-Mg-Sc-Zr research lot", "supplier": "SYNTHETIC"}
+    ],
+    "process_configurations": [
+      {
+        "configuration_id": "CFG-1",
+        "process_family": "DED_SYNTHETIC",
+        "machine_id": "SIMULATED-MACHINE",
+        "software_version": "synthetic-1",
+        "parameters": {"laser_power_w": 500, "travel_speed_mm_s": 10}
+      }
+    ],
+    "build_steps": [
+      {
+        "step_id": "STEP-1",
+        "material_lot_ids": ["LOT-1"],
+        "configuration_id": "CFG-1",
+        "operator": "synthetic-operator",
+        "telemetry_artifact_digests": ["sha256:synthetic-telemetry-placeholder"]
+      }
+    ],
+    "specimens": [
+      {
+        "specimen_id": "COUPON-1",
+        "build_step_ids": ["STEP-1"],
+        "geometry_ref": "synthetic://coupon-geometry",
+        "measurement_artifact_digests": [],
+        "physical_validation_performed": false
+      }
+    ],
+    "claims_boundary": ["Digital thread only; no physical property claim"]
+  },
+  "expected": {
+    "qualification_state": "DIGITAL_THREAD_ONLY",
+    "material_lot_count": 1,
+    "process_configuration_count": 1,
+    "build_step_count": 1,
+    "specimen_count": 1
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/mbse_legacy_fixture_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/mbse_legacy_fixture_v1.json
@@ -1,0 +1,67 @@
+{
+  "fixture_id": "WS-MBSE-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic legacy-system corpus with known ground truth.",
+    "Not derived from AEGIS or other Navy technical data.",
+    "Does not establish Cameo/MagicDraw interoperability or production SysML reconstruction accuracy."
+  ],
+  "ground_truth": {
+    "nodes": [
+      {"id": "power_bus", "type": "subsystem", "name": "Power Distribution"},
+      {"id": "sensor_a", "type": "sensor", "name": "Sensor A"},
+      {"id": "processor_a", "type": "compute", "name": "Mission Processor"},
+      {"id": "display_a", "type": "hmi", "name": "Operator Display"},
+      {"id": "service_track", "type": "software_service", "name": "Track Service"}
+    ],
+    "edges": [
+      {"source": "power_bus", "target": "sensor_a", "relation": "powers"},
+      {"source": "power_bus", "target": "processor_a", "relation": "powers"},
+      {"source": "sensor_a", "target": "processor_a", "relation": "ethernet_data"},
+      {"source": "processor_a", "target": "service_track", "relation": "hosts"},
+      {"source": "service_track", "target": "display_a", "relation": "publishes_track_data"}
+    ]
+  },
+  "legacy_artifacts": [
+    {
+      "artifact_id": "doc-001",
+      "kind": "technical_manual_excerpt",
+      "content": "Sensor A receives 28 VDC from the Power Distribution subsystem and forwards observation messages to the Mission Processor over Ethernet.",
+      "expected_support": ["power_bus->sensor_a:powers", "sensor_a->processor_a:ethernet_data"]
+    },
+    {
+      "artifact_id": "bom-001",
+      "kind": "hardware_bom",
+      "rows": [
+        {"item": "Sensor A", "part": "SYN-SA-001"},
+        {"item": "Mission Processor", "part": "SYN-MP-001"},
+        {"item": "Operator Display", "part": "SYN-DIS-001"}
+      ]
+    },
+    {
+      "artifact_id": "net-001",
+      "kind": "network_configuration",
+      "rows": [
+        {"host": "Mission Processor", "service": "Track Service", "protocol": "TCP", "port": 4500},
+        {"consumer": "Operator Display", "service": "Track Service"}
+      ],
+      "expected_support": ["processor_a->service_track:hosts", "service_track->display_a:publishes_track_data"]
+    },
+    {
+      "artifact_id": "cable-001",
+      "kind": "cable_record",
+      "rows": [
+        {"from": "Power Distribution", "to": "Mission Processor", "purpose": "28 VDC"}
+      ],
+      "expected_support": ["power_bus->processor_a:powers"]
+    }
+  ],
+  "scoring": {
+    "entity_precision_target": 0.95,
+    "entity_recall_target": 0.95,
+    "relationship_precision_target": 0.90,
+    "relationship_recall_target": 0.90,
+    "unsupported_inference_target": 0.0,
+    "notes": "Internal synthetic benchmark targets only; not government performance claims."
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/mission_replay_synthetic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/mission_replay_synthetic_v1.json
@@ -1,0 +1,23 @@
+{
+  "fixture_id": "WS-MISSION-REPLAY-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic mission-event fixture only.",
+    "Does not represent CCA, Navy, operational UAS, or classified mission data.",
+    "Follow-on actions are proposals requiring identified human authorization."
+  ],
+  "events": [
+    {"sequence": 1, "t_seconds": 0, "source": "mission_manager", "event_type": "mission_start", "payload": {}},
+    {"sequence": 2, "t_seconds": 10, "source": "comms", "event_type": "comms_degraded", "payload": {"packet_loss_fraction": 0.45}},
+    {"sequence": 3, "t_seconds": 20, "source": "sensor_a", "event_type": "sensor_stale", "payload": {"age_seconds": 12}},
+    {"sequence": 4, "t_seconds": 30, "source": "task_manager", "event_type": "task_failed", "payload": {"task_id": "survey-2", "reason": "insufficient_fresh_data"}},
+    {"sequence": 5, "t_seconds": 40, "source": "operator", "event_type": "operator_override", "payload": {"action": "hold_position"}},
+    {"sequence": 6, "t_seconds": 50, "source": "comms", "event_type": "comms_restored", "payload": {}},
+    {"sequence": 7, "t_seconds": 60, "source": "mission_manager", "event_type": "mission_complete", "payload": {"status": "partial_success"}}
+  ],
+  "expected": {
+    "finding_types": ["communications_degradation", "stale_sensor_dependency", "task_failure"],
+    "proposal_actions": ["validate_alternate_comms_path", "tighten_stale_data_gate", "review_task_reassignment_policy"],
+    "all_proposals_must_start_proposed": true
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/rf_sparams_synthetic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/rf_sparams_synthetic_v1.json
@@ -1,0 +1,19 @@
+{
+  "fixture_id": "WS-RF-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic S11-like values only.",
+    "No VNA, anechoic chamber, fabricated metasurface, RF power handling, radiation pattern, or physical material validation is represented."
+  ],
+  "points": [
+    {"frequency_ghz": 8.0, "predicted_s11_db": -8.0, "measured_s11_db": -7.7, "measurement_uncertainty_db": 0.5},
+    {"frequency_ghz": 9.0, "predicted_s11_db": -12.0, "measured_s11_db": -11.6, "measurement_uncertainty_db": 0.5},
+    {"frequency_ghz": 10.0, "predicted_s11_db": -18.0, "measured_s11_db": -17.5, "measurement_uncertainty_db": 0.6},
+    {"frequency_ghz": 11.0, "predicted_s11_db": -11.0, "measured_s11_db": -10.8, "measurement_uncertainty_db": 0.5},
+    {"frequency_ghz": 12.0, "predicted_s11_db": -7.0, "measured_s11_db": -6.6, "measurement_uncertainty_db": 0.5}
+  ],
+  "expected": {
+    "max_absolute_error_db": 0.6,
+    "minimum_within_uncertainty_fraction": 0.8
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/sensor_fusion_synthetic_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/sensor_fusion_synthetic_v1.json
@@ -1,0 +1,28 @@
+{
+  "fixture_id": "WS-FUSION-SYNTH-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic 2-D point observations only.",
+    "Does not represent AESA, EO/IR, NAVAIR, classified sensor data, or operational track performance.",
+    "Benchmark validates only the bounded deterministic association/fusion implementation."
+  ],
+  "truth": [
+    {"track_id": "T1", "t_seconds": 10.0, "x": 100.0, "y": 50.0},
+    {"track_id": "T2", "t_seconds": 10.0, "x": -40.0, "y": 80.0}
+  ],
+  "observations": [
+    {"observation_id": "A1", "sensor_id": "sensor_a", "t_seconds": 10.0, "x": 101.0, "y": 49.5, "confidence": 0.90},
+    {"observation_id": "B1", "sensor_id": "sensor_b", "t_seconds": 10.1, "x": 99.0, "y": 50.5, "confidence": 0.80},
+    {"observation_id": "A2", "sensor_id": "sensor_a", "t_seconds": 10.0, "x": -39.5, "y": 79.0, "confidence": 0.85},
+    {"observation_id": "B2", "sensor_id": "sensor_b", "t_seconds": 9.9, "x": -40.5, "y": 81.0, "confidence": 0.75}
+  ],
+  "association": {
+    "max_spatial_distance": 5.0,
+    "max_time_delta_seconds": 0.5
+  },
+  "expected": {
+    "fused_track_count": 2,
+    "max_position_error": 1.0,
+    "all_source_observations_preserved": true
+  }
+}

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "worldshepherd-sara"
 version = "0.1.0"
-description = "Evidence-governed local administration and relay service for Worldshepherd SARA"
+description = "Evidence-governed local administration, relay, and PRE qualification service for Worldshepherd SARA"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
@@ -19,6 +19,9 @@ test = [
   "pytest>=8,<9",
   "httpx>=0.27,<1",
 ]
+
+[project.scripts]
+ws-pre-bloom = "worldshepherd_sara.pre_bloom_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -20,6 +20,9 @@ test = [
   "httpx>=0.27,<1",
 ]
 
+[tool.setuptools]
+packages = ["worldshepherd_sara"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"

--- a/deployments/sara_verified_local_v1/tests/test_ade.py
+++ b/deployments/sara_verified_local_v1/tests/test_ade.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.ade import discover_expression
+from worldshepherd_sara.ade_qualification import qualify_synthetic_discovery
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0012",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="DARPA SPEED DIAL algorithm-discovery readiness target",
+            agency="DARPA",
+            url="https://www.darpa.mil/research/programs/speed-dial",
+            solicitation_or_topic="DPA26TZ05-DV003",
+            source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Develop bounded automated discovery evidence without overstating D2P2/SOTA maturity.",
+        recurrence="SPEED DIAL and predictive algorithm-discovery readiness",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["ADE-G", "AI governance", "digital engineering"],
+        existing_capability=["bounded symbolic search kernel"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["SOTA benchmark", "real engineering workflow integration", "D2P2 prior evidence"],
+        claims_boundary=["Synthetic discovery benchmark only; not SPEED DIAL D2P2 eligibility"],
+    )
+
+
+def test_ade_discovers_zero_error_interpretable_rule_deterministically():
+    fixture = json.loads((ROOT / "fixtures" / "ade_symbolic_v1.json").read_text())
+    kwargs = {
+        "constants": tuple(fixture["search"]["constants"]),
+        "max_depth": fixture["search"]["max_depth"],
+        "beam_width": fixture["search"]["beam_width"],
+    }
+    first = discover_expression(fixture["problem"]["samples"], **kwargs)
+    second = discover_expression(fixture["problem"]["samples"], **kwargs)
+    assert first.mse == 0.0
+    assert first.mse < first.baseline_mse
+    assert first.human_interpretable is True
+    assert first.expression.canonical() == second.expression.canonical()
+    assert first.evaluated_candidates == second.evaluated_candidates
+
+
+def test_ade_qualification_is_claims_bounded_and_reproducible():
+    fixture = json.loads((ROOT / "fixtures" / "ade_symbolic_v1.json").read_text())
+    first = qualify_synthetic_discovery(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    second = qualify_synthetic_discovery(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert first["evidence"][0]["result"] == "PASS"
+    assert first["bundle_digest"] == second["bundle_digest"]
+    assert "no SOTA" in first["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_apnt.py
+++ b/deployments/sara_verified_local_v1/tests/test_apnt.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.apnt import apnt_snapshot_graph, derive_apnt_decision
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "apnt_destroyer_strait_v1.json"
+)
+
+
+def test_synthetic_apnt_fixture_matches_expected_states_and_recovery_options():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    for item in payload["timeline"]:
+        decision = derive_apnt_decision(item["source_state"])
+        assert decision.operational_state == item["expected_operational_state"]
+        if "expected_recovery_options" in item:
+            assert set(decision.recovery_options) == set(item["expected_recovery_options"])
+
+
+def test_apnt_graph_preserves_all_sources_and_derived_state():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    item = payload["timeline"][2]
+    decision = derive_apnt_decision(item["source_state"])
+    graph = apnt_snapshot_graph(
+        graph_id="apnt-fixture-t120",
+        source_state=item["source_state"],
+        decision=decision,
+    )
+
+    node_ids = {node.node_id for node in graph.nodes}
+    assert {
+        "source:gnss_primary",
+        "source:ins_primary",
+        "source:alt_pnt_1",
+        "derived:operational_state",
+        "policy:recovery_options",
+    }.issubset(node_ids)
+    assert len(graph.edges) == 4

--- a/deployments/sara_verified_local_v1/tests/test_apnt_interface_contract.py
+++ b/deployments/sara_verified_local_v1/tests/test_apnt_interface_contract.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.apnt_interface_contract import (
+    AuthoritativeInterfaceContract,
+    ContractPntAdapter,
+)
+
+SPEC_DIGEST = "sha256:" + "a" * 64
+
+
+def test_apnt_contract_cannot_enable_without_required_mapping_and_validation():
+    with pytest.raises(ValueError):
+        AuthoritativeInterfaceContract(
+            contract_id="ASPN-TEST",
+            interface_name="Authoritative test interface",
+            version="1",
+            authoritative_spec_ref="spec://authoritative-test",
+            authoritative_spec_digest=SPEC_DIGEST,
+            field_mapping={"source_id": "id"},
+            validated_fields=["source_id"],
+            enabled=True,
+        )
+
+
+def test_contract_adapter_normalizes_only_after_explicit_contract_enablement():
+    contract = AuthoritativeInterfaceContract(
+        contract_id="ASPN-TEST",
+        interface_name="Authoritative test interface",
+        version="1",
+        authoritative_spec_ref="spec://authoritative-test",
+        authoritative_spec_digest=SPEC_DIGEST,
+        field_mapping={
+            "source_id": "id",
+            "source_kind": "kind",
+            "health": "status",
+            "confidence": "confidence_value",
+            "observed_utc": "timestamp",
+        },
+        validated_fields=["source_id", "source_kind", "health", "confidence", "observed_utc"],
+        enabled=True,
+    )
+    normalized = ContractPntAdapter(contract).normalize(
+        {"id": "source-1", "kind": "GNSS", "status": "NOMINAL", "confidence_value": 0.9, "timestamp": "2026-08-26T00:00:00Z"}
+    )
+    assert normalized.source_id == "source-1"
+    assert normalized.attributes["contract_id"] == "ASPN-TEST"
+    assert normalized.attributes["contract_digest"].startswith("sha256:")
+
+
+def test_disabled_contract_fails_closed():
+    contract = AuthoritativeInterfaceContract(
+        contract_id="DISABLED",
+        interface_name="Disabled interface",
+        version="1",
+        authoritative_spec_ref="spec://disabled",
+        authoritative_spec_digest=SPEC_DIGEST,
+    )
+    with pytest.raises(ValueError):
+        ContractPntAdapter(contract)

--- a/deployments/sara_verified_local_v1/tests/test_autonomy_policy.py
+++ b/deployments/sara_verified_local_v1/tests/test_autonomy_policy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from worldshepherd_sara.autonomy_policy import (
+    AutonomousActionCandidate,
+    AutonomyPolicy,
+    ExecutionDisposition,
+    evaluate_candidate,
+)
+
+
+def test_low_risk_reversible_allowlisted_action_can_be_auto_eligible():
+    policy = AutonomyPolicy(
+        policy_id="POL-1",
+        allowed_auto_action_types=["refresh_cache"],
+        denied_action_types=["release_payload"],
+        minimum_auto_confidence=0.99,
+        maximum_auto_authority=1,
+    )
+    candidate = AutonomousActionCandidate(action_id="A1", action_type="refresh_cache", confidence=1.0, requested_authority=1, reversible=True)
+    disposition, reasons = evaluate_candidate(candidate, policy)
+    assert disposition == ExecutionDisposition.AUTO_ELIGIBLE
+    assert reasons
+
+
+def test_non_allowlisted_or_high_authority_action_requires_human_review():
+    policy = AutonomyPolicy(policy_id="POL-1", allowed_auto_action_types=["refresh_cache"], minimum_auto_confidence=0.9, maximum_auto_authority=1)
+    candidate = AutonomousActionCandidate(action_id="A2", action_type="reroute_vehicle", confidence=0.95, requested_authority=2, reversible=True)
+    disposition, reasons = evaluate_candidate(candidate, policy)
+    assert disposition == ExecutionDisposition.HUMAN_REVIEW_REQUIRED
+    assert any("allowlist" in reason for reason in reasons)
+    assert any("authority" in reason for reason in reasons)
+
+
+def test_explicitly_denied_action_fails_closed():
+    policy = AutonomyPolicy(policy_id="POL-1", denied_action_types=["release_payload"])
+    candidate = AutonomousActionCandidate(action_id="A3", action_type="release_payload", confidence=1.0, requested_authority=0, reversible=True)
+    disposition, _ = evaluate_candidate(candidate, policy)
+    assert disposition == ExecutionDisposition.DENIED

--- a/deployments/sara_verified_local_v1/tests/test_bloom_stage2.py
+++ b/deployments/sara_verified_local_v1/tests/test_bloom_stage2.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worldshepherd_sara.compliance import (
+    ComplianceReadinessProfile,
+    ControlEvidence,
+    ControlEvidenceState,
+)
+from worldshepherd_sara.evidence_artifacts import (
+    ArtifactRole,
+    ComparisonOperator,
+    ExpectedResult,
+    QualificationTestDefinition,
+    artifact_from_bytes,
+    required_roles_present,
+    verify_artifact,
+)
+from worldshepherd_sara.mbse_extract import candidate_graph, extract_candidate_relations
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_artifact_hash_contract_detects_tampering_and_required_roles():
+    artifact = artifact_from_bytes(
+        artifact_id="input-1",
+        role=ArtifactRole.INPUT,
+        data=b"known fixture",
+        media_type="text/plain",
+        locator="fixture://input-1",
+    )
+    definition = QualificationTestDefinition(
+        test_id="T-001",
+        requirement_id="PRE-RD-2026-0001",
+        description="bounded deterministic test",
+        expected_results=[
+            ExpectedResult(metric="state_match", operator=ComparisonOperator.EQ, target=1)
+        ],
+        required_artifact_roles=[ArtifactRole.INPUT],
+    )
+    assert verify_artifact(b"known fixture", artifact) is True
+    assert verify_artifact(b"tampered fixture", artifact) is False
+    assert required_roles_present(definition, [artifact]) is True
+
+
+def test_compliance_readiness_defaults_fail_closed_and_present_requires_evidence():
+    profile = ComplianceReadinessProfile(
+        framework="NIST SP 800-171",
+        controls=[
+            ControlEvidence(control_id="AC.L1-3.1.1"),
+            ControlEvidence(control_id="AU-example", state=ControlEvidenceState.GAP),
+        ],
+    )
+    assert profile.externally_validated() is False
+    assert profile.gap_summary()["UNKNOWN"] == 1
+    assert "No CMMC/NIST 800-171 compliance" in profile.claims_boundary()
+    with pytest.raises(ValueError):
+        ControlEvidence(control_id="bad", state=ControlEvidenceState.PRESENT)
+
+
+def test_synthetic_mbse_extractor_recovers_only_explicit_fixture_relations():
+    fixture = json.loads((ROOT / "fixtures" / "mbse_legacy_fixture_v1.json").read_text())
+    relations = extract_candidate_relations(fixture["legacy_artifacts"])
+    canonical = {item.canonical for item in relations}
+    expected = {
+        "Power Distribution->Sensor A:powers",
+        "Sensor A->Mission Processor:ethernet_data",
+        "Mission Processor->Track Service:hosts",
+        "Track Service->Operator Display:publishes_track_data",
+        "Power Distribution->Mission Processor:powers",
+    }
+    assert canonical == expected
+    graph = candidate_graph("synthetic-mbse-extract-v1", relations)
+    assert len(graph.edges) == 5
+    assert all(edge.source_ref and edge.source_ref.startswith("artifact:") for edge in graph.edges)
+    assert all(edge.confidence is not None for edge in graph.edges)

--- a/deployments/sara_verified_local_v1/tests/test_bloom_stage3.py
+++ b/deployments/sara_verified_local_v1/tests/test_bloom_stage3.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from worldshepherd_sara.ddil import Envelope
+from worldshepherd_sara.ddil_campaign import run_ddil_campaign
+from worldshepherd_sara.evidence_artifacts import ComparisonOperator, ExpectedResult
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+    canonical_digest,
+)
+from worldshepherd_sara.qualification_eval import evaluate_all_expected_results
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0099",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="Synthetic DDIL qualification requirement",
+            agency="Worldshepherd internal test",
+            url="internal://pre/ddil-v1",
+            source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Exercise deterministic degraded-message handling before external validation.",
+        recurrence="Reusable readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["DDIL", "mission assurance"],
+        existing_capability=["synthetic transport-fault harness"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["real tactical-network validation"],
+        claims_boundary=["No RF or operational DDIL claim"],
+    )
+
+
+def test_expected_result_evaluator_is_explicit_and_fail_closed_on_missing_metric():
+    expected = [
+        ExpectedResult(metric="latency_ms", operator=ComparisonOperator.LE, target=100),
+        ExpectedResult(metric="passed", operator=ComparisonOperator.EQ, target=True),
+    ]
+    ok, outcomes = evaluate_all_expected_results(
+        expected, {"latency_ms": 90, "passed": True}
+    )
+    assert ok is True
+    assert outcomes == {"latency_ms": True, "passed": True}
+    missing_ok, missing = evaluate_all_expected_results(expected, {"latency_ms": 90})
+    assert missing_ok is False
+    assert missing["passed"] is False
+
+
+def test_ddil_campaign_is_replayable_and_claims_bounded():
+    messages = [
+        Envelope(sequence=i, source="sim-node", payload={"value": i}, timestamp_ms=i * 100)
+        for i in range(1, 7)
+    ]
+    first = run_ddil_campaign(
+        messages=messages,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    second = run_ddil_campaign(
+        messages=messages,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert first["campaign"] == "DDIL_SYNTHETIC_V1"
+    assert len(first["evidence"]) == 5
+    assert all(item["result"] == "PASS" for item in first["evidence"])
+    assert first["bundle_digest"] == second["bundle_digest"]
+    without_digest = dict(first)
+    digest = without_digest.pop("bundle_digest")
+    assert digest == canonical_digest(without_digest)
+    assert "no RF" in first["scope_note"].lower()

--- a/deployments/sara_verified_local_v1/tests/test_bloom_stage3.py
+++ b/deployments/sara_verified_local_v1/tests/test_bloom_stage3.py
@@ -78,4 +78,4 @@ def test_ddil_campaign_is_replayable_and_claims_bounded():
     without_digest = dict(first)
     digest = without_digest.pop("bundle_digest")
     assert digest == canonical_digest(without_digest)
-    assert "no RF" in first["scope_note"].lower()
+    assert "no rf" in first["scope_note"].lower()

--- a/deployments/sara_verified_local_v1/tests/test_cbm_qualification.py
+++ b/deployments/sara_verified_local_v1/tests/test_cbm_qualification.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.cbm_qualification import qualify_synthetic_cbm
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0016",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(title="CBM+ / digital-twin readiness target", agency="Worldshepherd PRE", url="internal://pre/cbm-v1", source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, retrieved_utc="2026-08-26T00:00:00Z"),
+        statement="Establish traceable synthetic health-state classification before predictive-maintenance claims.",
+        recurrence="Reusable CBM+/digital-twin readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["CBM+","digital twins","ECHO","maintenance"],
+        existing_capability=["bounded envelope-based health classification"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["real asset telemetry","failure labels","RUL validation"],
+        claims_boundary=["Synthetic telemetry only"],
+    )
+
+
+def test_cbm_qualification_bundle_is_traceable_and_claims_bounded():
+    fixture = json.loads((ROOT / "fixtures" / "cbm_twin_synthetic_v1.json").read_text())
+    bundle = qualify_synthetic_cbm(fixture=fixture, requirement=_requirement(), software_commit="test-commit", executed_utc="2026-08-26T00:00:00Z", operator="pytest")
+    assert bundle["evidence"][0]["result"] == "PASS"
+    assert bundle["evidence"][0]["outputs"][0]["anomaly_count"] == 2
+    assert bundle["evidence"][0]["outputs"][0]["traceable"] is True
+    assert "no real platform" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_cbm_twin.py
+++ b/deployments/sara_verified_local_v1/tests/test_cbm_twin.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from worldshepherd_sara.cbm_twin import (
+    ExpectedEnvelope,
+    TelemetrySample,
+    evaluate_series,
+    health_graph,
+)
+
+
+def test_cbm_twin_flags_only_envelope_deviation_and_preserves_source_lineage():
+    envelopes = {
+        "temperature_c": ExpectedEnvelope(metric="temperature_c", minimum=20.0, maximum=80.0, units="C")
+    }
+    samples = [
+        TelemetrySample(sample_id="S1", asset_id="pump-1", metric="temperature_c", value=60.0, t_seconds=0, source_ref="sensor://temp-1"),
+        TelemetrySample(sample_id="S2", asset_id="pump-1", metric="temperature_c", value=90.0, t_seconds=10, source_ref="sensor://temp-1"),
+    ]
+    findings = evaluate_series(samples, envelopes)
+    assert [finding.status for finding in findings] == ["NOMINAL", "HIGH"]
+    assert findings[1].deviation == 10.0
+    graph = health_graph(graph_id="CBM-SYNTH-1", samples=samples, findings=findings)
+    assert {edge.relation for edge in graph.edges} == {"supports_health_finding"}
+    assert any(node.source_ref == "sensor://temp-1" for node in graph.nodes)

--- a/deployments/sara_verified_local_v1/tests/test_codex_bloom.py
+++ b/deployments/sara_verified_local_v1/tests/test_codex_bloom.py
@@ -152,3 +152,5 @@ def test_apnt_timeline_compiles_claims_bounded_qualification_bundle():
     assert all(item["result"] == "PASS" for item in bundle["evidence"])
     assert all(item["evidence_scope"] == "SOFTWARE" for item in bundle["evidence"])
     assert bundle["scope_note"].startswith("Synthetic software qualification")
+    assert bundle["prime_action_proposals"]
+    assert all(item["state"] == "PROPOSED" for item in bundle["prime_action_proposals"])

--- a/deployments/sara_verified_local_v1/tests/test_codex_bloom.py
+++ b/deployments/sara_verified_local_v1/tests/test_codex_bloom.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worldshepherd_sara.apnt_adapter import AspnMappingStub, SyntheticPntAdapter
+from worldshepherd_sara.apnt_qualification import qualify_synthetic_apnt_timeline
+from worldshepherd_sara.common_services import AdapterManifest, MissionEnclaveRegistry, ServiceManifest
+from worldshepherd_sara.ddil import Envelope, FaultProfile, apply_fault_profile
+from worldshepherd_sara.legacy_normalization import normalize_legacy_corpus
+from worldshepherd_sara.prime import ActionProposal, ActionState, decide_action, revoke_action
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ddil_fault_profile_is_deterministic_and_preserves_fault_evidence():
+    messages = [
+        Envelope(sequence=i, source="sensor", payload={"value": i}, timestamp_ms=i * 10)
+        for i in range(1, 6)
+    ]
+    profile = FaultProfile(
+        drop_sequences=frozenset({2}),
+        duplicate_sequences=frozenset({3}),
+        stale_sequences=frozenset({4}),
+        added_latency_ms=25,
+        reorder_windows=((3, 5),),
+    )
+    first = apply_fault_profile(messages, profile)
+    second = apply_fault_profile(messages, profile)
+    assert first.replay_signature() == second.replay_signature()
+    assert first.dropped == [2]
+    assert first.duplicated == [3]
+    assert first.stale == [4]
+    assert any(item.payload.get("_ws_stale") for item in first.delivered)
+
+
+def test_apnt_adapter_boundary_fails_closed_for_unimplemented_aspn_mapping():
+    synthetic = SyntheticPntAdapter().normalize(
+        {
+            "source_id": "gnss_primary",
+            "source_kind": "GNSS",
+            "health": "DEGRADED",
+            "confidence": 0.5,
+        }
+    )
+    assert synthetic.source_id == "gnss_primary"
+    with pytest.raises(NotImplementedError):
+        AspnMappingStub().normalize({})
+
+
+def test_prime_action_gate_requires_identified_human_decision_and_supports_revocation():
+    proposal = ActionProposal(
+        proposal_id="APNT-RECOVERY-001",
+        action="exclude_gnss",
+        rationale=["primary GNSS is untrusted"],
+        authority_required="CRE1AWS",
+    )
+    approved = decide_action(
+        proposal,
+        reviewer="identified-human-reviewer",
+        state=ActionState.APPROVED,
+        reason="synthetic exercise approval",
+    )
+    assert approved.state == ActionState.APPROVED
+    revoked = revoke_action(
+        approved,
+        reviewer="identified-human-reviewer",
+        reason="exercise reset",
+    )
+    assert revoked.state == ActionState.REVOKED
+
+
+def test_legacy_normalization_preserves_source_identity_without_semantic_inference():
+    fixture = json.loads((ROOT / "fixtures" / "mbse_legacy_fixture_v1.json").read_text())
+    normalized = normalize_legacy_corpus(fixture["legacy_artifacts"])
+    assert len(normalized) == len(fixture["legacy_artifacts"])
+    assert {item.source_ref for item in normalized} == {
+        f"artifact:{artifact['artifact_id']}" for artifact in fixture["legacy_artifacts"]
+    }
+    assert all(item.records for item in normalized)
+
+
+def test_mission_enclave_registry_versions_and_rolls_back_services():
+    registry = MissionEnclaveRegistry()
+    v1 = ServiceManifest(
+        service_id="echo-provenance",
+        version="1.0.0",
+        interface_version="1",
+        software_digest="sha256:v1",
+        required_authority="SSPADAWANZZ",
+    )
+    v2 = v1.model_copy(update={"version": "1.1.0", "software_digest": "sha256:v2"})
+    registry.register_service(v1)
+    registry.register_service(v2)
+    registry.register_adapter(
+        AdapterManifest(
+            adapter_id="synthetic-apnt",
+            platform_family="synthetic",
+            interface_version="1",
+            software_digest="sha256:adapter",
+        )
+    )
+    assert registry.service("echo-provenance").version == "1.1.0"
+    assert registry.rollback_service("echo-provenance").version == "1.0.0"
+    assert registry.adapter("synthetic-apnt").validation_state == "UNVALIDATED"
+
+
+def test_apnt_timeline_compiles_claims_bounded_qualification_bundle():
+    fixture = json.loads((ROOT / "fixtures" / "apnt_destroyer_strait_v1.json").read_text())
+    requirement = RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0001",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="NAVWAR APNT synthetic qualification target",
+            agency="NAVWAR",
+            url="https://example.invalid/authoritative-source-placeholder",
+            solicitation_or_topic="DON26BX05-NP004",
+            source_status=SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Demonstrate bounded APNT operational-awareness behavior using representative synthetic data.",
+        recurrence="Release-5 capture requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["APNT", "C2", "mission assurance"],
+        existing_capability=["bounded software awareness model"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["ASPN/pntOS validation", "Navy operator validation"],
+        experiment_or_demonstration_needed=["frozen synthetic scenario"],
+        evidence_target=["replayable state/recovery evidence"],
+        claims_boundary=["No physical APNT or Navy operational-performance claim"],
+    )
+    bundle = qualify_synthetic_apnt_timeline(
+        fixture=fixture,
+        requirement=requirement,
+        software_commit="synthetic-test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert bundle["capture_ready_source"] is True
+    assert bundle["fixture_id"] == "WS-APNT-SYNTH-001"
+    assert len(bundle["evidence"]) == len(fixture["timeline"])
+    assert all(item["result"] == "PASS" for item in bundle["evidence"])
+    assert all(item["evidence_scope"] == "SOFTWARE" for item in bundle["evidence"])
+    assert bundle["scope_note"].startswith("Synthetic software qualification")

--- a/deployments/sara_verified_local_v1/tests/test_common_services_persistent.py
+++ b/deployments/sara_verified_local_v1/tests/test_common_services_persistent.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from worldshepherd_sara.common_services import AdapterManifest, ServiceManifest
+from worldshepherd_sara.common_services_persistent import PersistentMissionEnclaveRegistry
+from worldshepherd_sara.storage import DurableStore
+
+
+def test_common_services_registry_survives_reopen_and_emits_audit(tmp_path):
+    store = DurableStore(tmp_path / "data")
+    registry = PersistentMissionEnclaveRegistry(store)
+    v1 = ServiceManifest(
+        service_id="echo-provenance",
+        version="1.0.0",
+        interface_version="1",
+        software_digest="sha256:v1",
+        sbom_digest="sha256:sbom1",
+        required_authority="SSPADAWANZZ",
+    )
+    registry.register_service(v1)
+    registry.register_adapter(
+        AdapterManifest(
+            adapter_id="synthetic-apnt",
+            platform_family="synthetic",
+            interface_version="1",
+            software_digest="sha256:adapter",
+        )
+    )
+
+    reopened = PersistentMissionEnclaveRegistry(DurableStore(tmp_path / "data"))
+    assert reopened.service("echo-provenance").version == "1.0.0"
+    assert reopened.adapter("synthetic-apnt").adapter_id == "synthetic-apnt"
+    events = [item.get("event") for item in reopened.store.read_audit(20)]
+    assert "common_service_registered" in events
+    assert "common_adapter_registered" in events
+
+
+def test_persistent_service_registry_supports_version_history_and_rollback(tmp_path):
+    registry = PersistentMissionEnclaveRegistry(DurableStore(tmp_path / "data"))
+    v1 = ServiceManifest(service_id="prime", version="1.0.0", interface_version="1", software_digest="sha256:v1", required_authority="CRE1AWS")
+    v2 = v1.model_copy(update={"version":"1.1.0","software_digest":"sha256:v2"})
+    registry.register_service(v1)
+    registry.register_service(v2)
+    assert registry.service("prime").version == "1.1.0"
+    rolled_back = registry.rollback_service("prime")
+    assert rolled_back.version == "1.0.0"
+    assert registry.service("prime").version == "1.0.0"

--- a/deployments/sara_verified_local_v1/tests/test_config_custody.py
+++ b/deployments/sara_verified_local_v1/tests/test_config_custody.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.config_custody import ConfigurationCustodyLedger, create_snapshot
+
+
+def test_configuration_custody_chains_snapshots_and_verifies_lineage():
+    ledger = ConfigurationCustodyLedger()
+    first = create_snapshot(snapshot_id="CFG-001", payload={"mode":"safe"}, created_utc="2026-08-26T00:00:00Z", actor="operator", reason="initial")
+    ledger.append(first)
+    second = create_snapshot(snapshot_id="CFG-002", payload={"mode":"mission"}, created_utc="2026-08-26T00:10:00Z", actor="operator", reason="approved mission config", parent_digest=first.digest)
+    ledger.append(second)
+    assert ledger.head() == second
+    assert ledger.verify_chain() is True
+
+
+def test_configuration_rollback_is_new_append_only_snapshot_not_history_rewrite():
+    ledger = ConfigurationCustodyLedger()
+    first = create_snapshot(snapshot_id="CFG-001", payload={"threshold":1}, created_utc="2026-08-26T00:00:00Z", actor="operator", reason="initial")
+    ledger.append(first)
+    second = create_snapshot(snapshot_id="CFG-002", payload={"threshold":2}, created_utc="2026-08-26T00:10:00Z", actor="operator", reason="change", parent_digest=first.digest)
+    ledger.append(second)
+    rollback = ledger.rollback_snapshot(target_digest=first.digest, snapshot_id="CFG-003", created_utc="2026-08-26T00:20:00Z", actor="operator", reason="rollback")
+    ledger.append(rollback)
+    assert rollback.payload == first.payload
+    assert rollback.parent_digest == second.digest
+    assert len(ledger.records()) == 3
+    assert ledger.verify_chain() is True
+
+
+def test_configuration_custody_rejects_branching_from_stale_parent():
+    ledger = ConfigurationCustodyLedger()
+    first = create_snapshot(snapshot_id="CFG-001", payload={"x":1}, created_utc="2026-08-26T00:00:00Z", actor="operator", reason="initial")
+    ledger.append(first)
+    second = create_snapshot(snapshot_id="CFG-002", payload={"x":2}, created_utc="2026-08-26T00:10:00Z", actor="operator", reason="second", parent_digest=first.digest)
+    ledger.append(second)
+    stale = create_snapshot(snapshot_id="CFG-003", payload={"x":3}, created_utc="2026-08-26T00:20:00Z", actor="operator", reason="bad branch", parent_digest=first.digest)
+    with pytest.raises(ValueError):
+        ledger.append(stale)

--- a/deployments/sara_verified_local_v1/tests/test_ddil_reconcile.py
+++ b/deployments/sara_verified_local_v1/tests/test_ddil_reconcile.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from worldshepherd_sara.ddil_reconcile import (
+    ReconciliationState,
+    VersionedState,
+    reconcile_key,
+    reconcile_maps,
+)
+
+
+def test_newer_state_wins_after_partition_rejoin():
+    old = VersionedState(key="task", value="hold", logical_clock=4, authority=1, source_node="a")
+    new = VersionedState(key="task", value="resume", logical_clock=5, authority=1, source_node="b")
+    result = reconcile_key([old, new])
+    assert result.state == ReconciliationState.MERGED
+    assert result.selected is not None
+    assert result.selected.value == "resume"
+
+
+def test_higher_authority_wins_at_equal_clock():
+    low = VersionedState(key="route", value="east", logical_clock=7, authority=1, source_node="a")
+    high = VersionedState(key="route", value="west", logical_clock=7, authority=2, source_node="b")
+    result = reconcile_key([low, high])
+    assert result.state == ReconciliationState.MERGED
+    assert result.selected is not None
+    assert result.selected.source_node == "b"
+
+
+def test_equal_clock_equal_authority_divergence_is_not_silently_resolved():
+    a = VersionedState(key="mode", value="search", logical_clock=9, authority=1, source_node="a")
+    b = VersionedState(key="mode", value="return", logical_clock=9, authority=1, source_node="b")
+    result = reconcile_key([a, b])
+    assert result.state == ReconciliationState.CONFLICT
+    assert result.selected is None
+    assert "resolution required" in result.reason
+
+
+def test_reconcile_maps_preserves_one_sided_keys_and_surfaces_conflicts():
+    left = {
+        "a": VersionedState(key="a", value=1, logical_clock=1, authority=1, source_node="left"),
+        "shared": VersionedState(key="shared", value="x", logical_clock=2, authority=1, source_node="left"),
+    }
+    right = {
+        "b": VersionedState(key="b", value=2, logical_clock=1, authority=1, source_node="right"),
+        "shared": VersionedState(key="shared", value="y", logical_clock=2, authority=1, source_node="right"),
+    }
+    result = reconcile_maps(left, right)
+    assert set(result) == {"a", "b", "shared"}
+    assert result["shared"].state == ReconciliationState.CONFLICT

--- a/deployments/sara_verified_local_v1/tests/test_ddil_rejoin_qualification.py
+++ b/deployments/sara_verified_local_v1/tests/test_ddil_rejoin_qualification.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from worldshepherd_sara.ddil_rejoin_qualification import qualify_partition_rejoin
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0019",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(title="DDIL partition/rejoin readiness target", agency="Worldshepherd PRE", url="internal://pre/ddil-rejoin-v1", source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, retrieved_utc="2026-08-26T00:00:00Z"),
+        statement="Reconcile non-conflicting state after partition while surfacing equal-authority divergence for policy/human resolution.",
+        recurrence="Reusable DDIL/C2/autonomy readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["DDIL","C2","autonomy","configuration custody"],
+        existing_capability=["deterministic conflict-visible reconciliation policy"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["distributed deployment", "real network partitions", "consensus validation"],
+        claims_boundary=["Synthetic reconciliation only"],
+    )
+
+
+def test_partition_rejoin_qualification_surfaces_equal_authority_conflict():
+    bundle = qualify_partition_rejoin(requirement=_requirement(), software_commit="test-commit", executed_utc="2026-08-26T00:00:00Z", operator="pytest")
+    record = bundle["evidence"][0]
+    assert record["result"] == "PASS"
+    output = record["outputs"][0]
+    assert output["task_state"] == "MERGED"
+    assert output["task_selected_value"] == "resume"
+    assert output["mode_state"] == "CONFLICT"
+    assert output["mode_selected"] is None
+    assert "no distributed-consensus" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_discrepancy.py
+++ b/deployments/sara_verified_local_v1/tests/test_discrepancy.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.discrepancy import PairedMeasurement, compare_prediction_to_measurement
+
+
+def test_discrepancy_summary_preserves_absolute_relative_and_uncertainty_metrics():
+    summary = compare_prediction_to_measurement([
+        PairedMeasurement(key="gain", predicted=10.5, measured=10.0, uncertainty=0.6, units="dB"),
+        PairedMeasurement(key="phase", predicted=31.0, measured=30.0, uncertainty=0.5, units="deg"),
+    ])
+    assert summary.mean_absolute_error == 0.75
+    assert summary.max_absolute_error == 1.0
+    assert summary.mean_relative_error is not None
+    assert summary.within_uncertainty_fraction == 0.5
+    assert summary.metrics[0].normalized_error is not None
+
+
+def test_zero_measurement_has_no_relative_error_and_zero_uncertainty_is_handled_explicitly():
+    summary = compare_prediction_to_measurement([
+        PairedMeasurement(key="zero", predicted=0.0, measured=0.0, uncertainty=0.0)
+    ])
+    assert summary.metrics[0].relative_error is None
+    assert summary.metrics[0].normalized_error == 0.0
+    assert summary.within_uncertainty_fraction == 1.0
+
+
+def test_discrepancy_rejects_invalid_uncertainty():
+    with pytest.raises(ValueError):
+        compare_prediction_to_measurement([
+            PairedMeasurement(key="bad", predicted=1.0, measured=1.0, uncertainty=-1.0)
+        ])

--- a/deployments/sara_verified_local_v1/tests/test_edge_benchmark.py
+++ b/deployments/sara_verified_local_v1/tests/test_edge_benchmark.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from worldshepherd_sara.edge_benchmark import benchmark_callable
+
+
+def test_edge_benchmark_records_latency_memory_and_determinism_without_device_claims():
+    def transform(value: dict) -> dict:
+        return {"sum": sum(value["values"]), "count": len(value["values"])}
+
+    summary = benchmark_callable(transform, {"values": [1, 2, 3, 4]}, repetitions=5, warmup=1)
+    assert len(summary.runs) == 5
+    assert summary.median_elapsed_ms >= 0
+    assert summary.p95_elapsed_ms >= summary.median_elapsed_ms or summary.p95_elapsed_ms >= 0
+    assert summary.max_peak_python_bytes >= 0
+    assert summary.deterministic_output is True
+    assert summary.input_digest.startswith("sha256:")

--- a/deployments/sara_verified_local_v1/tests/test_edge_qualification.py
+++ b/deployments/sara_verified_local_v1/tests/test_edge_qualification.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from worldshepherd_sara.edge_qualification import qualify_host_callable
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0018",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(title="Edge-AI benchmark readiness target", agency="Worldshepherd PRE", url="internal://pre/edge-benchmark-v1", source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, retrieved_utc="2026-08-26T00:00:00Z"),
+        statement="Benchmark deterministic local software behavior before target-device performance claims.",
+        recurrence="Reusable edge-AI readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["edge AI","autonomy","C2","sensor fusion"],
+        existing_capability=["host-specific Python benchmark harness"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["target edge hardware", "power/thermal measurement", "real-time validation"],
+        claims_boundary=["Host-specific benchmark only"],
+    )
+
+
+def test_edge_qualification_is_replayable_in_output_and_device_claims_bounded():
+    def transform(value: dict) -> dict:
+        return {"total": sum(value["values"]), "count": len(value["values"])}
+
+    bundle = qualify_host_callable(
+        function=transform,
+        input_value={"values":[1,2,3,4]},
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+        environment={"runtime":"pytest-python"},
+        repetitions=3,
+        warmup=1,
+    )
+    record = bundle["evidence"][0]
+    assert record["result"] == "PASS"
+    assert record["outputs"][0]["deterministic_output"] is True
+    assert len(set(record["outputs"][0]["output_digests"])) == 1
+    assert "no GPU/NPU" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_evidence_lifecycle.py
+++ b/deployments/sara_verified_local_v1/tests/test_evidence_lifecycle.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.evidence_lifecycle import revoke_evidence, supersede_evidence
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    ResultStatus,
+    SupersessionState,
+)
+
+
+def _record() -> QualificationEvidenceRecord:
+    return QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-9001",
+        requirement_id="PRE-RD-2026-0001",
+        test_id="lifecycle-test",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest="sha256:env",
+        configuration_digest="sha256:config",
+        result=ResultStatus.PASS,
+        rationale="synthetic lifecycle fixture",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+
+
+def test_evidence_can_be_superseded_without_deleting_prior_record():
+    old = _record()
+    updated = supersede_evidence(
+        old,
+        superseded_by="WS-QE-2026-9002",
+        reviewer="identified-human-reviewer",
+        reviewed_utc="2026-08-26T01:00:00Z",
+    )
+    assert old.supersession.state == SupersessionState.CURRENT
+    assert updated.supersession.state == SupersessionState.SUPERSEDED
+    assert updated.supersession.superseded_by == "WS-QE-2026-9002"
+
+
+def test_evidence_revocation_retains_negative_reason_and_fails_repeat_revoke():
+    revoked = revoke_evidence(
+        _record(),
+        reviewer="identified-human-reviewer",
+        reviewed_utc="2026-08-26T01:00:00Z",
+        reason="fixture invalidated",
+    )
+    assert revoked.supersession.state == SupersessionState.REVOKED
+    assert revoked.negative_evidence[-1]["revocation_reason"] == "fixture invalidated"
+    with pytest.raises(ValueError):
+        revoke_evidence(
+            revoked,
+            reviewer="identified-human-reviewer",
+            reviewed_utc="2026-08-26T02:00:00Z",
+            reason="repeat",
+        )

--- a/deployments/sara_verified_local_v1/tests/test_evidence_store.py
+++ b/deployments/sara_verified_local_v1/tests/test_evidence_store.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldshepherd_sara.evidence_store import EvidenceIntegrityError, EvidenceStore
+from worldshepherd_sara.qualification import canonical_digest
+
+
+def _bundle() -> dict:
+    value = {
+        "requirement": {"id": "PRE-RD-TEST"},
+        "evidence": [{"test_id": "T1", "result": "PASS"}],
+        "claims_boundary": ["synthetic only"],
+    }
+    value["bundle_digest"] = canonical_digest(value)
+    return value
+
+
+def test_evidence_store_round_trips_hash_addressed_bundle(tmp_path):
+    store = EvidenceStore(tmp_path / "evidence")
+    bundle = _bundle()
+    digest = store.put_bundle(bundle)
+    assert digest == bundle["bundle_digest"]
+    assert store.get_bundle(digest) == bundle
+    assert store.verify_all() == {digest: True}
+
+
+def test_evidence_store_rejects_bad_declared_digest(tmp_path):
+    store = EvidenceStore(tmp_path / "evidence")
+    bundle = _bundle()
+    bundle["bundle_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(EvidenceIntegrityError):
+        store.put_bundle(bundle)
+
+
+def test_evidence_store_detects_post_write_tampering(tmp_path):
+    store = EvidenceStore(tmp_path / "evidence")
+    bundle = _bundle()
+    digest = store.put_bundle(bundle)
+    path = store.root / f"{digest.split(':', 1)[1]}.json"
+    tampered = json.loads(path.read_text())
+    tampered["evidence"][0]["result"] = "FAIL"
+    path.write_text(json.dumps(tampered))
+    with pytest.raises(EvidenceIntegrityError):
+        store.get_bundle(digest)
+    assert store.verify_all() == {digest: False}

--- a/deployments/sara_verified_local_v1/tests/test_graph_metrics.py
+++ b/deployments/sara_verified_local_v1/tests/test_graph_metrics.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from worldshepherd_sara.graph_metrics import score_graph
+
+
+def test_graph_score_perfect_match():
+    score = score_graph(
+        expected_entities={"a", "b"},
+        predicted_entities={"a", "b"},
+        expected_relationships={"a->b:connects"},
+        predicted_relationships={"a->b:connects"},
+    )
+    assert score.entity_precision == 1.0
+    assert score.entity_recall == 1.0
+    assert score.relationship_precision == 1.0
+    assert score.relationship_recall == 1.0
+    assert score.unsupported_entities == ()
+    assert score.unsupported_relationships == ()
+
+
+def test_graph_score_reports_unsupported_and_missed_content():
+    score = score_graph(
+        expected_entities={"a", "b", "c"},
+        predicted_entities={"a", "b", "x"},
+        expected_relationships={"a->b:connects", "b->c:feeds"},
+        predicted_relationships={"a->b:connects", "b->x:feeds"},
+    )
+    assert score.entity_precision == 2 / 3
+    assert score.entity_recall == 2 / 3
+    assert score.relationship_precision == 0.5
+    assert score.relationship_recall == 0.5
+    assert score.unsupported_entities == ("x",)
+    assert score.missed_entities == ("c",)
+    assert score.unsupported_relationships == ("b->x:feeds",)
+    assert score.missed_relationships == ("b->c:feeds",)

--- a/deployments/sara_verified_local_v1/tests/test_horizons.py
+++ b/deployments/sara_verified_local_v1/tests/test_horizons.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.horizons import CapabilityHorizonPortfolio, CapabilityHorizonRecord
+from worldshepherd_sara.qualification import ForecastHorizon
+from worldshepherd_sara.readiness import ReadinessRung
+
+
+def test_horizon_portfolio_keeps_forecast_actions_separate_from_readiness_claims():
+    portfolio = CapabilityHorizonPortfolio(records=[
+        CapabilityHorizonRecord(
+            horizon_id="H-APNT-001",
+            capability_id="CAP-APNT",
+            horizon=ForecastHorizon.D0_90,
+            prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE,
+            target_rung=ReadinessRung.SIMULATION,
+            requirement_delta_ids=["PRE-RD-2026-0001"],
+            build_actions=["implement authoritative ASPN mapping adapter"],
+            experiments=["run representative simulation with controlled source faults"],
+            partner_actions=["obtain APNT interface/validation partner"],
+            evidence_targets=["simulation qualification bundle"],
+            blocking_conditions=["authoritative interface definitions unavailable"],
+            forecast_only=True,
+        )
+    ])
+    assert portfolio.records[0].forecast_only is True
+    assert "implement authoritative ASPN mapping adapter" in portfolio.immediate_actions()
+
+
+def test_horizon_record_rejects_multi_rung_readiness_jump():
+    with pytest.raises(ValueError):
+        CapabilityHorizonRecord(
+            horizon_id="H-BAD",
+            capability_id="CAP-BAD",
+            horizon=ForecastHorizon.D0_90,
+            prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE,
+            target_rung=ReadinessRung.PHYSICAL_LAB,
+        )

--- a/deployments/sara_verified_local_v1/tests/test_ietm.py
+++ b/deployments/sara_verified_local_v1/tests/test_ietm.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.ietm import (
+    inspect_synthetic_projection,
+    project_synthetic_manual_to_xml,
+    qualify_synthetic_ietm,
+)
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0003",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="NAVAIR IETM synthetic qualification target",
+            agency="NAVAIR",
+            url="https://example.invalid/navair-ietm-placeholder",
+            solicitation_or_topic="DON26BZ05-NV078",
+            source_status=SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Preserve structure and source markings through a synthetic technical-data XML projection.",
+        recurrence="Release-5 capture requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["technical data", "IETM", "provenance"],
+        existing_capability=["synthetic XML projection"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["S1000D validation", "Navy viewer compatibility"],
+        claims_boundary=["Synthetic XML only; no standards-compliance claim"],
+    )
+
+
+def test_synthetic_ietm_projection_preserves_structure_and_marking():
+    fixture = json.loads((ROOT / "fixtures" / "ietm_synthetic_v1.json").read_text())
+    xml_text = project_synthetic_manual_to_xml(fixture)
+    observed = inspect_synthetic_projection(xml_text, fixture)
+    assert observed == fixture["expected"]
+    assert "SYNTHETIC DISTRIBUTION MARKING - TEST ONLY" in xml_text
+
+
+def test_synthetic_ietm_uses_shared_qualification_bundle():
+    fixture = json.loads((ROOT / "fixtures" / "ietm_synthetic_v1.json").read_text())
+    bundle = qualify_synthetic_ietm(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert bundle["evidence"][0]["result"] == "PASS"
+    assert bundle["evidence"][0]["evidence_scope"] == "SOFTWARE"
+    assert bundle["fixture_id"] == "WS-IETM-SYNTH-001"
+    assert "no S1000D" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_interoperability.py
+++ b/deployments/sara_verified_local_v1/tests/test_interoperability.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.interoperability import (
+    ConformanceCheck,
+    ConformanceState,
+    InterfaceConformanceRecord,
+    InterfaceContract,
+)
+
+
+def test_internal_conformance_pass_requires_all_checks_and_stays_non_certification_claim():
+    contract = InterfaceContract(
+        contract_id="IFACE-1",
+        interface_name="Synthetic C2 Adapter",
+        version="1",
+        required_message_types=["track_update"],
+        required_fields={"track_update":["track_id","timestamp","position"]},
+    )
+    record = InterfaceConformanceRecord(
+        record_id="CONF-1",
+        contract_digest=contract.digest(),
+        implementation_id="adapter-1",
+        implementation_digest="sha256:adapter",
+        state=ConformanceState.INTERNAL_PASS,
+        checks=[ConformanceCheck(check_id="C1", description="required fields present", passed=True, evidence_refs=["fixture://track-update"])],
+    )
+    assert "no platform acceptance" in record.claims_boundary().lower()
+
+
+def test_external_certification_state_requires_authority_and_certificate():
+    with pytest.raises(ValueError):
+        InterfaceConformanceRecord(
+            record_id="BAD",
+            contract_digest="sha256:contract",
+            implementation_id="adapter",
+            implementation_digest="sha256:adapter",
+            state=ConformanceState.EXTERNALLY_CERTIFIED,
+        )

--- a/deployments/sara_verified_local_v1/tests/test_manufacturing_qualification.py
+++ b/deployments/sara_verified_local_v1/tests/test_manufacturing_qualification.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.manufacturing_qualification import qualify_synthetic_manufacturing_thread
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0017",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(title="DED/manufacturing digital-thread readiness target", agency="Worldshepherd PRE", url="internal://pre/mfg-thread-v1", source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, retrieved_utc="2026-08-26T00:00:00Z"),
+        statement="Establish machine-readable material/process/specimen provenance before physical qualification claims.",
+        recurrence="Reusable additive-manufacturing qualification requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["DED","additive manufacturing","digital thread","qualification evidence"],
+        existing_capability=["manufacturing digital-thread schema"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["physical coupon","machine calibration evidence","property measurement","partner lab validation"],
+        claims_boundary=["Digital thread only"],
+    )
+
+
+def test_manufacturing_qualification_bundle_stays_digital_thread_only():
+    fixture = json.loads((ROOT / "fixtures" / "manufacturing_thread_synthetic_v1.json").read_text())
+    bundle = qualify_synthetic_manufacturing_thread(fixture=fixture, requirement=_requirement(), software_commit="test-commit", executed_utc="2026-08-26T00:00:00Z", operator="pytest")
+    record = bundle["evidence"][0]
+    assert record["result"] == "PASS"
+    assert record["evidence_scope"] == "SOFTWARE"
+    assert record["physical_validation_performed"] is False
+    assert record["outputs"][0]["qualification_state"] == "DIGITAL_THREAD_ONLY"
+    assert "no physical coupon" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_manufacturing_thread.py
+++ b/deployments/sara_verified_local_v1/tests/test_manufacturing_thread.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.manufacturing_thread import (
+    BuildStep,
+    ManufacturingDigitalThread,
+    MaterialLot,
+    ProcessConfiguration,
+    SpecimenRecord,
+)
+
+
+def test_manufacturing_digital_thread_preserves_material_process_specimen_lineage():
+    thread = ManufacturingDigitalThread(
+        thread_id="WS-MFG-SYNTH-001",
+        material_lots=[MaterialLot(lot_id="LOT-1", material_designation="Synthetic Al-Ti-Mg-Sc-Zr research lot")],
+        process_configurations=[
+            ProcessConfiguration(
+                configuration_id="CFG-1",
+                process_family="DED_SYNTHETIC",
+                machine_id="SIMULATED-MACHINE",
+                parameters={"laser_power_w": 500, "travel_speed_mm_s": 10},
+            )
+        ],
+        build_steps=[BuildStep(step_id="STEP-1", material_lot_ids=["LOT-1"], configuration_id="CFG-1")],
+        specimens=[SpecimenRecord(specimen_id="COUPON-1", build_step_ids=["STEP-1"])],
+        claims_boundary=["Digital thread only; no material-property or process-performance claim"],
+    )
+    assert thread.qualification_state() == "DIGITAL_THREAD_ONLY"
+    assert thread.digest().startswith("sha256:")
+
+
+def test_manufacturing_thread_requires_resolvable_references():
+    with pytest.raises(ValueError):
+        ManufacturingDigitalThread(
+            thread_id="BAD",
+            material_lots=[],
+            process_configurations=[],
+            build_steps=[BuildStep(step_id="S1", material_lot_ids=["MISSING"], configuration_id="NOPE")],
+        )
+
+
+def test_physical_measurement_state_requires_explicit_measurement_reference_and_flag():
+    thread = ManufacturingDigitalThread(
+        thread_id="WS-MFG-MEASURED-SYNTH",
+        material_lots=[MaterialLot(lot_id="LOT-1", material_designation="Synthetic alloy")],
+        process_configurations=[ProcessConfiguration(configuration_id="CFG-1", process_family="DED_SYNTHETIC", machine_id="M1")],
+        build_steps=[BuildStep(step_id="STEP-1", material_lot_ids=["LOT-1"], configuration_id="CFG-1")],
+        specimens=[
+            SpecimenRecord(
+                specimen_id="COUPON-1",
+                build_step_ids=["STEP-1"],
+                measurement_artifact_digests=["sha256:measurement-placeholder"],
+                physical_validation_performed=True,
+            )
+        ],
+    )
+    assert thread.qualification_state() == "PHYSICAL_MEASUREMENT_REFERENCED"

--- a/deployments/sara_verified_local_v1/tests/test_mbse_benchmark.py
+++ b/deployments/sara_verified_local_v1/tests/test_mbse_benchmark.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.mbse_benchmark import benchmark_synthetic_mbse, qualify_synthetic_mbse
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0002",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="NAVSEA AI to MBSE synthetic qualification target",
+            agency="NAVSEA",
+            url="https://example.invalid/navsea-mbse-placeholder",
+            solicitation_or_topic="DON26BX05-NP003",
+            source_status=SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Evaluate source-traceable reconstruction against a frozen synthetic ground truth.",
+        recurrence="Release-5 capture requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["MBSE", "digital engineering", "provenance"],
+        existing_capability=["conservative synthetic relationship extraction"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["general document understanding", "SysML/Cameo interoperability"],
+        claims_boundary=["Synthetic fixture only; no Navy production reconstruction claim"],
+    )
+
+
+def test_synthetic_mbse_benchmark_meets_frozen_targets_without_unsupported_inference():
+    fixture = json.loads((ROOT / "fixtures" / "mbse_legacy_fixture_v1.json").read_text())
+    score = benchmark_synthetic_mbse(fixture)
+    assert score.entity_precision == 1.0
+    assert score.entity_recall == 1.0
+    assert score.relationship_precision == 1.0
+    assert score.relationship_recall == 1.0
+    assert score.unsupported_entities == ()
+    assert score.unsupported_relationships == ()
+    assert score.missed_entities == ()
+    assert score.missed_relationships == ()
+
+
+def test_mbse_qualification_bundle_is_reproducible_and_narrowly_scoped():
+    fixture = json.loads((ROOT / "fixtures" / "mbse_legacy_fixture_v1.json").read_text())
+    first = qualify_synthetic_mbse(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    second = qualify_synthetic_mbse(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert first["evidence"][0]["result"] == "PASS"
+    assert first["bundle_digest"] == second["bundle_digest"]
+    assert "Synthetic rule-based extraction benchmark only" in first["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_mbse_fixture.py
+++ b/deployments/sara_verified_local_v1/tests/test_mbse_fixture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.graph_metrics import score_graph
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "mbse_legacy_fixture_v1.json"
+)
+
+
+def _relationship_key(item: dict[str, str]) -> str:
+    return f'{item["source"]}->{item["target"]}:{item["relation"]}'
+
+
+def test_mbse_fixture_ground_truth_scores_perfectly_against_itself():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    truth = payload["ground_truth"]
+    entities = {item["id"] for item in truth["nodes"]}
+    relationships = {_relationship_key(item) for item in truth["edges"]}
+
+    score = score_graph(
+        expected_entities=entities,
+        predicted_entities=entities,
+        expected_relationships=relationships,
+        predicted_relationships=relationships,
+    )
+
+    assert score.entity_precision == 1.0
+    assert score.entity_recall == 1.0
+    assert score.relationship_precision == 1.0
+    assert score.relationship_recall == 1.0
+
+
+def test_mbse_fixture_artifacts_cover_each_ground_truth_relationship():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    expected = {
+        _relationship_key(item) for item in payload["ground_truth"]["edges"]
+    }
+    supported: set[str] = set()
+    for artifact in payload["legacy_artifacts"]:
+        supported.update(artifact.get("expected_support", []))
+
+    assert expected == supported

--- a/deployments/sara_verified_local_v1/tests/test_mission_replay.py
+++ b/deployments/sara_verified_local_v1/tests/test_mission_replay.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.mission_qualification import qualify_synthetic_mission_replay
+from worldshepherd_sara.mission_replay import MissionEvent, derive_findings, propose_follow_on_actions, replay_events
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0013",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="Navy post-mission debrief and replanning readiness target",
+            agency="Navy",
+            url="https://www.sbir.gov/",
+            solicitation_or_topic="DON26BZ05-NV074",
+            source_status=SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Preserve mission evidence, reconstruct events, derive bounded findings, and keep follow-on COAs behind human authorization.",
+        recurrence="Release-5 post-mission autonomy demand",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["OVERWATCH", "ECHO", "PRIME", "autonomy governance"],
+        existing_capability=["synthetic deterministic mission replay"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["operational mission data", "validated causal reasoning", "CCA integration"],
+        claims_boundary=["Synthetic mission-event evidence only"],
+    )
+
+
+def test_mission_replay_derives_expected_findings_and_proposals():
+    fixture = json.loads((ROOT / "fixtures" / "mission_replay_synthetic_v1.json").read_text())
+    events = [MissionEvent.model_validate(event) for event in fixture["events"]]
+    findings = derive_findings(replay_events(events))
+    proposals = propose_follow_on_actions(findings)
+    assert sorted(f.finding_type for f in findings) == sorted(fixture["expected"]["finding_types"])
+    assert sorted(p.action for p in proposals) == sorted(fixture["expected"]["proposal_actions"])
+    assert all(p.state.value == "PROPOSED" for p in proposals)
+
+
+def test_mission_qualification_bundle_retains_event_to_finding_to_proposal_lineage():
+    fixture = json.loads((ROOT / "fixtures" / "mission_replay_synthetic_v1.json").read_text())
+    bundle = qualify_synthetic_mission_replay(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert bundle["evidence"][0]["result"] == "PASS"
+    graph = bundle["evidence_graph"]
+    node_types = {node["node_type"] for node in graph["nodes"]}
+    relations = {edge["relation"] for edge in graph["edges"]}
+    assert {"mission_event", "debrief_finding", "prime_action_proposal"}.issubset(node_types)
+    assert {"supports", "informs"}.issubset(relations)
+    assert all(p["state"] == "PROPOSED" for p in bundle["prime_action_proposals"])

--- a/deployments/sara_verified_local_v1/tests/test_pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_pre_bloom_cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.pre_bloom_cli import build_bloom
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_full_bloom_compiler_emits_cross_domain_evidence_readiness_horizons_and_provenance(tmp_path):
+    out = tmp_path / "bloom"
+    index = build_bloom(
+        fixtures=ROOT / "fixtures",
+        out=out,
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    expected_bundles = {
+        "apnt", "mbse", "ietm", "ade", "mission", "fusion", "rf", "cbm",
+        "manufacturing", "ddil", "edge", "ddil_rejoin",
+    }
+    assert expected_bundles.issubset(index["bundle_digests"])
+    assert all(not failures for failures in index["failures"].values())
+    assert all(index["custody_verification"].values())
+    assert (out / "capability_readiness_ledger.json").is_file()
+    assert (out / "capability_horizons.json").is_file()
+    assert (out / "software_provenance.json").is_file()
+    provenance = json.loads((out / "software_provenance.json").read_text())
+    assert provenance["attestation_state"] == "INTERNAL_UNSIGNED"
+    horizons = json.loads((out / "capability_horizons.json").read_text())
+    assert {record["horizon"] for record in horizons["records"]} >= {"0-90D", "3-12M", "12-24M_PLUS"}

--- a/deployments/sara_verified_local_v1/tests/test_pre_portfolio.py
+++ b/deployments/sara_verified_local_v1/tests/test_pre_portfolio.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from worldshepherd_sara.pre_portfolio import build_horizon_portfolio, build_readiness_ledger
+
+
+def test_readiness_ledger_separates_synthetic_software_from_rf_simulation_rung():
+    digests = {name: "sha256:" + str(index) * 64 for index, name in enumerate(["apnt","mbse","ietm","ade","mission","fusion","cbm","manufacturing","ddil","rf"], start=1)}
+    ledger = build_readiness_ledger(digests)
+    records = {record["capability_id"]: record for record in ledger["records"]}
+    assert records["CAP-APNT"]["highest_supported_rung"] == 3
+    assert records["CAP-RF-DISCREPANCY"]["highest_supported_rung"] == 4
+    assert records["CAP-RF-DISCREPANCY"]["blocked_next_rung"] == 5
+    assert ledger["ledger_digest"].startswith("sha256:")
+
+
+def test_horizon_portfolio_covers_all_three_windows_and_is_forecast_only():
+    portfolio = build_horizon_portfolio()
+    horizons = {record["horizon"] for record in portfolio["records"]}
+    assert {"0-90D", "3-12M", "12-24M_PLUS"}.issubset(horizons)
+    assert all(record["forecast_only"] is True for record in portfolio["records"])
+    assert portfolio["immediate_actions"]
+    assert portfolio["portfolio_digest"].startswith("sha256:")

--- a/deployments/sara_verified_local_v1/tests/test_qualification.py
+++ b/deployments/sara_verified_local_v1/tests/test_qualification.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    EvidenceGraph,
+    EvidenceGraphEdge,
+    EvidenceGraphNode,
+    EvidenceScope,
+    ForecastHorizon,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    SourceRecord,
+    SourceStatus,
+    compile_qualification_bundle,
+)
+
+
+def _requirement(source_status: SourceStatus = SourceStatus.OFFICIAL_SOURCE_VERIFIED):
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0100",
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="Synthetic APNT test requirement",
+            agency="Worldshepherd test fixture",
+            url="fixture://apnt",
+            solicitation_or_topic="TEST-001",
+            source_status=source_status,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Preserve source lineage through a degraded-navigation scenario.",
+        recurrence="test fixture",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["APNT", "ECHO SENTINEL LINK"],
+        existing_capability=["audit/provenance schema"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["real APNT sensor validation"],
+        evidence_target=["replayable synthetic degradation trace"],
+        claims_boundary=["synthetic fixture is not Navy or physical APNT validation"],
+    )
+
+
+def test_conflicting_or_unverified_source_is_not_capture_ready():
+    assert _requirement(SourceStatus.UNVERIFIED).capture_ready() is False
+    assert _requirement(SourceStatus.CONFLICTING_SOURCES).capture_ready() is False
+    assert _requirement(SourceStatus.OFFICIAL_SOURCE_VERIFIED).capture_ready() is True
+
+
+def test_evidence_graph_rejects_unknown_node_reference():
+    with pytest.raises(ValidationError):
+        EvidenceGraph(
+            graph_id="g1",
+            nodes=[EvidenceGraphNode(node_id="n1", node_type="source", label="GNSS")],
+            edges=[
+                EvidenceGraphEdge(
+                    edge_id="e1",
+                    source_node_id="n1",
+                    target_node_id="missing",
+                    relation="supports",
+                )
+            ],
+        )
+
+
+def test_physical_proven_status_fails_closed_without_physical_validation():
+    with pytest.raises(ValidationError):
+        QualificationEvidenceRecord(
+            qualification_id="WS-QE-2026-0100",
+            requirement_id="PRE-RD-2026-0100",
+            test_id="TEST-PHYSICAL-001",
+            evidence_scope=EvidenceScope.PHYSICAL,
+            capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+            environment_digest="sha256:env",
+            configuration_digest="sha256:cfg",
+            result=ResultStatus.PASS,
+            rationale="This must not be accepted without physical validation.",
+            executed_utc="2026-08-26T00:00:00Z",
+            operator="pytest",
+            physical_validation_performed=False,
+        )
+
+
+def test_bundle_digest_is_deterministic():
+    requirement = _requirement()
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-0101",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="APNT-SYNTH-001",
+        evidence_scope=EvidenceScope.SIMULATION,
+        capability_status=CapabilityStatus.SIMULATED_ONLY,
+        environment_digest="sha256:env",
+        configuration_digest="sha256:cfg",
+        inputs=[{"name": "fixture", "digest": "sha256:fixture"}],
+        outputs=[{"name": "trace", "digest": "sha256:trace"}],
+        metrics=[{"name": "lineage_complete", "value": True}],
+        uncertainty=[{"name": "physical_validity", "value": "UNKNOWN"}],
+        result=ResultStatus.PASS,
+        rationale="Synthetic lineage test passed.",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    graph = EvidenceGraph(
+        graph_id="apnt-test",
+        nodes=[
+            EvidenceGraphNode(node_id="gnss", node_type="source", label="GNSS"),
+            EvidenceGraphNode(node_id="confidence", node_type="derived", label="Confidence"),
+        ],
+        edges=[
+            EvidenceGraphEdge(
+                edge_id="e1",
+                source_node_id="gnss",
+                target_node_id="confidence",
+                relation="contributes_to",
+            )
+        ],
+    )
+
+    first = compile_qualification_bundle(requirement, [evidence], graph)
+    second = compile_qualification_bundle(requirement, [evidence], graph)
+    assert first["bundle_digest"] == second["bundle_digest"]

--- a/deployments/sara_verified_local_v1/tests/test_readiness.py
+++ b/deployments/sara_verified_local_v1/tests/test_readiness.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.readiness import CapabilityReadinessRecord, ReadinessRung
+
+
+def test_readiness_record_requires_explicit_evidence_for_every_supported_rung():
+    record = CapabilityReadinessRecord(
+        capability_id="CAP-APNT-SYNTH",
+        capability_name="Synthetic APNT bounded awareness",
+        highest_supported_rung=ReadinessRung.INTERNAL_SOFTWARE,
+        evidence_refs={
+            ReadinessRung.SCHEMA: ["qualification.py"],
+            ReadinessRung.FIXTURE: ["WS-APNT-SYNTH-001"],
+            ReadinessRung.INTERNAL_SOFTWARE: ["apnt_qualification_bundle"],
+        },
+        blocked_next_rung=ReadinessRung.SIMULATION,
+        missing_evidence=["representative validated simulation"],
+    )
+    assert record.can_claim(ReadinessRung.INTERNAL_SOFTWARE) is True
+    assert record.can_claim(ReadinessRung.PHYSICAL_LAB) is False
+    assert record.next_rung() == ReadinessRung.SIMULATION
+
+
+def test_readiness_record_rejects_skipped_or_implicit_rungs():
+    with pytest.raises(ValueError):
+        CapabilityReadinessRecord(
+            capability_id="CAP-BAD",
+            capability_name="Bad readiness claim",
+            highest_supported_rung=ReadinessRung.PHYSICAL_LAB,
+            evidence_refs={ReadinessRung.PHYSICAL_LAB: ["one-test"]},
+        )

--- a/deployments/sara_verified_local_v1/tests/test_rf_validation.py
+++ b/deployments/sara_verified_local_v1/tests/test_rf_validation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+from worldshepherd_sara.rf_validation import qualify_synthetic_rf_discrepancy
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0015",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(
+            title="RF/metasurface simulation-to-measurement readiness target",
+            agency="Worldshepherd PRE",
+            url="internal://pre/rf-discrepancy-v1",
+            source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Quantify simulation-to-measurement discrepancy before any physical RF performance claim.",
+        recurrence="Reusable RF/metasurface readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["RF", "metasurfaces", "simulation governance"],
+        existing_capability=["generic discrepancy accounting"],
+        capability_status=[CapabilityStatus.SIMULATED_ONLY],
+        missing_capability=["fabricated coupon", "VNA/chamber measurement", "independent physical validation"],
+        claims_boundary=["Synthetic RF values only"],
+    )
+
+
+def test_rf_synthetic_discrepancy_bundle_passes_frozen_targets_without_physical_claim():
+    fixture = json.loads((ROOT / "fixtures" / "rf_sparams_synthetic_v1.json").read_text())
+    bundle = qualify_synthetic_rf_discrepancy(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    record = bundle["evidence"][0]
+    assert record["result"] == "PASS"
+    assert record["evidence_scope"] == "SIMULATION"
+    assert record["capability_status"] == "SIMULATED_ONLY"
+    assert record["physical_validation_performed"] is False
+    assert "no VNA" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_sensor_fusion.py
+++ b/deployments/sara_verified_local_v1/tests/test_sensor_fusion.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+from worldshepherd_sara.sensor_fusion import Observation, fuse_observations
+from worldshepherd_sara.sensor_fusion_qualification import qualify_synthetic_sensor_fusion
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0014",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(
+            title="Synthetic distributed sensing readiness target",
+            agency="Worldshepherd PRE",
+            url="internal://pre/sensor-fusion-v1",
+            source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement="Establish a source-traceable deterministic fusion baseline before learned or operational sensor-fusion work.",
+        recurrence="Reusable distributed sensing readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["distributed sensing", "sensor fusion", "ECHO", "mission assurance"],
+        existing_capability=["deterministic weighted 2-D synthetic fusion baseline"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["operational sensor data", "validated multi-target association", "edge deployment"],
+        claims_boundary=["Synthetic 2-D point observations only"],
+    )
+
+
+def test_synthetic_fusion_is_deterministic_and_preserves_observation_lineage():
+    fixture = json.loads((ROOT / "fixtures" / "sensor_fusion_synthetic_v1.json").read_text())
+    observations = [Observation.model_validate(item) for item in fixture["observations"]]
+    association = fixture["association"]
+    first = fuse_observations(
+        observations,
+        max_spatial_distance=association["max_spatial_distance"],
+        max_time_delta_seconds=association["max_time_delta_seconds"],
+    )
+    second = fuse_observations(
+        observations,
+        max_spatial_distance=association["max_spatial_distance"],
+        max_time_delta_seconds=association["max_time_delta_seconds"],
+    )
+    assert first == second
+    assert len(first) == 2
+    assert sorted(obs for track in first for obs in track.source_observation_ids) == sorted(
+        item["observation_id"] for item in fixture["observations"]
+    )
+
+
+def test_sensor_fusion_qualification_meets_frozen_truth_target_and_retains_graph_lineage():
+    fixture = json.loads((ROOT / "fixtures" / "sensor_fusion_synthetic_v1.json").read_text())
+    bundle = qualify_synthetic_sensor_fusion(
+        fixture=fixture,
+        requirement=_requirement(),
+        software_commit="test-commit",
+        executed_utc="2026-08-26T00:00:00Z",
+        operator="pytest",
+    )
+    assert bundle["evidence"][0]["result"] == "PASS"
+    assert bundle["evidence"][0]["outputs"][0]["max_position_error"] <= fixture["expected"]["max_position_error"]
+    assert bundle["evidence"][0]["outputs"][0]["source_observations_preserved"] is True
+    assert {edge["relation"] for edge in bundle["evidence_graph"]["edges"]} == {"contributes_to"}
+    assert "no AESA" in bundle["scope_note"]

--- a/deployments/sara_verified_local_v1/tests/test_software_provenance.py
+++ b/deployments/sara_verified_local_v1/tests/test_software_provenance.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.software_provenance import (
+    AttestationState,
+    BuildProvenance,
+    SoftwareComponent,
+)
+
+
+def test_internal_unsigned_provenance_is_machine_readable_and_claims_bounded():
+    provenance = BuildProvenance(
+        provenance_id="WS-BUILD-001",
+        source_repository="Bdavis1390/Sara_pro",
+        source_commit="abc123",
+        builder_id="github-actions",
+        build_environment_digest="sha256:env",
+        output_artifact_digest="sha256:artifact",
+        components=[SoftwareComponent(name="fastapi", version="0.141.1", package_type="pypi")],
+        sbom_digest="sha256:sbom",
+    )
+    assert provenance.attestation_state == AttestationState.INTERNAL_UNSIGNED
+    assert provenance.digest().startswith("sha256:")
+    assert "no external signing" in provenance.claims_boundary().lower()
+
+
+def test_signed_and_external_states_require_corresponding_evidence():
+    with pytest.raises(ValueError):
+        BuildProvenance(
+            provenance_id="BAD1",
+            source_repository="repo",
+            source_commit="c",
+            builder_id="b",
+            build_environment_digest="sha256:e",
+            output_artifact_digest="sha256:o",
+            attestation_state=AttestationState.INTERNALLY_SIGNED,
+        )
+    with pytest.raises(ValueError):
+        BuildProvenance(
+            provenance_id="BAD2",
+            source_repository="repo",
+            source_commit="c",
+            builder_id="b",
+            build_environment_digest="sha256:e",
+            output_artifact_digest="sha256:o",
+            attestation_state=AttestationState.EXTERNALLY_VERIFIED,
+            signature_ref="sig://1",
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ade.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ade.py
@@ -146,10 +146,8 @@ def discover_expression(
     best_mse = _mse(best, data)
     if baseline_mse == 0.0:
         improvement = 1.0 if best_mse == 0.0 else 0.0
-    elif best_mse == 0.0:
-        improvement = float("inf")
     else:
-        improvement = baseline_mse / best_mse
+        improvement = baseline_mse / max(best_mse, 1e-12)
 
     return DiscoveryResult(
         expression=best,

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ade.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ade.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Expr:
+    op: str
+    value: float | None = None
+    left: "Expr | None" = None
+    right: "Expr | None" = None
+
+    def evaluate(self, x: float) -> float:
+        if self.op == "x":
+            return x
+        if self.op == "const":
+            assert self.value is not None
+            return self.value
+        if self.op == "add":
+            assert self.left is not None and self.right is not None
+            return self.left.evaluate(x) + self.right.evaluate(x)
+        if self.op == "sub":
+            assert self.left is not None and self.right is not None
+            return self.left.evaluate(x) - self.right.evaluate(x)
+        if self.op == "mul":
+            assert self.left is not None and self.right is not None
+            return self.left.evaluate(x) * self.right.evaluate(x)
+        if self.op == "square":
+            assert self.left is not None
+            value = self.left.evaluate(x)
+            return value * value
+        raise ValueError(f"unknown op: {self.op}")
+
+    def complexity(self) -> int:
+        if self.op in {"x", "const"}:
+            return 1
+        if self.op == "square":
+            assert self.left is not None
+            return 1 + self.left.complexity()
+        assert self.left is not None and self.right is not None
+        return 1 + self.left.complexity() + self.right.complexity()
+
+    def text(self) -> str:
+        if self.op == "x":
+            return "x"
+        if self.op == "const":
+            assert self.value is not None
+            return str(int(self.value)) if self.value.is_integer() else str(self.value)
+        if self.op == "square":
+            assert self.left is not None
+            return f"square({self.left.text()})"
+        assert self.left is not None and self.right is not None
+        symbol = {"add": "+", "sub": "-", "mul": "*"}[self.op]
+        return f"({self.left.text()} {symbol} {self.right.text()})"
+
+    def canonical(self) -> str:
+        if self.op in {"x", "const"}:
+            return self.text()
+        if self.op == "square":
+            assert self.left is not None
+            return f"square:{self.left.canonical()}"
+        assert self.left is not None and self.right is not None
+        left = self.left.canonical()
+        right = self.right.canonical()
+        if self.op in {"add", "mul"} and right < left:
+            left, right = right, left
+        return f"{self.op}:{left}:{right}"
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    expression: Expr
+    mse: float
+    baseline_mse: float
+    improvement_ratio: float
+    evaluated_candidates: int
+
+    @property
+    def human_interpretable(self) -> bool:
+        return True
+
+
+def _mse(expr: Expr, samples: list[tuple[float, float]]) -> float:
+    total = 0.0
+    for x, target in samples:
+        try:
+            observed = expr.evaluate(x)
+        except (OverflowError, ZeroDivisionError, ValueError):
+            return float("inf")
+        if not isfinite(observed):
+            return float("inf")
+        delta = observed - target
+        total += delta * delta
+    return total / max(len(samples), 1)
+
+
+def _rank_key(expr: Expr, samples: list[tuple[float, float]]) -> tuple[float, int, str]:
+    return (_mse(expr, samples), expr.complexity(), expr.canonical())
+
+
+def discover_expression(
+    samples: Iterable[tuple[float, float]],
+    *,
+    constants: tuple[int, ...] = (-2, -1, 0, 1, 2),
+    max_depth: int = 2,
+    beam_width: int = 256,
+) -> DiscoveryResult:
+    """Deterministic bounded symbolic search for interpretable arithmetic rules.
+
+    This is a research kernel for synthetic discovery benchmarks. It is not
+    evidence of state-of-the-art algorithm discovery or DARPA SPEED DIAL D2P2
+    qualification.
+    """
+    data = [(float(x), float(y)) for x, y in samples]
+    if not data:
+        raise ValueError("at least one sample is required")
+
+    x_expr = Expr("x")
+    terminals = [x_expr] + [Expr("const", value=float(c)) for c in constants]
+    baseline_mse = _mse(x_expr, data)
+    pool: dict[str, Expr] = {expr.canonical(): expr for expr in terminals}
+    evaluated: set[str] = set(pool)
+    frontier = list(pool.values())
+
+    for _depth in range(max_depth):
+        candidates: dict[str, Expr] = dict(pool)
+        for expr in frontier:
+            squared = Expr("square", left=expr)
+            candidates[squared.canonical()] = squared
+
+        base = list(pool.values())
+        for left in frontier:
+            for right in base:
+                for op in ("add", "sub", "mul"):
+                    candidate = Expr(op, left=left, right=right)
+                    candidates[candidate.canonical()] = candidate
+
+        ranked = sorted(candidates.values(), key=lambda expr: _rank_key(expr, data))
+        pool = {expr.canonical(): expr for expr in ranked[:beam_width]}
+        frontier = list(pool.values())
+        evaluated.update(candidates)
+
+    best = min(pool.values(), key=lambda expr: _rank_key(expr, data))
+    best_mse = _mse(best, data)
+    if baseline_mse == 0.0:
+        improvement = 1.0 if best_mse == 0.0 else 0.0
+    elif best_mse == 0.0:
+        improvement = float("inf")
+    else:
+        improvement = baseline_mse / best_mse
+
+    return DiscoveryResult(
+        expression=best,
+        mse=best_mse,
+        baseline_mse=baseline_mse,
+        improvement_ratio=improvement,
+        evaluated_candidates=len(evaluated),
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ade_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ade_qualification.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .ade import discover_expression
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_synthetic_discovery(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    search = fixture["search"]
+    result = discover_expression(
+        fixture["problem"]["samples"],
+        constants=tuple(int(value) for value in search["constants"]),
+        max_depth=int(search["max_depth"]),
+        beam_width=int(search["beam_width"]),
+    )
+    expected = fixture["expected"]
+    improved = result.mse < result.baseline_mse
+    passed = (
+        result.mse <= float(expected["mse_max"])
+        and result.human_interpretable is bool(expected["human_interpretable"])
+        and (improved if expected["must_improve_over_baseline"] else True)
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-4001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="ade_symbolic_discovery_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest(
+            {"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}
+        ),
+        configuration_digest=canonical_digest(fixture["search"]),
+        inputs=[{"samples": fixture["problem"]["samples"]}],
+        outputs=[
+            {
+                "expression": result.expression.text(),
+                "mse": result.mse,
+                "baseline_mse": result.baseline_mse,
+                "improvement_ratio": result.improvement_ratio,
+                "human_interpretable": result.human_interpretable,
+                "evaluated_candidates": result.evaluated_candidates,
+            }
+        ],
+        metrics=[
+            {"name": "mse", "value": result.mse, "target_max": expected["mse_max"]},
+            {"name": "baseline_mse", "value": result.baseline_mse},
+            {"name": "improved_over_baseline", "value": improved},
+            {"name": "human_interpretable", "value": result.human_interpretable},
+            {"name": "evaluated_candidates", "value": result.evaluated_candidates},
+        ],
+        uncertainty=[
+            {
+                "name": "generalization_to_real_engineering_discovery",
+                "state": "NOT_EVALUATED",
+            },
+            {
+                "name": "state_of_the_art_comparison",
+                "state": "NOT_EVALUATED",
+            },
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Bounded symbolic search discovered an interpretable zero-error rule that improved over the frozen baseline"
+            if passed
+            else "Bounded symbolic search did not satisfy the frozen synthetic discovery target"
+        ),
+        negative_evidence=[] if passed else [{"observed_mse": result.mse, "baseline_mse": result.baseline_mse}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = (
+        "Synthetic interpretable algorithm-discovery evidence only; no SOTA, novelty, scientific-discovery, or DARPA SPEED DIAL D2P2 eligibility claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .qualification import EvidenceGraph, EvidenceGraphEdge, EvidenceGraphNode
+
+
+@dataclass(frozen=True)
+class ApntDecision:
+    operational_state: str
+    confidence: float
+    recovery_options: tuple[str, ...]
+    rationale: tuple[str, ...]
+
+
+def derive_apnt_decision(source_state: dict[str, dict[str, Any]]) -> ApntDecision:
+    """Derive a bounded synthetic APNT-awareness state from normalized source health.
+
+    This is a demonstrator rule set, not a navigation solution or sensor-fusion algorithm.
+    It intentionally produces operator-awareness/recovery metadata only.
+    """
+    gnss = source_state.get("gnss_primary", {})
+    ins = source_state.get("ins_primary", {})
+    alt = source_state.get("alt_pnt_1", {})
+
+    gnss_conf = float(gnss.get("confidence", 0.0))
+    ins_conf = float(ins.get("confidence", 0.0))
+    alt_conf = float(alt.get("confidence", 0.0))
+    gnss_health = str(gnss.get("health", "UNKNOWN"))
+
+    rationale: list[str] = []
+    recovery: list[str] = []
+
+    if gnss_health in {"UNTRUSTED", "DENIED"} or gnss_conf < 0.25:
+        state = "GNSS_DENIED"
+        rationale.append("primary GNSS confidence is below trusted-use threshold")
+        recovery.extend(["exclude_gnss", "fuse_ins_alt_pnt", "request_operator_approval"])
+        confidence = max(ins_conf, alt_conf)
+    elif gnss_health in {"DEGRADED"} or gnss_conf < 0.70:
+        state = "DEGRADED_PNT"
+        rationale.append("primary GNSS is degraded or below nominal confidence")
+        recovery.extend(["weight_ins_more", "enable_alt_pnt_cross_check", "alert_operator"])
+        confidence = max(gnss_conf, ins_conf, alt_conf)
+    elif gnss_health == "RECOVERING":
+        state = "RECOVERY"
+        rationale.append("primary GNSS is recovering and requires cross-validation")
+        recovery.extend(["cross_validate_gnss_before_reentry", "retain_alt_pnt", "operator_review"])
+        confidence = max(ins_conf, alt_conf)
+    else:
+        state = "NORMAL"
+        rationale.append("normalized source set is within nominal demonstrator thresholds")
+        confidence = max(gnss_conf, ins_conf, alt_conf)
+
+    return ApntDecision(
+        operational_state=state,
+        confidence=round(confidence, 4),
+        recovery_options=tuple(recovery),
+        rationale=tuple(rationale),
+    )
+
+
+def apnt_snapshot_graph(
+    *,
+    graph_id: str,
+    source_state: dict[str, dict[str, Any]],
+    decision: ApntDecision,
+) -> EvidenceGraph:
+    nodes: list[EvidenceGraphNode] = []
+    edges: list[EvidenceGraphEdge] = []
+
+    for source_id, state in sorted(source_state.items()):
+        node_id = f"source:{source_id}"
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=node_id,
+                node_type="apnt_source_state",
+                label=source_id,
+                confidence=float(state.get("confidence", 0.0)),
+                attributes=dict(state),
+            )
+        )
+
+    nodes.extend(
+        [
+            EvidenceGraphNode(
+                node_id="derived:operational_state",
+                node_type="derived_state",
+                label=decision.operational_state,
+                confidence=decision.confidence,
+                attributes={"rationale": list(decision.rationale)},
+            ),
+            EvidenceGraphNode(
+                node_id="policy:recovery_options",
+                node_type="policy_candidate_set",
+                label="recovery options",
+                attributes={"options": list(decision.recovery_options)},
+            ),
+        ]
+    )
+
+    for source_id in sorted(source_state):
+        edges.append(
+            EvidenceGraphEdge(
+                edge_id=f"edge:{source_id}:state",
+                source_node_id=f"source:{source_id}",
+                target_node_id="derived:operational_state",
+                relation="contributes_to",
+            )
+        )
+
+    edges.append(
+        EvidenceGraphEdge(
+            edge_id="edge:state:recovery",
+            source_node_id="derived:operational_state",
+            target_node_id="policy:recovery_options",
+            relation="informs",
+        )
+    )
+    return EvidenceGraph(graph_id=graph_id, nodes=nodes, edges=edges)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt.py
@@ -37,16 +37,16 @@ def derive_apnt_decision(source_state: dict[str, dict[str, Any]]) -> ApntDecisio
         rationale.append("primary GNSS confidence is below trusted-use threshold")
         recovery.extend(["exclude_gnss", "fuse_ins_alt_pnt", "request_operator_approval"])
         confidence = max(ins_conf, alt_conf)
-    elif gnss_health in {"DEGRADED"} or gnss_conf < 0.70:
-        state = "DEGRADED_PNT"
-        rationale.append("primary GNSS is degraded or below nominal confidence")
-        recovery.extend(["weight_ins_more", "enable_alt_pnt_cross_check", "alert_operator"])
-        confidence = max(gnss_conf, ins_conf, alt_conf)
     elif gnss_health == "RECOVERING":
         state = "RECOVERY"
         rationale.append("primary GNSS is recovering and requires cross-validation")
         recovery.extend(["cross_validate_gnss_before_reentry", "retain_alt_pnt", "operator_review"])
         confidence = max(ins_conf, alt_conf)
+    elif gnss_health == "DEGRADED" or gnss_conf < 0.70:
+        state = "DEGRADED_PNT"
+        rationale.append("primary GNSS is degraded or below nominal confidence")
+        recovery.extend(["weight_ins_more", "enable_alt_pnt_cross_check", "alert_operator"])
+        confidence = max(gnss_conf, ins_conf, alt_conf)
     else:
         state = "NORMAL"
         rationale.append("normalized source set is within nominal demonstrator thresholds")
@@ -70,10 +70,9 @@ def apnt_snapshot_graph(
     edges: list[EvidenceGraphEdge] = []
 
     for source_id, state in sorted(source_state.items()):
-        node_id = f"source:{source_id}"
         nodes.append(
             EvidenceGraphNode(
-                node_id=node_id,
+                node_id=f"source:{source_id}",
                 node_type="apnt_source_state",
                 label=source_id,
                 confidence=float(state.get("confidence", 0.0)),

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_adapter.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_adapter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+
+class NormalizedPntSource(BaseModel):
+    source_id: str = Field(min_length=1)
+    source_kind: str = Field(min_length=1)
+    health: str = Field(min_length=1)
+    confidence: float = Field(ge=0.0, le=1.0)
+    observed_utc: str | None = None
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class PntSourceAdapter(Protocol):
+    adapter_name: str
+
+    def normalize(self, payload: dict[str, Any]) -> NormalizedPntSource:
+        ...
+
+
+class SyntheticPntAdapter:
+    """Adapter for frozen synthetic fixtures only.
+
+    It intentionally does not implement ASPN, pntOS, GPNTS, or any government
+    interface. Those integrations remain separate validation work.
+    """
+
+    adapter_name = "synthetic_fixture_v1"
+
+    def normalize(self, payload: dict[str, Any]) -> NormalizedPntSource:
+        return NormalizedPntSource(
+            source_id=str(payload["source_id"]),
+            source_kind=str(payload["source_kind"]),
+            health=str(payload["health"]),
+            confidence=float(payload["confidence"]),
+            observed_utc=payload.get("observed_utc"),
+            attributes=dict(payload.get("attributes", {})),
+        )
+
+
+class AspnMappingStub:
+    """Non-operational mapping contract for future ASPN/pntOS work.
+
+    This class documents the normalized fields Worldshepherd expects from a
+    future adapter but raises until an actual interface mapping is implemented
+    and validated with authoritative schema/data.
+    """
+
+    adapter_name = "aspn_mapping_stub"
+
+    required_normalized_fields = (
+        "source_id",
+        "source_kind",
+        "health",
+        "confidence",
+        "observed_utc",
+    )
+
+    def normalize(self, payload: dict[str, Any]) -> NormalizedPntSource:
+        raise NotImplementedError(
+            "ASPN/pntOS mapping is not implemented or validated; use authoritative interface definitions before enabling"
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_interface_contract.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_interface_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .apnt_adapter import NormalizedPntSource
+from .qualification import canonical_digest
+
+
+class AuthoritativeInterfaceContract(BaseModel):
+    contract_id: str = Field(min_length=1)
+    interface_name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    authoritative_spec_ref: str = Field(min_length=1)
+    authoritative_spec_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    field_mapping: dict[str, str] = Field(default_factory=dict)
+    validated_fields: list[str] = Field(default_factory=list)
+    partner_validation_ref: str | None = None
+    enabled: bool = False
+
+    @model_validator(mode="after")
+    def enabling_requires_minimum_mapping(self) -> "AuthoritativeInterfaceContract":
+        required = {"source_id", "source_kind", "health", "confidence"}
+        if self.enabled:
+            if not required.issubset(self.field_mapping):
+                raise ValueError("enabled APNT interface contract lacks required normalized field mapping")
+            if not required.issubset(set(self.validated_fields)):
+                raise ValueError("enabled APNT interface contract lacks validation evidence for required fields")
+        return self
+
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+
+class ContractPntAdapter:
+    """Map an external payload only through an explicit authoritative contract.
+
+    The adapter refuses to run until the contract has authoritative spec identity,
+    required field mappings, and explicit validation markers. This does not itself
+    prove ASPN/pntOS/GPNTS interoperability or partner/platform acceptance.
+    """
+
+    def __init__(self, contract: AuthoritativeInterfaceContract) -> None:
+        if not contract.enabled:
+            raise ValueError("interface contract is not enabled")
+        self.contract = contract
+        self.adapter_name = f"contract:{contract.contract_id}"
+
+    def normalize(self, payload: dict[str, Any]) -> NormalizedPntSource:
+        mapping = self.contract.field_mapping
+        missing = [external for external in mapping.values() if external not in payload]
+        if missing:
+            raise ValueError(f"external payload missing contracted fields: {sorted(missing)}")
+        return NormalizedPntSource(
+            source_id=str(payload[mapping["source_id"]]),
+            source_kind=str(payload[mapping["source_kind"]]),
+            health=str(payload[mapping["health"]]),
+            confidence=float(payload[mapping["confidence"]]),
+            observed_utc=(
+                str(payload[mapping["observed_utc"]])
+                if mapping.get("observed_utc") and mapping["observed_utc"] in payload
+                else None
+            ),
+            attributes={
+                "contract_id": self.contract.contract_id,
+                "contract_digest": self.contract.digest(),
+                "authoritative_spec_ref": self.contract.authoritative_spec_ref,
+            },
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_qualification.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .apnt import apnt_snapshot_graph, derive_apnt_decision
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_synthetic_apnt_timeline(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    """Evaluate the frozen synthetic APNT timeline and compile replayable evidence."""
+    evidence: list[QualificationEvidenceRecord] = []
+    last_graph = None
+
+    env_digest = canonical_digest({"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]})
+    config_digest = canonical_digest({"model": "bounded_apnt_awareness_v1"})
+
+    for index, point in enumerate(fixture["timeline"], start=1):
+        decision = derive_apnt_decision(point["source_state"])
+        expected = point["expected_operational_state"]
+        passed = decision.operational_state == expected
+        last_graph = apnt_snapshot_graph(
+            graph_id=f"{fixture['fixture_id']}:t{point['t_seconds']}",
+            source_state=point["source_state"],
+            decision=decision,
+        )
+        evidence.append(
+            QualificationEvidenceRecord(
+                qualification_id=f"WS-QE-2026-{index:04d}",
+                requirement_id=requirement.requirement_delta_id,
+                test_id=f"apnt_state_t{point['t_seconds']}",
+                evidence_scope=EvidenceScope.SOFTWARE,
+                capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+                environment_digest=env_digest,
+                configuration_digest=config_digest,
+                inputs=[{"source_state": point["source_state"]}],
+                outputs=[{"operational_state": decision.operational_state, "recovery_options": list(decision.recovery_options)}],
+                metrics=[{"name": "state_match", "value": 1 if passed else 0, "expected": expected}],
+                uncertainty=[{"name": "physical_validity", "state": "NOT_EVALUATED"}],
+                result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+                rationale="Synthetic bounded-awareness state matched frozen expectation" if passed else "Synthetic bounded-awareness state did not match frozen expectation",
+                negative_evidence=[] if passed else [{"expected": expected, "observed": decision.operational_state}],
+                software_commit=software_commit,
+                executed_utc=executed_utc,
+                operator=operator,
+                physical_validation_performed=False,
+            )
+        )
+
+    bundle = compile_qualification_bundle(requirement, evidence, last_graph)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = "Synthetic software qualification only; no physical APNT or Navy operational claim."
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_qualification.py
@@ -26,7 +26,12 @@ def qualify_synthetic_apnt_timeline(
     evidence: list[QualificationEvidenceRecord] = []
     last_graph = None
 
-    env_digest = canonical_digest({"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]})
+    env_digest = canonical_digest(
+        {
+            "fixture_id": fixture["fixture_id"],
+            "classification": fixture["classification"],
+        }
+    )
     config_digest = canonical_digest({"model": "bounded_apnt_awareness_v1"})
 
     for index, point in enumerate(fixture["timeline"], start=1):
@@ -48,12 +53,38 @@ def qualify_synthetic_apnt_timeline(
                 environment_digest=env_digest,
                 configuration_digest=config_digest,
                 inputs=[{"source_state": point["source_state"]}],
-                outputs=[{"operational_state": decision.operational_state, "recovery_options": list(decision.recovery_options)}],
-                metrics=[{"name": "state_match", "value": 1 if passed else 0, "expected": expected}],
-                uncertainty=[{"name": "physical_validity", "state": "NOT_EVALUATED"}],
+                outputs=[
+                    {
+                        "operational_state": decision.operational_state,
+                        "recovery_options": list(decision.recovery_options),
+                    }
+                ],
+                metrics=[
+                    {
+                        "name": "state_match",
+                        "value": 1 if passed else 0,
+                        "expected": expected,
+                    }
+                ],
+                uncertainty=[
+                    {"name": "physical_validity", "state": "NOT_EVALUATED"}
+                ],
                 result=ResultStatus.PASS if passed else ResultStatus.FAIL,
-                rationale="Synthetic bounded-awareness state matched frozen expectation" if passed else "Synthetic bounded-awareness state did not match frozen expectation",
-                negative_evidence=[] if passed else [{"expected": expected, "observed": decision.operational_state}],
+                rationale=(
+                    "Synthetic bounded-awareness state matched frozen expectation"
+                    if passed
+                    else "Synthetic bounded-awareness state did not match frozen expectation"
+                ),
+                negative_evidence=(
+                    []
+                    if passed
+                    else [
+                        {
+                            "expected": expected,
+                            "observed": decision.operational_state,
+                        }
+                    ]
+                ),
                 software_commit=software_commit,
                 executed_utc=executed_utc,
                 operator=operator,
@@ -62,6 +93,10 @@ def qualify_synthetic_apnt_timeline(
         )
 
     bundle = compile_qualification_bundle(requirement, evidence, last_graph)
+    bundle.pop("bundle_digest", None)
     bundle["fixture_id"] = fixture["fixture_id"]
-    bundle["scope_note"] = "Synthetic software qualification only; no physical APNT or Navy operational claim."
+    bundle["scope_note"] = (
+        "Synthetic software qualification only; no physical APNT or Navy operational claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
     return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/apnt_qualification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .apnt import apnt_snapshot_graph, derive_apnt_decision
+from .prime import ActionProposal
 from .qualification import (
     CapabilityStatus,
     EvidenceScope,
@@ -24,6 +25,7 @@ def qualify_synthetic_apnt_timeline(
 ) -> dict[str, Any]:
     """Evaluate the frozen synthetic APNT timeline and compile replayable evidence."""
     evidence: list[QualificationEvidenceRecord] = []
+    proposals: list[dict[str, Any]] = []
     last_graph = None
 
     env_digest = canonical_digest(
@@ -43,6 +45,15 @@ def qualify_synthetic_apnt_timeline(
             source_state=point["source_state"],
             decision=decision,
         )
+        for action_index, action in enumerate(decision.recovery_options, start=1):
+            proposals.append(
+                ActionProposal(
+                    proposal_id=f"APNT-{point['t_seconds']}-{action_index}",
+                    action=action,
+                    rationale=list(decision.rationale),
+                    authority_required="identified-human-authority",
+                ).model_dump(mode="json")
+            )
         evidence.append(
             QualificationEvidenceRecord(
                 qualification_id=f"WS-QE-2026-{index:04d}",
@@ -95,8 +106,9 @@ def qualify_synthetic_apnt_timeline(
     bundle = compile_qualification_bundle(requirement, evidence, last_graph)
     bundle.pop("bundle_digest", None)
     bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["prime_action_proposals"] = proposals
     bundle["scope_note"] = (
-        "Synthetic software qualification only; no physical APNT or Navy operational claim."
+        "Synthetic software qualification only; recovery options remain PROPOSED until identified human review; no physical APNT or Navy operational claim."
     )
     bundle["bundle_digest"] = canonical_digest(bundle)
     return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/autonomy_policy.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/autonomy_policy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from enum import Enum
+from pydantic import BaseModel, Field
+
+
+class ExecutionDisposition(str, Enum):
+    AUTO_ELIGIBLE = "AUTO_ELIGIBLE"
+    HUMAN_REVIEW_REQUIRED = "HUMAN_REVIEW_REQUIRED"
+    DENIED = "DENIED"
+
+
+class AutonomousActionCandidate(BaseModel):
+    action_id: str = Field(min_length=1)
+    action_type: str = Field(min_length=1)
+    confidence: float = Field(ge=0.0, le=1.0)
+    requested_authority: int = Field(ge=0)
+    reversible: bool
+    payload: dict = Field(default_factory=dict)
+
+
+class AutonomyPolicy(BaseModel):
+    policy_id: str = Field(min_length=1)
+    allowed_auto_action_types: list[str] = Field(default_factory=list)
+    denied_action_types: list[str] = Field(default_factory=list)
+    minimum_auto_confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    maximum_auto_authority: int = Field(default=0, ge=0)
+    require_reversible_for_auto: bool = True
+
+
+def evaluate_candidate(
+    candidate: AutonomousActionCandidate, policy: AutonomyPolicy
+) -> tuple[ExecutionDisposition, list[str]]:
+    reasons: list[str] = []
+
+    if candidate.action_type in policy.denied_action_types:
+        return ExecutionDisposition.DENIED, ["action type explicitly denied by policy"]
+
+    if candidate.action_type not in policy.allowed_auto_action_types:
+        reasons.append("action type is not in automatic-execution allowlist")
+    if candidate.confidence < policy.minimum_auto_confidence:
+        reasons.append("candidate confidence is below automatic-execution threshold")
+    if candidate.requested_authority > policy.maximum_auto_authority:
+        reasons.append("requested authority exceeds automatic-execution ceiling")
+    if policy.require_reversible_for_auto and not candidate.reversible:
+        reasons.append("automatic execution requires reversible action")
+
+    if reasons:
+        return ExecutionDisposition.HUMAN_REVIEW_REQUIRED, reasons
+    return ExecutionDisposition.AUTO_ELIGIBLE, ["candidate satisfies all bounded automatic-execution policy gates"]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/cbm_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/cbm_qualification.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .cbm_twin import ExpectedEnvelope, TelemetrySample, evaluate_series, health_graph
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_synthetic_cbm(
+    *, fixture: dict[str, Any], requirement: RequirementDeltaRecord,
+    software_commit: str, executed_utc: str, operator: str,
+) -> dict[str, Any]:
+    envelopes = {
+        item["metric"]: ExpectedEnvelope.model_validate(item)
+        for item in fixture["expected_envelopes"]
+    }
+    samples = [TelemetrySample.model_validate(item) for item in fixture["telemetry"]]
+    findings = evaluate_series(samples, envelopes)
+    graph = health_graph(graph_id=fixture["fixture_id"], samples=samples, findings=findings)
+    statuses = [finding.status for finding in findings]
+    anomaly_count = sum(1 for status in statuses if status != "NOMINAL")
+    traceable = all(edge.source_ref for edge in graph.edges)
+    expected = fixture["expected"]
+    passed = (
+        statuses == expected["finding_statuses"]
+        and anomaly_count == int(expected["anomaly_count"])
+        and traceable is bool(expected["all_findings_traceable"])
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-8001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="cbm_twin_synthetic_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest({"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}),
+        configuration_digest=canonical_digest({"expected_envelopes": fixture["expected_envelopes"]}),
+        inputs=[{"telemetry_count": len(samples), "asset_id": fixture["asset_id"]}],
+        outputs=[{"statuses": statuses, "anomaly_count": anomaly_count, "traceable": traceable}],
+        metrics=[
+            {"name": "anomaly_count", "value": anomaly_count, "expected": expected["anomaly_count"]},
+            {"name": "all_findings_traceable", "value": traceable},
+        ],
+        uncertainty=[
+            {"name": "predictive_maintenance_validity", "state": "NOT_EVALUATED"},
+            {"name": "remaining_useful_life", "state": "NOT_EVALUATED"},
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=("Synthetic envelope-based asset health classification met frozen expectations" if passed else "Synthetic asset health classification diverged from frozen expectations"),
+        negative_evidence=[] if passed else [{"expected": expected, "observed_statuses": statuses, "anomaly_count": anomaly_count}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence], graph)
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = "Synthetic telemetry/envelope CBM+ evidence only; no real platform, predictive-maintenance, RUL, or fleet-effectiveness claim."
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/cbm_twin.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/cbm_twin.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .qualification import EvidenceGraph, EvidenceGraphEdge, EvidenceGraphNode
+
+
+class ExpectedEnvelope(BaseModel):
+    metric: str = Field(min_length=1)
+    minimum: float
+    maximum: float
+    units: str | None = None
+
+
+class TelemetrySample(BaseModel):
+    sample_id: str = Field(min_length=1)
+    asset_id: str = Field(min_length=1)
+    metric: str = Field(min_length=1)
+    value: float
+    t_seconds: float = Field(ge=0)
+    source_ref: str = Field(min_length=1)
+
+
+@dataclass(frozen=True)
+class HealthFinding:
+    sample_id: str
+    asset_id: str
+    metric: str
+    status: str
+    deviation: float
+    expected_minimum: float
+    expected_maximum: float
+
+
+def evaluate_sample(sample: TelemetrySample, envelope: ExpectedEnvelope) -> HealthFinding:
+    if sample.metric != envelope.metric:
+        raise ValueError("sample metric and envelope metric must match")
+    if envelope.minimum > envelope.maximum:
+        raise ValueError("envelope minimum cannot exceed maximum")
+    if sample.value < envelope.minimum:
+        status = "LOW"
+        deviation = envelope.minimum - sample.value
+    elif sample.value > envelope.maximum:
+        status = "HIGH"
+        deviation = sample.value - envelope.maximum
+    else:
+        status = "NOMINAL"
+        deviation = 0.0
+    return HealthFinding(
+        sample_id=sample.sample_id,
+        asset_id=sample.asset_id,
+        metric=sample.metric,
+        status=status,
+        deviation=deviation,
+        expected_minimum=envelope.minimum,
+        expected_maximum=envelope.maximum,
+    )
+
+
+def evaluate_series(
+    samples: list[TelemetrySample], envelopes: dict[str, ExpectedEnvelope]
+) -> tuple[HealthFinding, ...]:
+    findings: list[HealthFinding] = []
+    for sample in sorted(samples, key=lambda item: (item.t_seconds, item.sample_id)):
+        if sample.metric not in envelopes:
+            raise KeyError(f"no expected envelope for metric {sample.metric}")
+        findings.append(evaluate_sample(sample, envelopes[sample.metric]))
+    return tuple(findings)
+
+
+def health_graph(
+    *, graph_id: str, samples: list[TelemetrySample], findings: tuple[HealthFinding, ...]
+) -> EvidenceGraph:
+    nodes: list[EvidenceGraphNode] = []
+    edges: list[EvidenceGraphEdge] = []
+    for sample in samples:
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=f"sample:{sample.sample_id}",
+                node_type="telemetry_sample",
+                label=f"{sample.asset_id}:{sample.metric}",
+                source_ref=sample.source_ref,
+                attributes=sample.model_dump(mode="json"),
+            )
+        )
+    for index, finding in enumerate(findings, start=1):
+        finding_id = f"health:{index:04d}"
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=finding_id,
+                node_type="cbm_health_finding",
+                label=finding.status,
+                attributes={
+                    "asset_id": finding.asset_id,
+                    "metric": finding.metric,
+                    "deviation": finding.deviation,
+                    "expected_minimum": finding.expected_minimum,
+                    "expected_maximum": finding.expected_maximum,
+                },
+            )
+        )
+        edges.append(
+            EvidenceGraphEdge(
+                edge_id=f"edge:{finding.sample_id}:{index}",
+                source_node_id=f"sample:{finding.sample_id}",
+                target_node_id=finding_id,
+                relation="supports_health_finding",
+                source_ref=f"sample:{finding.sample_id}",
+                confidence=1.0,
+            )
+        )
+    return EvidenceGraph(graph_id=graph_id, nodes=nodes, edges=edges)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/common_services.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/common_services.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ServiceManifest(BaseModel):
+    service_id: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    interface_version: str = Field(min_length=1)
+    software_digest: str = Field(min_length=1)
+    sbom_digest: str | None = None
+    required_authority: str = Field(min_length=1)
+    health_endpoint: str | None = None
+
+
+class AdapterManifest(BaseModel):
+    adapter_id: str = Field(min_length=1)
+    platform_family: str = Field(min_length=1)
+    interface_version: str = Field(min_length=1)
+    software_digest: str = Field(min_length=1)
+    validation_state: str = "UNVALIDATED"
+
+
+class MissionEnclaveRegistry:
+    """In-memory contract registry for trusted-core prototype work only."""
+
+    def __init__(self) -> None:
+        self._services: dict[str, ServiceManifest] = {}
+        self._adapters: dict[str, AdapterManifest] = {}
+        self._service_history: dict[str, list[ServiceManifest]] = {}
+
+    def register_service(self, manifest: ServiceManifest) -> None:
+        current = self._services.get(manifest.service_id)
+        if current is not None:
+            self._service_history.setdefault(manifest.service_id, []).append(current)
+        self._services[manifest.service_id] = manifest
+
+    def register_adapter(self, manifest: AdapterManifest) -> None:
+        self._adapters[manifest.adapter_id] = manifest
+
+    def service(self, service_id: str) -> ServiceManifest:
+        if service_id not in self._services:
+            raise KeyError(service_id)
+        return self._services[service_id]
+
+    def adapter(self, adapter_id: str) -> AdapterManifest:
+        if adapter_id not in self._adapters:
+            raise KeyError(adapter_id)
+        return self._adapters[adapter_id]
+
+    def rollback_service(self, service_id: str) -> ServiceManifest:
+        history = self._service_history.get(service_id, [])
+        if not history:
+            raise ValueError(f"no rollback state available for {service_id}")
+        prior = history.pop()
+        current = self._services[service_id]
+        self._service_history.setdefault(service_id, []).append(current)
+        self._services[service_id] = prior
+        return prior
+
+    def snapshot(self) -> dict[str, object]:
+        return {
+            "services": {
+                key: value.model_dump(mode="json")
+                for key, value in sorted(self._services.items())
+            },
+            "adapters": {
+                key: value.model_dump(mode="json")
+                for key, value in sorted(self._adapters.items())
+            },
+        }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/common_services_persistent.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/common_services_persistent.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .common_services import AdapterManifest, ServiceManifest
+from .models import AuditRecord
+from .storage import DurableStore
+
+
+_REGISTRY_KEY = "worldshepherd_common_services_v1"
+
+
+class PersistentMissionEnclaveRegistry:
+    """Durable Common Services/adapter registry using SARA's secured store.
+
+    This provides local persistence and audit integration only. It is not a
+    platform certification authority, software factory, or government registry.
+    """
+
+    def __init__(self, store: DurableStore) -> None:
+        self.store = store
+
+    def _state(self) -> dict[str, Any]:
+        registry = self.store.get_registry()
+        value = registry.get(_REGISTRY_KEY, {})
+        if not isinstance(value, dict):
+            raise ValueError("persistent common-services registry must be an object")
+        return {
+            "services": dict(value.get("services", {})),
+            "adapters": dict(value.get("adapters", {})),
+            "service_history": dict(value.get("service_history", {})),
+        }
+
+    def _write(self, state: dict[str, Any], *, event: str, payload: dict[str, Any]) -> None:
+        self.store.patch_registry({_REGISTRY_KEY: state})
+        self.store.append_audit(AuditRecord.create(event=event, actor="system", payload=payload))
+
+    def register_service(self, manifest: ServiceManifest) -> None:
+        state = self._state()
+        service_id = manifest.service_id
+        current = state["services"].get(service_id)
+        if current is not None:
+            state["service_history"].setdefault(service_id, []).append(current)
+        state["services"][service_id] = manifest.model_dump(mode="json")
+        self._write(
+            state,
+            event="common_service_registered",
+            payload={"service_id": service_id, "version": manifest.version},
+        )
+
+    def register_adapter(self, manifest: AdapterManifest) -> None:
+        state = self._state()
+        state["adapters"][manifest.adapter_id] = manifest.model_dump(mode="json")
+        self._write(
+            state,
+            event="common_adapter_registered",
+            payload={"adapter_id": manifest.adapter_id, "platform_family": manifest.platform_family},
+        )
+
+    def service(self, service_id: str) -> ServiceManifest:
+        state = self._state()
+        if service_id not in state["services"]:
+            raise KeyError(service_id)
+        return ServiceManifest.model_validate(state["services"][service_id])
+
+    def adapter(self, adapter_id: str) -> AdapterManifest:
+        state = self._state()
+        if adapter_id not in state["adapters"]:
+            raise KeyError(adapter_id)
+        return AdapterManifest.model_validate(state["adapters"][adapter_id])
+
+    def rollback_service(self, service_id: str) -> ServiceManifest:
+        state = self._state()
+        history = state["service_history"].get(service_id, [])
+        if not history:
+            raise ValueError(f"no rollback state available for {service_id}")
+        prior = history.pop()
+        current = state["services"][service_id]
+        history.append(current)
+        state["service_history"][service_id] = history
+        state["services"][service_id] = prior
+        manifest = ServiceManifest.model_validate(prior)
+        self._write(
+            state,
+            event="common_service_rolled_back",
+            payload={"service_id": service_id, "version": manifest.version},
+        )
+        return manifest
+
+    def snapshot(self) -> dict[str, Any]:
+        return self._state()

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/compliance.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/compliance.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ControlEvidenceState(str, Enum):
+    UNKNOWN = "UNKNOWN"
+    PRESENT = "PRESENT"
+    GAP = "GAP"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class ControlEvidence(BaseModel):
+    control_id: str = Field(min_length=1)
+    state: ControlEvidenceState = ControlEvidenceState.UNKNOWN
+    evidence_refs: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+    @model_validator(mode="after")
+    def present_requires_evidence(self) -> "ControlEvidence":
+        if self.state == ControlEvidenceState.PRESENT and not self.evidence_refs:
+            raise ValueError("PRESENT control evidence requires at least one evidence reference")
+        return self
+
+
+class ComplianceReadinessProfile(BaseModel):
+    framework: str = Field(min_length=1)
+    assessment_status: str = "UNKNOWN"
+    controls: list[ControlEvidence] = Field(default_factory=list)
+    authoritative_assessment_ref: str | None = None
+
+    def gap_summary(self) -> dict[str, int]:
+        counts = {state.value: 0 for state in ControlEvidenceState}
+        for control in self.controls:
+            counts[control.state.value] += 1
+        return counts
+
+    def externally_validated(self) -> bool:
+        return (
+            self.assessment_status == "AUTHORITATIVE_VALIDATED"
+            and bool(self.authoritative_assessment_ref)
+        )
+
+    def claims_boundary(self) -> str:
+        if self.externally_validated():
+            return "Authoritative assessment reference is recorded; scope and currency still govern any external claim."
+        return "Readiness evidence only. No CMMC/NIST 800-171 compliance, certification, SPRS score, or government authorization is claimed."

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .qualification import canonical_digest
+
+
+@dataclass(frozen=True)
+class ConfigurationSnapshot:
+    snapshot_id: str
+    parent_digest: str | None
+    payload: dict[str, Any]
+    created_utc: str
+    actor: str
+    reason: str
+    digest: str
+
+
+def create_snapshot(
+    *,
+    snapshot_id: str,
+    payload: dict[str, Any],
+    created_utc: str,
+    actor: str,
+    reason: str,
+    parent_digest: str | None = None,
+) -> ConfigurationSnapshot:
+    material = {
+        "snapshot_id": snapshot_id,
+        "parent_digest": parent_digest,
+        "payload": payload,
+        "created_utc": created_utc,
+        "actor": actor,
+        "reason": reason,
+    }
+    return ConfigurationSnapshot(
+        snapshot_id=snapshot_id,
+        parent_digest=parent_digest,
+        payload=payload,
+        created_utc=created_utc,
+        actor=actor,
+        reason=reason,
+        digest=canonical_digest(material),
+    )
+
+
+class ConfigurationCustodyLedger:
+    """Append-only in-memory configuration lineage model.
+
+    Persistence should be provided by SARA/ECHO storage. The ledger makes
+    version lineage explicit and detects broken parent references; it is not a
+    cryptographic signing service or external configuration-management authority.
+    """
+
+    def __init__(self) -> None:
+        self._snapshots: list[ConfigurationSnapshot] = []
+        self._by_digest: dict[str, ConfigurationSnapshot] = {}
+
+    def append(self, snapshot: ConfigurationSnapshot) -> None:
+        if snapshot.digest in self._by_digest:
+            if self._by_digest[snapshot.digest] != snapshot:
+                raise ValueError("digest collision or inconsistent snapshot")
+            return
+        if snapshot.parent_digest is not None and snapshot.parent_digest not in self._by_digest:
+            raise ValueError("parent configuration digest is not present in custody ledger")
+        if self._snapshots:
+            expected_parent = self._snapshots[-1].digest
+            if snapshot.parent_digest != expected_parent:
+                raise ValueError("new configuration snapshot must chain from current head")
+        elif snapshot.parent_digest is not None:
+            raise ValueError("first configuration snapshot cannot have a parent")
+        self._snapshots.append(snapshot)
+        self._by_digest[snapshot.digest] = snapshot
+
+    def head(self) -> ConfigurationSnapshot | None:
+        return self._snapshots[-1] if self._snapshots else None
+
+    def snapshot(self, digest: str) -> ConfigurationSnapshot:
+        if digest not in self._by_digest:
+            raise KeyError(digest)
+        return self._by_digest[digest]
+
+    def verify_chain(self) -> bool:
+        previous: str | None = None
+        for snapshot in self._snapshots:
+            if snapshot.parent_digest != previous:
+                return False
+            material = {
+                "snapshot_id": snapshot.snapshot_id,
+                "parent_digest": snapshot.parent_digest,
+                "payload": snapshot.payload,
+                "created_utc": snapshot.created_utc,
+                "actor": snapshot.actor,
+                "reason": snapshot.reason,
+            }
+            if snapshot.digest != canonical_digest(material):
+                return False
+            previous = snapshot.digest
+        return True
+
+    def rollback_snapshot(
+        self,
+        *,
+        target_digest: str,
+        snapshot_id: str,
+        created_utc: str,
+        actor: str,
+        reason: str,
+    ) -> ConfigurationSnapshot:
+        target = self.snapshot(target_digest)
+        head = self.head()
+        return create_snapshot(
+            snapshot_id=snapshot_id,
+            payload=dict(target.payload),
+            created_utc=created_utc,
+            actor=actor,
+            reason=reason,
+            parent_digest=head.digest if head else None,
+        )
+
+    def records(self) -> tuple[ConfigurationSnapshot, ...]:
+        return tuple(self._snapshots)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ddil.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ddil.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Envelope:
+    sequence: int
+    source: str
+    payload: dict[str, Any]
+    timestamp_ms: int
+
+
+@dataclass(frozen=True)
+class FaultProfile:
+    """Deterministic transport-fault profile for software qualification only."""
+
+    drop_sequences: frozenset[int] = frozenset()
+    duplicate_sequences: frozenset[int] = frozenset()
+    stale_sequences: frozenset[int] = frozenset()
+    added_latency_ms: int = 0
+    reorder_windows: tuple[tuple[int, int], ...] = ()
+
+
+@dataclass
+class FaultResult:
+    delivered: list[Envelope] = field(default_factory=list)
+    dropped: list[int] = field(default_factory=list)
+    duplicated: list[int] = field(default_factory=list)
+    stale: list[int] = field(default_factory=list)
+
+    def replay_signature(self) -> tuple[tuple[int, str, int], ...]:
+        return tuple((m.sequence, m.source, m.timestamp_ms) for m in self.delivered)
+
+
+def apply_fault_profile(messages: list[Envelope], profile: FaultProfile) -> FaultResult:
+    """Apply deterministic DDIL-like transport faults.
+
+    This models message delivery behavior only. It does not establish RF/link,
+    tactical-network, or operational DDIL performance.
+    """
+    result = FaultResult()
+    working: list[Envelope] = []
+
+    for message in messages:
+        if message.sequence in profile.drop_sequences:
+            result.dropped.append(message.sequence)
+            continue
+
+        timestamp = message.timestamp_ms + profile.added_latency_ms
+        payload = dict(message.payload)
+        if message.sequence in profile.stale_sequences:
+            payload["_ws_stale"] = True
+            result.stale.append(message.sequence)
+
+        delivered = Envelope(
+            sequence=message.sequence,
+            source=message.source,
+            payload=payload,
+            timestamp_ms=timestamp,
+        )
+        working.append(delivered)
+
+        if message.sequence in profile.duplicate_sequences:
+            working.append(delivered)
+            result.duplicated.append(message.sequence)
+
+    for start, end in profile.reorder_windows:
+        indexes = [i for i, item in enumerate(working) if start <= item.sequence <= end]
+        if indexes:
+            values = [working[i] for i in indexes][::-1]
+            for index, value in zip(indexes, values):
+                working[index] = value
+
+    result.delivered = working
+    return result

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ddil_campaign.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ddil_campaign.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .ddil import Envelope, FaultProfile, apply_fault_profile
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def _profiles() -> dict[str, FaultProfile]:
+    return {
+        "nominal": FaultProfile(),
+        "packet_loss": FaultProfile(drop_sequences=frozenset({2, 5})),
+        "latency": FaultProfile(added_latency_ms=250),
+        "reorder": FaultProfile(reorder_windows=((2, 4),)),
+        "stale_and_duplicate": FaultProfile(
+            stale_sequences=frozenset({3}), duplicate_sequences=frozenset({4})
+        ),
+    }
+
+
+def run_ddil_campaign(
+    *,
+    messages: list[Envelope],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    """Exercise deterministic message-fault handling and package internal evidence.
+
+    Passing this campaign proves only the software harness behaves reproducibly
+    against its synthetic fault profiles. It is not tactical-link or mission DDIL
+    validation.
+    """
+    evidence: list[QualificationEvidenceRecord] = []
+    base_digest = canonical_digest(
+        [
+            {
+                "sequence": m.sequence,
+                "source": m.source,
+                "payload": m.payload,
+                "timestamp_ms": m.timestamp_ms,
+            }
+            for m in messages
+        ]
+    )
+
+    for index, (name, profile) in enumerate(_profiles().items(), start=1):
+        first = apply_fault_profile(messages, profile)
+        second = apply_fault_profile(messages, profile)
+        deterministic = first.replay_signature() == second.replay_signature()
+        result = ResultStatus.PASS if deterministic else ResultStatus.FAIL
+        evidence.append(
+            QualificationEvidenceRecord(
+                qualification_id=f"WS-QE-2026-{1000 + index:04d}",
+                requirement_id=requirement.requirement_delta_id,
+                test_id=f"ddil_{name}",
+                evidence_scope=EvidenceScope.SOFTWARE,
+                capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+                environment_digest=canonical_digest({"campaign": "ddil_v1"}),
+                configuration_digest=canonical_digest(
+                    {
+                        "profile": name,
+                        "drop": sorted(profile.drop_sequences),
+                        "duplicate": sorted(profile.duplicate_sequences),
+                        "stale": sorted(profile.stale_sequences),
+                        "latency_ms": profile.added_latency_ms,
+                        "reorder_windows": profile.reorder_windows,
+                    }
+                ),
+                inputs=[{"message_set_digest": base_digest}],
+                outputs=[
+                    {
+                        "replay_signature": first.replay_signature(),
+                        "dropped": first.dropped,
+                        "duplicated": first.duplicated,
+                        "stale": first.stale,
+                    }
+                ],
+                metrics=[{"name": "deterministic_replay", "value": deterministic}],
+                uncertainty=[
+                    {"name": "operational_network_validity", "state": "NOT_EVALUATED"}
+                ],
+                result=result,
+                rationale=(
+                    "Synthetic fault profile replay was deterministic"
+                    if deterministic
+                    else "Synthetic fault profile replay diverged"
+                ),
+                negative_evidence=[] if deterministic else [{"profile": name}],
+                software_commit=software_commit,
+                executed_utc=executed_utc,
+                operator=operator,
+            )
+        )
+
+    bundle = compile_qualification_bundle(requirement, evidence)
+    bundle.pop("bundle_digest", None)
+    bundle["campaign"] = "DDIL_SYNTHETIC_V1"
+    bundle["scope_note"] = (
+        "Synthetic transport-fault qualification only; no RF, tactical network, or mission-readiness claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ddil_reconcile.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ddil_reconcile.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class ReconciliationState(str, Enum):
+    MERGED = "MERGED"
+    CONFLICT = "CONFLICT"
+    NO_CHANGE = "NO_CHANGE"
+
+
+@dataclass(frozen=True)
+class VersionedState:
+    key: str
+    value: Any
+    logical_clock: int
+    authority: int
+    source_node: str
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    key: str
+    state: ReconciliationState
+    selected: VersionedState | None
+    candidates: tuple[VersionedState, ...]
+    reason: str
+
+
+def reconcile_key(candidates: list[VersionedState]) -> ReconciliationResult:
+    """Reconcile one key while surfacing unresolved equal-authority divergence.
+
+    Policy:
+    1. newer logical clock wins over older state;
+    2. for equal clocks, higher explicit authority wins;
+    3. equal clock + equal authority + different values is a visible CONFLICT;
+    4. identical equal-priority values merge deterministically.
+
+    This is an internal software policy baseline, not an operational distributed
+    consensus or safety-certified conflict-resolution protocol.
+    """
+    if not candidates:
+        raise ValueError("at least one candidate is required")
+    keys = {item.key for item in candidates}
+    if len(keys) != 1:
+        raise ValueError("all candidates must share the same key")
+
+    ordered = sorted(
+        candidates,
+        key=lambda item: (item.logical_clock, item.authority, item.source_node),
+        reverse=True,
+    )
+    newest_clock = ordered[0].logical_clock
+    newest = [item for item in ordered if item.logical_clock == newest_clock]
+    highest_authority = max(item.authority for item in newest)
+    finalists = [item for item in newest if item.authority == highest_authority]
+
+    distinct_values = {repr(item.value) for item in finalists}
+    if len(distinct_values) > 1:
+        return ReconciliationResult(
+            key=ordered[0].key,
+            state=ReconciliationState.CONFLICT,
+            selected=None,
+            candidates=tuple(sorted(finalists, key=lambda item: item.source_node)),
+            reason="equal-clock equal-authority candidates disagree; human/policy resolution required",
+        )
+
+    selected = sorted(finalists, key=lambda item: item.source_node)[0]
+    if all(
+        item.logical_clock == selected.logical_clock
+        and item.authority == selected.authority
+        and item.value == selected.value
+        for item in candidates
+    ):
+        state = ReconciliationState.NO_CHANGE
+        reason = "all candidate states are equivalent"
+    else:
+        state = ReconciliationState.MERGED
+        reason = "selected newest/highest-authority non-conflicting state"
+    return ReconciliationResult(
+        key=selected.key,
+        state=state,
+        selected=selected,
+        candidates=tuple(sorted(candidates, key=lambda item: item.source_node)),
+        reason=reason,
+    )
+
+
+def reconcile_maps(
+    left: dict[str, VersionedState], right: dict[str, VersionedState]
+) -> dict[str, ReconciliationResult]:
+    results: dict[str, ReconciliationResult] = {}
+    for key in sorted(set(left) | set(right)):
+        candidates = [mapping[key] for mapping in (left, right) if key in mapping]
+        results[key] = reconcile_key(candidates)
+    return results

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ddil_rejoin_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ddil_rejoin_qualification.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .ddil_reconcile import ReconciliationState, VersionedState, reconcile_maps
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_partition_rejoin(
+    *,
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    left = {
+        "task": VersionedState(key="task", value="hold", logical_clock=4, authority=1, source_node="left"),
+        "mode": VersionedState(key="mode", value="search", logical_clock=9, authority=1, source_node="left"),
+    }
+    right = {
+        "task": VersionedState(key="task", value="resume", logical_clock=5, authority=1, source_node="right"),
+        "mode": VersionedState(key="mode", value="return", logical_clock=9, authority=1, source_node="right"),
+    }
+    results = reconcile_maps(left, right)
+    task = results["task"]
+    mode = results["mode"]
+    passed = (
+        task.state == ReconciliationState.MERGED
+        and task.selected is not None
+        and task.selected.value == "resume"
+        and mode.state == ReconciliationState.CONFLICT
+        and mode.selected is None
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-9201",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="ddil_partition_rejoin_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest({"scenario":"synthetic-partition-rejoin-v1"}),
+        configuration_digest=canonical_digest({"policy":"logical-clock-authority-visible-conflict-v1"}),
+        inputs=[
+            {"left": {key: value.__dict__ for key, value in left.items()}},
+            {"right": {key: value.__dict__ for key, value in right.items()}},
+        ],
+        outputs=[
+            {
+                "task_state": task.state.value,
+                "task_selected_value": task.selected.value if task.selected else None,
+                "mode_state": mode.state.value,
+                "mode_selected": None if mode.selected is None else mode.selected.value,
+            }
+        ],
+        metrics=[
+            {"name":"newer_state_selected", "value": task.selected is not None and task.selected.value == "resume"},
+            {"name":"equal_authority_conflict_visible", "value": mode.state == ReconciliationState.CONFLICT},
+            {"name":"conflict_not_silently_resolved", "value": mode.selected is None},
+        ],
+        uncertainty=[{"name":"distributed_consensus_validity", "state":"NOT_EVALUATED"}],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=("Synthetic partition/rejoin reconciliation selected newer non-conflicting state and surfaced equal-authority divergence" if passed else "Partition/rejoin reconciliation violated one or more frozen conflict-policy expectations"),
+        negative_evidence=[] if passed else [{"task": task.state.value, "mode": mode.state.value}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["scope_note"] = "Synthetic partition/rejoin policy evidence only; no distributed-consensus, tactical-network, safety, or operational autonomy claim."
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/discrepancy.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/discrepancy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class PairedMeasurement:
+    key: str
+    predicted: float
+    measured: float
+    uncertainty: float | None = None
+    units: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscrepancyMetric:
+    key: str
+    absolute_error: float
+    relative_error: float | None
+    normalized_error: float | None
+    units: str | None
+
+
+@dataclass(frozen=True)
+class DiscrepancySummary:
+    metrics: tuple[DiscrepancyMetric, ...]
+    mean_absolute_error: float
+    max_absolute_error: float
+    mean_relative_error: float | None
+    within_uncertainty_fraction: float | None
+
+
+def compare_prediction_to_measurement(
+    pairs: Iterable[PairedMeasurement],
+) -> DiscrepancySummary:
+    """Compare predicted vs measured values without upgrading either evidence class.
+
+    This records discrepancy only. It does not establish model validity unless an
+    external requirement defines acceptable thresholds and the measurement itself
+    is trustworthy for the intended scope.
+    """
+    values = tuple(pairs)
+    if not values:
+        raise ValueError("at least one prediction/measurement pair is required")
+
+    metrics: list[DiscrepancyMetric] = []
+    relative_values: list[float] = []
+    uncertainty_checks: list[bool] = []
+    for pair in values:
+        if not isfinite(pair.predicted) or not isfinite(pair.measured):
+            raise ValueError(f"non-finite value for {pair.key}")
+        error = abs(pair.predicted - pair.measured)
+        relative = None if pair.measured == 0 else error / abs(pair.measured)
+        normalized = None
+        if pair.uncertainty is not None:
+            if pair.uncertainty < 0 or not isfinite(pair.uncertainty):
+                raise ValueError(f"invalid uncertainty for {pair.key}")
+            normalized = 0.0 if pair.uncertainty == 0 and error == 0 else (
+                None if pair.uncertainty == 0 else error / pair.uncertainty
+            )
+            uncertainty_checks.append(error <= pair.uncertainty)
+        if relative is not None:
+            relative_values.append(relative)
+        metrics.append(
+            DiscrepancyMetric(
+                key=pair.key,
+                absolute_error=error,
+                relative_error=relative,
+                normalized_error=normalized,
+                units=pair.units,
+            )
+        )
+
+    absolute = [metric.absolute_error for metric in metrics]
+    return DiscrepancySummary(
+        metrics=tuple(metrics),
+        mean_absolute_error=sum(absolute) / len(absolute),
+        max_absolute_error=max(absolute),
+        mean_relative_error=(sum(relative_values) / len(relative_values)) if relative_values else None,
+        within_uncertainty_fraction=(sum(1 for value in uncertainty_checks if value) / len(uncertainty_checks)) if uncertainty_checks else None,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/edge_benchmark.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/edge_benchmark.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import statistics
+import time
+import tracemalloc
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .qualification import canonical_digest
+
+
+@dataclass(frozen=True)
+class BenchmarkRun:
+    elapsed_ms: float
+    peak_python_bytes: int
+    output_digest: str
+
+
+@dataclass(frozen=True)
+class BenchmarkSummary:
+    runs: tuple[BenchmarkRun, ...]
+    median_elapsed_ms: float
+    p95_elapsed_ms: float
+    max_peak_python_bytes: int
+    deterministic_output: bool
+    input_digest: str
+
+
+def _percentile_nearest_rank(values: list[float], percentile: float) -> float:
+    if not values:
+        raise ValueError("values required")
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), int((percentile * len(ordered)) + 0.999999)))
+    return ordered[rank - 1]
+
+
+def benchmark_callable(
+    function: Callable[[Any], Any],
+    input_value: Any,
+    *,
+    repetitions: int = 10,
+    warmup: int = 1,
+) -> BenchmarkSummary:
+    """Benchmark a local Python callable with deterministic input.
+
+    Results are host/runtime specific. They are not edge-device, accelerator,
+    real-time, safety, or mission-performance evidence unless run on that exact
+    target environment with corresponding qualification controls.
+    """
+    if repetitions < 1:
+        raise ValueError("repetitions must be >= 1")
+    if warmup < 0:
+        raise ValueError("warmup must be >= 0")
+
+    for _ in range(warmup):
+        function(input_value)
+
+    results: list[BenchmarkRun] = []
+    for _ in range(repetitions):
+        tracemalloc.start()
+        start = time.perf_counter_ns()
+        output = function(input_value)
+        elapsed_ns = time.perf_counter_ns() - start
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        results.append(
+            BenchmarkRun(
+                elapsed_ms=elapsed_ns / 1_000_000.0,
+                peak_python_bytes=peak,
+                output_digest=canonical_digest({"output": output}),
+            )
+        )
+
+    elapsed = [run.elapsed_ms for run in results]
+    digests = {run.output_digest for run in results}
+    return BenchmarkSummary(
+        runs=tuple(results),
+        median_elapsed_ms=statistics.median(elapsed),
+        p95_elapsed_ms=_percentile_nearest_rank(elapsed, 0.95),
+        max_peak_python_bytes=max(run.peak_python_bytes for run in results),
+        deterministic_output=len(digests) == 1,
+        input_digest=canonical_digest({"input": input_value}),
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/edge_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/edge_qualification.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .edge_benchmark import benchmark_callable
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_host_callable(
+    *,
+    function: Callable[[Any], Any],
+    input_value: Any,
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+    environment: dict[str, Any],
+    repetitions: int = 10,
+    warmup: int = 1,
+) -> dict[str, Any]:
+    summary = benchmark_callable(
+        function, input_value, repetitions=repetitions, warmup=warmup
+    )
+    passed = summary.deterministic_output
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-9101",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="edge_host_callable_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest(environment),
+        configuration_digest=canonical_digest(
+            {"repetitions": repetitions, "warmup": warmup}
+        ),
+        inputs=[{"input_digest": summary.input_digest}],
+        outputs=[
+            {
+                "median_elapsed_ms": summary.median_elapsed_ms,
+                "p95_elapsed_ms": summary.p95_elapsed_ms,
+                "max_peak_python_bytes": summary.max_peak_python_bytes,
+                "deterministic_output": summary.deterministic_output,
+                "output_digests": [run.output_digest for run in summary.runs],
+            }
+        ],
+        metrics=[
+            {"name": "median_elapsed_ms", "value": summary.median_elapsed_ms},
+            {"name": "p95_elapsed_ms", "value": summary.p95_elapsed_ms},
+            {"name": "max_peak_python_bytes", "value": summary.max_peak_python_bytes},
+            {"name": "deterministic_output", "value": summary.deterministic_output},
+        ],
+        uncertainty=[
+            {"name": "target_edge_device_performance", "state": "NOT_EVALUATED"},
+            {"name": "real_time_schedulability", "state": "NOT_EVALUATED"},
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Host-specific callable benchmark produced deterministic output across repetitions"
+            if passed
+            else "Host-specific callable benchmark produced divergent output"
+        ),
+        negative_evidence=[] if passed else [{"output_digests": [run.output_digest for run in summary.runs]}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["scope_note"] = (
+        "Host/runtime-specific Python benchmark only; no GPU/NPU/Jetson/flight-computer, hard-real-time, power, thermal, or mission-performance claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_artifacts.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_artifacts.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ArtifactRole(str, Enum):
+    INPUT = "INPUT"
+    OUTPUT = "OUTPUT"
+    LOG = "LOG"
+    CONFIGURATION = "CONFIGURATION"
+    SOURCE = "SOURCE"
+
+
+class ArtifactEvidence(BaseModel):
+    artifact_id: str = Field(min_length=1)
+    role: ArtifactRole
+    sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    media_type: str = Field(min_length=1)
+    locator: str = Field(min_length=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ComparisonOperator(str, Enum):
+    EQ = "EQ"
+    NE = "NE"
+    LT = "LT"
+    LE = "LE"
+    GT = "GT"
+    GE = "GE"
+
+
+class ExpectedResult(BaseModel):
+    metric: str = Field(min_length=1)
+    operator: ComparisonOperator
+    target: float | int | str | bool
+    units: str | None = None
+
+
+class QualificationTestDefinition(BaseModel):
+    test_id: str = Field(min_length=1)
+    requirement_id: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    expected_results: list[ExpectedResult] = Field(min_length=1)
+    required_artifact_roles: list[ArtifactRole] = Field(default_factory=list)
+
+    @field_validator("required_artifact_roles")
+    @classmethod
+    def no_duplicate_roles(cls, value: list[ArtifactRole]) -> list[ArtifactRole]:
+        if len(value) != len(set(value)):
+            raise ValueError("required artifact roles must be unique")
+        return value
+
+
+def sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def artifact_from_bytes(
+    *, artifact_id: str, role: ArtifactRole, data: bytes, media_type: str, locator: str
+) -> ArtifactEvidence:
+    return ArtifactEvidence(
+        artifact_id=artifact_id,
+        role=role,
+        sha256=sha256_bytes(data),
+        media_type=media_type,
+        locator=locator,
+    )
+
+
+def verify_artifact(data: bytes, artifact: ArtifactEvidence) -> bool:
+    return sha256_bytes(data) == artifact.sha256
+
+
+def required_roles_present(
+    definition: QualificationTestDefinition, artifacts: list[ArtifactEvidence]
+) -> bool:
+    present = {artifact.role for artifact in artifacts}
+    return set(definition.required_artifact_roles).issubset(present)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_lifecycle.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_lifecycle.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from .qualification import (
+    QualificationEvidenceRecord,
+    ReviewRecord,
+    ReviewStatus,
+    SupersessionRecord,
+    SupersessionState,
+)
+
+
+def supersede_evidence(
+    record: QualificationEvidenceRecord,
+    *,
+    superseded_by: str,
+    reviewer: str,
+    reviewed_utc: str,
+) -> QualificationEvidenceRecord:
+    if record.supersession.state != SupersessionState.CURRENT:
+        raise ValueError("only CURRENT evidence may be superseded")
+    return record.model_copy(
+        update={
+            "review": ReviewRecord(
+                status=ReviewStatus.ACCEPTED,
+                reviewer=reviewer,
+                reviewed_utc=reviewed_utc,
+            ),
+            "supersession": SupersessionRecord(
+                state=SupersessionState.SUPERSEDED,
+                superseded_by=superseded_by,
+            ),
+        }
+    )
+
+
+def revoke_evidence(
+    record: QualificationEvidenceRecord,
+    *,
+    reviewer: str,
+    reviewed_utc: str,
+    reason: str,
+) -> QualificationEvidenceRecord:
+    if record.supersession.state == SupersessionState.REVOKED:
+        raise ValueError("evidence is already revoked")
+    negative = list(record.negative_evidence)
+    negative.append({"revocation_reason": reason, "reviewer": reviewer})
+    return record.model_copy(
+        update={
+            "negative_evidence": negative,
+            "review": ReviewRecord(
+                status=ReviewStatus.REJECTED,
+                reviewer=reviewer,
+                reviewed_utc=reviewed_utc,
+            ),
+            "supersession": SupersessionRecord(
+                state=SupersessionState.REVOKED,
+                superseded_by=None,
+            ),
+        }
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_store.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_store.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from .qualification import canonical_digest
+
+
+class EvidenceIntegrityError(RuntimeError):
+    pass
+
+
+class EvidenceStore:
+    """Small local hash-addressed evidence store for qualification bundles.
+
+    The store provides local custody/integrity behavior only. It is not a
+    government records system, WORM archive, legal chain-of-custody service, or
+    accredited evidence repository.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root).resolve()
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.root, 0o700)
+
+    @staticmethod
+    def _payload_digest(bundle: dict[str, Any]) -> str:
+        payload = dict(bundle)
+        payload.pop("bundle_digest", None)
+        return canonical_digest(payload)
+
+    @staticmethod
+    def _digest_filename(digest: str) -> str:
+        if not digest.startswith("sha256:") or len(digest) != 71:
+            raise ValueError("expected sha256:<64 lowercase hex> digest")
+        hex_part = digest.split(":", 1)[1]
+        if any(char not in "0123456789abcdef" for char in hex_part):
+            raise ValueError("digest must be lowercase hexadecimal")
+        return f"{hex_part}.json"
+
+    def put_bundle(self, bundle: dict[str, Any]) -> str:
+        expected = self._payload_digest(bundle)
+        declared = bundle.get("bundle_digest")
+        if declared != expected:
+            raise EvidenceIntegrityError(
+                f"bundle digest mismatch: declared={declared!r} expected={expected!r}"
+            )
+
+        target = self.root / self._digest_filename(expected)
+        if target.exists():
+            existing = self.get_bundle(expected)
+            if existing != bundle:
+                raise EvidenceIntegrityError("digest collision or inconsistent existing bundle")
+            return expected
+
+        encoded = (
+            json.dumps(bundle, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+        ).encode("utf-8")
+        temp = self.root / f".{target.name}.{secrets.token_hex(8)}.tmp"
+        descriptor = os.open(
+            temp,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp, target)
+            os.chmod(target, 0o600)
+        finally:
+            if temp.exists():
+                temp.unlink(missing_ok=True)
+        return expected
+
+    def get_bundle(self, digest: str) -> dict[str, Any]:
+        path = self.root / self._digest_filename(digest)
+        if not path.exists():
+            raise KeyError(digest)
+        bundle = json.loads(path.read_text(encoding="utf-8"))
+        actual = self._payload_digest(bundle)
+        declared = bundle.get("bundle_digest")
+        if actual != digest or declared != digest:
+            raise EvidenceIntegrityError(
+                f"stored bundle integrity failure: requested={digest} declared={declared} actual={actual}"
+            )
+        return bundle
+
+    def verify_all(self) -> dict[str, bool]:
+        results: dict[str, bool] = {}
+        for path in sorted(self.root.glob("*.json")):
+            digest = f"sha256:{path.stem}"
+            try:
+                self.get_bundle(digest)
+            except (EvidenceIntegrityError, json.JSONDecodeError, OSError, ValueError):
+                results[digest] = False
+            else:
+                results[digest] = True
+        return results

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/graph_metrics.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/graph_metrics.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class GraphScore:
+    entity_precision: float
+    entity_recall: float
+    relationship_precision: float
+    relationship_recall: float
+    unsupported_entities: tuple[str, ...]
+    unsupported_relationships: tuple[str, ...]
+    missed_entities: tuple[str, ...]
+    missed_relationships: tuple[str, ...]
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float:
+    return 1.0 if denominator == 0 and numerator == 0 else (
+        0.0 if denominator == 0 else numerator / denominator
+    )
+
+
+def score_graph(
+    *,
+    expected_entities: Iterable[str],
+    predicted_entities: Iterable[str],
+    expected_relationships: Iterable[str],
+    predicted_relationships: Iterable[str],
+) -> GraphScore:
+    expected_e = set(expected_entities)
+    predicted_e = set(predicted_entities)
+    expected_r = set(expected_relationships)
+    predicted_r = set(predicted_relationships)
+
+    entity_true_positive = len(expected_e & predicted_e)
+    relationship_true_positive = len(expected_r & predicted_r)
+
+    return GraphScore(
+        entity_precision=_safe_ratio(entity_true_positive, len(predicted_e)),
+        entity_recall=_safe_ratio(entity_true_positive, len(expected_e)),
+        relationship_precision=_safe_ratio(
+            relationship_true_positive, len(predicted_r)
+        ),
+        relationship_recall=_safe_ratio(
+            relationship_true_positive, len(expected_r)
+        ),
+        unsupported_entities=tuple(sorted(predicted_e - expected_e)),
+        unsupported_relationships=tuple(sorted(predicted_r - expected_r)),
+        missed_entities=tuple(sorted(expected_e - predicted_e)),
+        missed_relationships=tuple(sorted(expected_r - predicted_r)),
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/horizons.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/horizons.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import ForecastHorizon
+from .readiness import ReadinessRung
+
+
+class CapabilityHorizonRecord(BaseModel):
+    horizon_id: str = Field(min_length=1)
+    capability_id: str = Field(min_length=1)
+    horizon: ForecastHorizon
+    target_rung: ReadinessRung
+    prerequisite_rung: ReadinessRung
+    requirement_delta_ids: list[str] = Field(default_factory=list)
+    build_actions: list[str] = Field(default_factory=list)
+    experiments: list[str] = Field(default_factory=list)
+    partner_actions: list[str] = Field(default_factory=list)
+    evidence_targets: list[str] = Field(default_factory=list)
+    blocking_conditions: list[str] = Field(default_factory=list)
+    forecast_only: bool = False
+
+    @model_validator(mode="after")
+    def target_must_not_skip_prerequisite(self) -> "CapabilityHorizonRecord":
+        if self.target_rung < self.prerequisite_rung:
+            raise ValueError("target rung cannot be below prerequisite rung")
+        if self.target_rung > self.prerequisite_rung + 1:
+            raise ValueError("horizon plan may advance at most one readiness rung per evidence gate")
+        return self
+
+    def actionable(self) -> bool:
+        return bool(self.build_actions or self.experiments or self.partner_actions)
+
+
+class CapabilityHorizonPortfolio(BaseModel):
+    records: list[CapabilityHorizonRecord] = Field(default_factory=list)
+
+    def by_horizon(self, horizon: ForecastHorizon) -> list[CapabilityHorizonRecord]:
+        return [record for record in self.records if record.horizon == horizon]
+
+    def immediate_actions(self) -> list[str]:
+        actions: list[str] = []
+        for record in self.by_horizon(ForecastHorizon.D0_90):
+            actions.extend(record.build_actions)
+            actions.extend(record.experiments)
+            actions.extend(record.partner_actions)
+        return sorted(set(actions))

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/ietm.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/ietm.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def project_synthetic_manual_to_xml(fixture: dict[str, Any]) -> str:
+    """Project the frozen synthetic manual into a simple XML interchange form.
+
+    This output is intentionally NOT claimed as S1000D/MIL-standard compliant.
+    It exists to validate source preservation, structure, and qualification flow.
+    """
+    manual = fixture["manual"]
+    root = ET.Element(
+        "syntheticTechnicalManual",
+        attrib={
+            "manualId": str(manual["manual_id"]),
+            "revision": str(manual["revision"]),
+        },
+    )
+    marking = ET.SubElement(root, "distributionMarking")
+    marking.text = str(manual["distribution_marking"])
+    title = ET.SubElement(root, "title")
+    title.text = str(manual["title"])
+
+    sections = ET.SubElement(root, "sections")
+    for section in manual["sections"]:
+        section_node = ET.SubElement(
+            sections,
+            "section",
+            attrib={"id": str(section["section_id"]), "title": str(section["title"])},
+        )
+        for step in section["steps"]:
+            step_node = ET.SubElement(section_node, "step", attrib={"id": str(step["step_id"])})
+            step_node.text = str(step["text"])
+
+    return ET.tostring(root, encoding="unicode")
+
+
+def inspect_synthetic_projection(xml_text: str, fixture: dict[str, Any]) -> dict[str, Any]:
+    root = ET.fromstring(xml_text)
+    sections = root.findall("./sections/section")
+    steps = root.findall("./sections/section/step")
+    marking = root.findtext("distributionMarking")
+    return {
+        "section_count": len(sections),
+        "step_count": len(steps),
+        "marking_preserved": marking == fixture["manual"]["distribution_marking"],
+        "manual_id_preserved": root.attrib.get("manualId") == fixture["manual"]["manual_id"],
+    }
+
+
+def qualify_synthetic_ietm(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    xml_text = project_synthetic_manual_to_xml(fixture)
+    observed = inspect_synthetic_projection(xml_text, fixture)
+    expected = fixture["expected"]
+    passed = all(observed[key] == expected[key] for key in expected)
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-3001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="ietm_synthetic_projection_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest(
+            {"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}
+        ),
+        configuration_digest=canonical_digest({"projector": "synthetic_xml_v1"}),
+        inputs=[{"manual_id": fixture["manual"]["manual_id"]}],
+        outputs=[{"xml_digest": canonical_digest({"xml": xml_text}), "observed": observed}],
+        metrics=[{"name": key, "value": value, "expected": expected[key]} for key, value in observed.items()],
+        uncertainty=[
+            {
+                "name": "standards_compliance",
+                "state": "NOT_EVALUATED",
+                "note": "No S1000D/MIL-standard validator has been applied",
+            }
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Synthetic XML projection preserved frozen structural/marking expectations"
+            if passed
+            else "Synthetic XML projection failed one or more frozen expectations"
+        ),
+        negative_evidence=[] if passed else [{"expected": expected, "observed": observed}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = (
+        "Synthetic XML transformation evidence only; no S1000D, MIL-standard, Navy-viewer, or production conversion claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/interoperability.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/interoperability.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import canonical_digest
+
+
+class ConformanceState(str, Enum):
+    UNTESTED = "UNTESTED"
+    INTERNAL_PASS = "INTERNAL_PASS"
+    INTERNAL_FAIL = "INTERNAL_FAIL"
+    PARTNER_VALIDATED = "PARTNER_VALIDATED"
+    EXTERNALLY_CERTIFIED = "EXTERNALLY_CERTIFIED"
+
+
+class InterfaceContract(BaseModel):
+    contract_id: str = Field(min_length=1)
+    interface_name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    required_message_types: list[str] = Field(default_factory=list)
+    required_fields: dict[str, list[str]] = Field(default_factory=dict)
+    authoritative_spec_ref: str | None = None
+    spec_digest: str | None = None
+
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+
+class ConformanceCheck(BaseModel):
+    check_id: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    passed: bool
+    evidence_refs: list[str] = Field(default_factory=list)
+    observed: dict[str, Any] = Field(default_factory=dict)
+
+
+class InterfaceConformanceRecord(BaseModel):
+    record_id: str = Field(min_length=1)
+    contract_digest: str = Field(min_length=1)
+    implementation_id: str = Field(min_length=1)
+    implementation_digest: str = Field(min_length=1)
+    state: ConformanceState = ConformanceState.UNTESTED
+    checks: list[ConformanceCheck] = Field(default_factory=list)
+    partner: str | None = None
+    external_authority: str | None = None
+    certificate_ref: str | None = None
+
+    @model_validator(mode="after")
+    def state_requires_evidence(self) -> "InterfaceConformanceRecord":
+        if self.state == ConformanceState.INTERNAL_PASS:
+            if not self.checks or not all(check.passed for check in self.checks):
+                raise ValueError("INTERNAL_PASS requires at least one check and all checks passing")
+        if self.state == ConformanceState.INTERNAL_FAIL:
+            if not self.checks or all(check.passed for check in self.checks):
+                raise ValueError("INTERNAL_FAIL requires at least one failing check")
+        if self.state == ConformanceState.PARTNER_VALIDATED and not self.partner:
+            raise ValueError("PARTNER_VALIDATED requires partner identity")
+        if self.state == ConformanceState.EXTERNALLY_CERTIFIED:
+            if not self.external_authority or not self.certificate_ref:
+                raise ValueError("EXTERNALLY_CERTIFIED requires authority and certificate reference")
+        return self
+
+    def claims_boundary(self) -> str:
+        if self.state == ConformanceState.EXTERNALLY_CERTIFIED:
+            return "External certification metadata is recorded; scope, validity period, and certificate terms still govern the claim."
+        if self.state == ConformanceState.PARTNER_VALIDATED:
+            return "Partner validation is recorded only for the stated interface and evidence scope; no government certification is inferred."
+        return "Internal interface-conformance evidence only; no platform acceptance, government certification, or operational interoperability is claimed."

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/legacy_normalization.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/legacy_normalization.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NormalizedArtifact:
+    artifact_id: str
+    artifact_kind: str
+    records: tuple[dict[str, Any], ...]
+    source_ref: str
+
+
+def normalize_legacy_artifact(artifact: dict[str, Any]) -> NormalizedArtifact:
+    """Normalize one synthetic/authorized legacy artifact without inferring relationships.
+
+    This stage preserves source identity and structure. It intentionally does not
+    claim semantic extraction, SysML generation, or document understanding.
+    """
+    artifact_id = str(artifact["artifact_id"])
+    kind = str(artifact["kind"])
+    source_ref = f"artifact:{artifact_id}"
+
+    if "rows" in artifact:
+        records = tuple(dict(row) for row in artifact["rows"])
+    elif "content" in artifact:
+        records = ({"text": str(artifact["content"])},)
+    else:
+        records = ({"raw": dict(artifact)},)
+
+    return NormalizedArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=kind,
+        records=records,
+        source_ref=source_ref,
+    )
+
+
+def normalize_legacy_corpus(artifacts: list[dict[str, Any]]) -> tuple[NormalizedArtifact, ...]:
+    seen: set[str] = set()
+    normalized: list[NormalizedArtifact] = []
+    for artifact in artifacts:
+        item = normalize_legacy_artifact(artifact)
+        if item.artifact_id in seen:
+            raise ValueError(f"duplicate artifact_id: {item.artifact_id}")
+        seen.add(item.artifact_id)
+        normalized.append(item)
+    return tuple(normalized)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/manufacturing_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/manufacturing_qualification.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .manufacturing_thread import ManufacturingDigitalThread
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_synthetic_manufacturing_thread(
+    *, fixture: dict[str, Any], requirement: RequirementDeltaRecord,
+    software_commit: str, executed_utc: str, operator: str,
+) -> dict[str, Any]:
+    thread = ManufacturingDigitalThread.model_validate(fixture["thread"])
+    expected = fixture["expected"]
+    observed = {
+        "qualification_state": thread.qualification_state(),
+        "material_lot_count": len(thread.material_lots),
+        "process_configuration_count": len(thread.process_configurations),
+        "build_step_count": len(thread.build_steps),
+        "specimen_count": len(thread.specimens),
+        "thread_digest": thread.digest(),
+    }
+    passed = all(observed[key] == expected[key] for key in expected)
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-9002",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="manufacturing_thread_synthetic_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest({"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}),
+        configuration_digest=canonical_digest({"thread_schema": "ManufacturingDigitalThread"}),
+        inputs=[{"thread_id": thread.thread_id}],
+        outputs=[observed],
+        metrics=[{"name": key, "value": observed[key], "expected": value} for key, value in expected.items()],
+        uncertainty=[
+            {"name": "physical_material_performance", "state": "NOT_EVALUATED"},
+            {"name": "process_qualification", "state": "NOT_EVALUATED"},
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=("Synthetic material-process-build-specimen lineage met frozen digital-thread expectations" if passed else "Synthetic manufacturing digital thread diverged from frozen expectations"),
+        negative_evidence=[] if passed else [{"expected": expected, "observed": observed}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+        physical_validation_performed=False,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["thread_digest"] = thread.digest()
+    bundle["scope_note"] = "Synthetic manufacturing digital-thread evidence only; no physical coupon, alloy-property, machine, DED process-qualification, or production-acceptance claim."
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/manufacturing_thread.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/manufacturing_thread.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import canonical_digest
+
+
+class MaterialLot(BaseModel):
+    lot_id: str = Field(min_length=1)
+    material_designation: str = Field(min_length=1)
+    supplier: str | None = None
+    certificate_digest: str | None = None
+    composition_evidence_ref: str | None = None
+
+
+class ProcessConfiguration(BaseModel):
+    configuration_id: str = Field(min_length=1)
+    process_family: str = Field(min_length=1)
+    machine_id: str = Field(min_length=1)
+    software_version: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    configuration_artifact_digest: str | None = None
+
+
+class BuildStep(BaseModel):
+    step_id: str = Field(min_length=1)
+    material_lot_ids: list[str] = Field(default_factory=list)
+    configuration_id: str = Field(min_length=1)
+    start_utc: str | None = None
+    end_utc: str | None = None
+    telemetry_artifact_digests: list[str] = Field(default_factory=list)
+    operator: str | None = None
+
+
+class SpecimenRecord(BaseModel):
+    specimen_id: str = Field(min_length=1)
+    build_step_ids: list[str] = Field(default_factory=list)
+    geometry_ref: str | None = None
+    measurement_artifact_digests: list[str] = Field(default_factory=list)
+    physical_validation_performed: bool = False
+
+
+class ManufacturingDigitalThread(BaseModel):
+    thread_id: str = Field(min_length=1)
+    material_lots: list[MaterialLot] = Field(default_factory=list)
+    process_configurations: list[ProcessConfiguration] = Field(default_factory=list)
+    build_steps: list[BuildStep] = Field(default_factory=list)
+    specimens: list[SpecimenRecord] = Field(default_factory=list)
+    claims_boundary: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def references_must_resolve(self) -> "ManufacturingDigitalThread":
+        lots = {item.lot_id for item in self.material_lots}
+        configs = {item.configuration_id for item in self.process_configurations}
+        steps = {item.step_id for item in self.build_steps}
+        if len(lots) != len(self.material_lots):
+            raise ValueError("duplicate material lot id")
+        if len(configs) != len(self.process_configurations):
+            raise ValueError("duplicate process configuration id")
+        if len(steps) != len(self.build_steps):
+            raise ValueError("duplicate build step id")
+        for step in self.build_steps:
+            unknown_lots = set(step.material_lot_ids) - lots
+            if unknown_lots:
+                raise ValueError(f"build step {step.step_id} references unknown material lots: {sorted(unknown_lots)}")
+            if step.configuration_id not in configs:
+                raise ValueError(f"build step {step.step_id} references unknown configuration")
+        for specimen in self.specimens:
+            unknown_steps = set(specimen.build_step_ids) - steps
+            if unknown_steps:
+                raise ValueError(f"specimen {specimen.specimen_id} references unknown build steps: {sorted(unknown_steps)}")
+        return self
+
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+    def qualification_state(self) -> str:
+        if any(specimen.physical_validation_performed and specimen.measurement_artifact_digests for specimen in self.specimens):
+            return "PHYSICAL_MEASUREMENT_REFERENCED"
+        return "DIGITAL_THREAD_ONLY"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/mbse_benchmark.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/mbse_benchmark.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .graph_metrics import GraphScore, score_graph
+from .mbse_extract import extract_candidate_relations
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def _expected_entities(fixture: dict[str, Any]) -> set[str]:
+    return {str(node["name"]) for node in fixture["ground_truth"]["nodes"]}
+
+
+def _expected_relations(fixture: dict[str, Any]) -> set[str]:
+    names = {
+        str(node["id"]): str(node["name"])
+        for node in fixture["ground_truth"]["nodes"]
+    }
+    return {
+        f"{names[str(edge['source'])]}->{names[str(edge['target'])]}:{edge['relation']}"
+        for edge in fixture["ground_truth"]["edges"]
+    }
+
+
+def benchmark_synthetic_mbse(fixture: dict[str, Any]) -> GraphScore:
+    relations = extract_candidate_relations(fixture["legacy_artifacts"])
+    predicted_relations = {relation.canonical for relation in relations}
+    predicted_entities = {
+        name
+        for relation in relations
+        for name in (relation.source_name, relation.target_name)
+    }
+    return score_graph(
+        expected_entities=_expected_entities(fixture),
+        predicted_entities=predicted_entities,
+        expected_relationships=_expected_relations(fixture),
+        predicted_relationships=predicted_relations,
+    )
+
+
+def qualify_synthetic_mbse(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    score = benchmark_synthetic_mbse(fixture)
+    targets = fixture["scoring"]
+    passed = (
+        score.entity_precision >= float(targets["entity_precision_target"])
+        and score.entity_recall >= float(targets["entity_recall_target"])
+        and score.relationship_precision >= float(targets["relationship_precision_target"])
+        and score.relationship_recall >= float(targets["relationship_recall_target"])
+        and len(score.unsupported_entities) <= int(targets["unsupported_inference_target"])
+        and len(score.unsupported_relationships) <= int(targets["unsupported_inference_target"])
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-2001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="mbse_synthetic_extraction_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest(
+            {"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}
+        ),
+        configuration_digest=canonical_digest({"extractor": "conservative_rules_v1"}),
+        inputs=[{"legacy_artifact_count": len(fixture["legacy_artifacts"])}],
+        outputs=[
+            {
+                "entity_precision": score.entity_precision,
+                "entity_recall": score.entity_recall,
+                "relationship_precision": score.relationship_precision,
+                "relationship_recall": score.relationship_recall,
+                "unsupported_entities": list(score.unsupported_entities),
+                "unsupported_relationships": list(score.unsupported_relationships),
+                "missed_entities": list(score.missed_entities),
+                "missed_relationships": list(score.missed_relationships),
+            }
+        ],
+        metrics=[
+            {"name": "entity_precision", "value": score.entity_precision},
+            {"name": "entity_recall", "value": score.entity_recall},
+            {"name": "relationship_precision", "value": score.relationship_precision},
+            {"name": "relationship_recall", "value": score.relationship_recall},
+        ],
+        uncertainty=[
+            {
+                "name": "generalization",
+                "state": "NOT_EVALUATED",
+                "note": "Frozen synthetic fixture only",
+            }
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Conservative extractor met frozen synthetic benchmark targets"
+            if passed
+            else "Conservative extractor did not meet frozen synthetic benchmark targets"
+        ),
+        negative_evidence=[
+            {"unsupported_entities": list(score.unsupported_entities)},
+            {"unsupported_relationships": list(score.unsupported_relationships)},
+            {"missed_entities": list(score.missed_entities)},
+            {"missed_relationships": list(score.missed_relationships)},
+        ],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = (
+        "Synthetic rule-based extraction benchmark only; no general AI, SysML/Cameo, Navy/Aegis, or classified-system claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/mbse_extract.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/mbse_extract.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from .qualification import EvidenceGraph, EvidenceGraphEdge, EvidenceGraphNode
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+@dataclass(frozen=True)
+class CandidateRelation:
+    source_name: str
+    target_name: str
+    relation: str
+    source_ref: str
+    confidence: float
+
+    @property
+    def canonical(self) -> str:
+        return f"{self.source_name}->{self.target_name}:{self.relation}"
+
+
+def extract_candidate_relations(artifacts: list[dict[str, Any]]) -> tuple[CandidateRelation, ...]:
+    """Conservative rule-based extractor for the frozen synthetic fixture family.
+
+    It only extracts relationships explicitly encoded in supported text/row patterns.
+    It is not a general document-understanding or SysML reconstruction engine.
+    """
+    relations: list[CandidateRelation] = []
+
+    for artifact in artifacts:
+        artifact_id = str(artifact["artifact_id"])
+        source_ref = f"artifact:{artifact_id}"
+        kind = str(artifact["kind"])
+
+        if kind == "technical_manual_excerpt":
+            text = str(artifact.get("content", ""))
+            power_match = re.search(
+                r"(?P<target>.+?) receives 28 VDC from the (?P<source>.+?) subsystem",
+                text,
+            )
+            if power_match:
+                relations.append(
+                    CandidateRelation(
+                        source_name=power_match.group("source").strip(),
+                        target_name=power_match.group("target").strip(),
+                        relation="powers",
+                        source_ref=source_ref,
+                        confidence=0.95,
+                    )
+                )
+            ethernet_match = re.search(
+                r"(?P<source>Sensor A).+?forwards observation messages to the (?P<target>Mission Processor) over Ethernet",
+                text,
+            )
+            if ethernet_match:
+                relations.append(
+                    CandidateRelation(
+                        source_name=ethernet_match.group("source").strip(),
+                        target_name=ethernet_match.group("target").strip(),
+                        relation="ethernet_data",
+                        source_ref=source_ref,
+                        confidence=0.95,
+                    )
+                )
+
+        elif kind == "network_configuration":
+            for row in artifact.get("rows", []):
+                if row.get("host") and row.get("service"):
+                    relations.append(
+                        CandidateRelation(
+                            source_name=str(row["host"]),
+                            target_name=str(row["service"]),
+                            relation="hosts",
+                            source_ref=source_ref,
+                            confidence=0.99,
+                        )
+                    )
+                if row.get("consumer") and row.get("service"):
+                    relations.append(
+                        CandidateRelation(
+                            source_name=str(row["service"]),
+                            target_name=str(row["consumer"]),
+                            relation="publishes_track_data",
+                            source_ref=source_ref,
+                            confidence=0.99,
+                        )
+                    )
+
+        elif kind == "cable_record":
+            for row in artifact.get("rows", []):
+                if row.get("from") and row.get("to") and "28 VDC" in str(row.get("purpose", "")):
+                    relations.append(
+                        CandidateRelation(
+                            source_name=str(row["from"]),
+                            target_name=str(row["to"]),
+                            relation="powers",
+                            source_ref=source_ref,
+                            confidence=0.99,
+                        )
+                    )
+
+    unique: dict[str, CandidateRelation] = {}
+    for relation in relations:
+        unique[relation.canonical] = relation
+    return tuple(unique[key] for key in sorted(unique))
+
+
+def candidate_graph(graph_id: str, relations: tuple[CandidateRelation, ...]) -> EvidenceGraph:
+    names = sorted({r.source_name for r in relations} | {r.target_name for r in relations})
+    nodes = [
+        EvidenceGraphNode(
+            node_id=f"entity:{_slug(name)}",
+            node_type="synthetic_legacy_entity",
+            label=name,
+        )
+        for name in names
+    ]
+    edges = [
+        EvidenceGraphEdge(
+            edge_id=f"rel:{index:04d}",
+            source_node_id=f"entity:{_slug(relation.source_name)}",
+            target_node_id=f"entity:{_slug(relation.target_name)}",
+            relation=relation.relation,
+            source_ref=relation.source_ref,
+            confidence=relation.confidence,
+        )
+        for index, relation in enumerate(relations, start=1)
+    ]
+    return EvidenceGraph(graph_id=graph_id, nodes=nodes, edges=edges)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/mission_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/mission_qualification.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .mission_replay import (
+    MissionEvent,
+    derive_findings,
+    mission_replay_graph,
+    propose_follow_on_actions,
+    replay_events,
+)
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_synthetic_mission_replay(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    events = [MissionEvent.model_validate(event) for event in fixture["events"]]
+    replay = replay_events(events)
+    findings = derive_findings(replay)
+    proposals = propose_follow_on_actions(findings)
+    graph = mission_replay_graph(
+        graph_id=fixture["fixture_id"],
+        events=replay,
+        findings=findings,
+        proposals=proposals,
+    )
+    observed_finding_types = sorted(finding.finding_type for finding in findings)
+    observed_actions = sorted(proposal.action for proposal in proposals)
+    expected_findings = sorted(fixture["expected"]["finding_types"])
+    expected_actions = sorted(fixture["expected"]["proposal_actions"])
+    all_proposed = all(proposal.state.value == "PROPOSED" for proposal in proposals)
+    passed = (
+        observed_finding_types == expected_findings
+        and observed_actions == expected_actions
+        and all_proposed is bool(fixture["expected"]["all_proposals_must_start_proposed"])
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-5001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="mission_replay_synthetic_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest(
+            {"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}
+        ),
+        configuration_digest=canonical_digest({"replay_model": "deterministic_rules_v1"}),
+        inputs=[{"event_count": len(events)}],
+        outputs=[
+            {
+                "finding_types": observed_finding_types,
+                "proposal_actions": observed_actions,
+                "all_proposals_start_proposed": all_proposed,
+                "graph_digest": canonical_digest(graph),
+            }
+        ],
+        metrics=[
+            {"name": "finding_set_match", "value": observed_finding_types == expected_findings},
+            {"name": "proposal_set_match", "value": observed_actions == expected_actions},
+            {"name": "all_proposals_proposed", "value": all_proposed},
+        ],
+        uncertainty=[
+            {"name": "operational_generalization", "state": "NOT_EVALUATED"},
+            {"name": "causal_validity", "state": "NOT_EVALUATED"},
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Synthetic mission replay produced the frozen findings and kept all follow-on actions behind a human approval gate"
+            if passed
+            else "Synthetic mission replay diverged from one or more frozen expectations"
+        ),
+        negative_evidence=[] if passed else [
+            {
+                "expected_findings": expected_findings,
+                "observed_findings": observed_finding_types,
+                "expected_actions": expected_actions,
+                "observed_actions": observed_actions,
+            }
+        ],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence], graph)
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["prime_action_proposals"] = [proposal.model_dump(mode="json") for proposal in proposals]
+    bundle["scope_note"] = (
+        "Synthetic deterministic mission-debrief/replay evidence only; no operational CCA/UAS, causal-AI, or autonomous replanning claim. Follow-on actions remain proposals pending identified human authorization."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/mission_replay.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/mission_replay.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .prime import ActionProposal
+from .qualification import EvidenceGraph, EvidenceGraphEdge, EvidenceGraphNode
+
+
+class MissionEvent(BaseModel):
+    sequence: int = Field(ge=1)
+    t_seconds: float = Field(ge=0)
+    source: str = Field(min_length=1)
+    event_type: str = Field(min_length=1)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DebriefFinding:
+    finding_type: str
+    summary: str
+    source_sequences: tuple[int, ...]
+    confidence: float
+
+
+def replay_events(events: list[MissionEvent]) -> tuple[MissionEvent, ...]:
+    ordered = tuple(sorted(events, key=lambda event: (event.sequence, event.t_seconds)))
+    seen: set[int] = set()
+    for event in ordered:
+        if event.sequence in seen:
+            raise ValueError(f"duplicate mission-event sequence: {event.sequence}")
+        seen.add(event.sequence)
+    return ordered
+
+
+def derive_findings(events: tuple[MissionEvent, ...]) -> tuple[DebriefFinding, ...]:
+    findings: list[DebriefFinding] = []
+    by_type: dict[str, list[MissionEvent]] = {}
+    for event in events:
+        by_type.setdefault(event.event_type, []).append(event)
+
+    if by_type.get("comms_degraded"):
+        seqs = tuple(event.sequence for event in by_type["comms_degraded"])
+        findings.append(
+            DebriefFinding(
+                finding_type="communications_degradation",
+                summary="Mission experienced a recorded communications-degradation event.",
+                source_sequences=seqs,
+                confidence=1.0,
+            )
+        )
+
+    if by_type.get("sensor_stale"):
+        seqs = tuple(event.sequence for event in by_type["sensor_stale"])
+        findings.append(
+            DebriefFinding(
+                finding_type="stale_sensor_dependency",
+                summary="Mission consumed or encountered stale sensor state requiring review.",
+                source_sequences=seqs,
+                confidence=1.0,
+            )
+        )
+
+    if by_type.get("task_failed"):
+        seqs = tuple(event.sequence for event in by_type["task_failed"])
+        findings.append(
+            DebriefFinding(
+                finding_type="task_failure",
+                summary="At least one mission task failed and requires causal review.",
+                source_sequences=seqs,
+                confidence=1.0,
+            )
+        )
+
+    return tuple(sorted(findings, key=lambda finding: finding.finding_type))
+
+
+def propose_follow_on_actions(
+    findings: tuple[DebriefFinding, ...],
+) -> tuple[ActionProposal, ...]:
+    mapping = {
+        "communications_degradation": "validate_alternate_comms_path",
+        "stale_sensor_dependency": "tighten_stale_data_gate",
+        "task_failure": "review_task_reassignment_policy",
+    }
+    proposals: list[ActionProposal] = []
+    for index, finding in enumerate(findings, start=1):
+        action = mapping.get(finding.finding_type)
+        if action is None:
+            continue
+        proposals.append(
+            ActionProposal(
+                proposal_id=f"MISSION-COA-{index:03d}",
+                action=action,
+                rationale=[finding.summary],
+                authority_required="identified-human-authority",
+            )
+        )
+    return tuple(proposals)
+
+
+def mission_replay_graph(
+    *,
+    graph_id: str,
+    events: tuple[MissionEvent, ...],
+    findings: tuple[DebriefFinding, ...],
+    proposals: tuple[ActionProposal, ...],
+) -> EvidenceGraph:
+    nodes: list[EvidenceGraphNode] = []
+    edges: list[EvidenceGraphEdge] = []
+
+    for event in events:
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=f"event:{event.sequence}",
+                node_type="mission_event",
+                label=event.event_type,
+                source_ref=f"event-sequence:{event.sequence}",
+                confidence=1.0,
+                attributes={
+                    "t_seconds": event.t_seconds,
+                    "source": event.source,
+                    "payload": event.payload,
+                },
+            )
+        )
+
+    for index, finding in enumerate(findings, start=1):
+        finding_id = f"finding:{index}"
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=finding_id,
+                node_type="debrief_finding",
+                label=finding.finding_type,
+                confidence=finding.confidence,
+                attributes={"summary": finding.summary},
+            )
+        )
+        for sequence in finding.source_sequences:
+            edges.append(
+                EvidenceGraphEdge(
+                    edge_id=f"edge:event:{sequence}:finding:{index}",
+                    source_node_id=f"event:{sequence}",
+                    target_node_id=finding_id,
+                    relation="supports",
+                    source_ref=f"event-sequence:{sequence}",
+                    confidence=finding.confidence,
+                )
+            )
+
+    for index, proposal in enumerate(proposals, start=1):
+        proposal_id = f"proposal:{index}"
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=proposal_id,
+                node_type="prime_action_proposal",
+                label=proposal.action,
+                attributes=proposal.model_dump(mode="json"),
+            )
+        )
+        if index <= len(findings):
+            edges.append(
+                EvidenceGraphEdge(
+                    edge_id=f"edge:finding:{index}:proposal:{index}",
+                    source_node_id=f"finding:{index}",
+                    target_node_id=proposal_id,
+                    relation="informs",
+                )
+            )
+
+    return EvidenceGraph(graph_id=graph_id, nodes=nodes, edges=edges)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/neutral_model.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/neutral_model.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .qualification import EvidenceGraph, canonical_digest
+
+
+def evidence_graph_to_neutral_model(graph: EvidenceGraph) -> dict[str, Any]:
+    """Project an Evidence Graph into a canonical Worldshepherd neutral model.
+
+    This is an intermediate representation only. It is not SysML, XMI, Cameo,
+    MagicDraw, or any other vendor/government modeling standard.
+    """
+    model = {
+        "schema": "WS-NEUTRAL-SYSTEM-MODEL-V1",
+        "source_graph_id": graph.graph_id,
+        "elements": [
+            {
+                "id": node.node_id,
+                "type": node.node_type,
+                "name": node.label,
+                "source_ref": node.source_ref,
+                "confidence": node.confidence,
+                "attributes": node.attributes,
+            }
+            for node in sorted(graph.nodes, key=lambda item: item.node_id)
+        ],
+        "relationships": [
+            {
+                "id": edge.edge_id,
+                "source": edge.source_node_id,
+                "target": edge.target_node_id,
+                "type": edge.relation,
+                "source_ref": edge.source_ref,
+                "confidence": edge.confidence,
+                "attributes": edge.attributes,
+            }
+            for edge in sorted(graph.edges, key=lambda item: item.edge_id)
+        ],
+        "claims_boundary": [
+            "Neutral internal representation only.",
+            "No SysML/XMI/Cameo/MagicDraw compatibility is inferred from this projection.",
+        ],
+    }
+    model["model_digest"] = canonical_digest(model)
+    return model
+
+
+def export_sysml_xmi_stub(model: dict[str, Any]) -> str:
+    raise NotImplementedError(
+        "SysML/XMI export is not implemented or validated; authoritative target schema/tool interoperability must be established first"
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .ddil_rejoin_qualification import qualify_partition_rejoin
+from .edge_qualification import qualify_host_callable
+from .evidence_store import EvidenceStore
+from .pre_cli import build_all
+from .pre_portfolio import build_horizon_portfolio, build_readiness_ledger
+from .qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+    canonical_digest,
+)
+from .software_provenance import BuildProvenance, SoftwareComponent
+
+
+def _write(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _requirement(
+    requirement_id: str,
+    title: str,
+    statement: str,
+    lanes: list[str],
+    missing: list[str],
+) -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id=requirement_id,
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(
+            title=title,
+            agency="Worldshepherd PRE",
+            url=f"internal://pre/{requirement_id.lower()}",
+            source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement=statement,
+        recurrence="Reusable predictive readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=lanes,
+        existing_capability=["claims-controlled internal software baseline"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=missing,
+        experiment_or_demonstration_needed=["reproducible bounded benchmark"],
+        evidence_target=["machine-readable Qualification Evidence bundle"],
+        claims_boundary=["Internal/synthetic evidence only unless explicitly upgraded by corresponding external evidence."],
+    )
+
+
+def _edge_workload(value: dict[str, Any]) -> dict[str, Any]:
+    values = [float(item) for item in value["values"]]
+    return {
+        "count": len(values),
+        "sum": sum(values),
+        "minimum": min(values),
+        "maximum": max(values),
+    }
+
+
+def build_bloom(
+    *, fixtures: Path, out: Path, software_commit: str, executed_utc: str, operator: str
+) -> dict[str, Any]:
+    index = build_all(
+        fixtures=fixtures,
+        out=out,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+
+    edge_requirement = _requirement(
+        "PRE-RD-2026-0018",
+        "Edge-AI host benchmark readiness target",
+        "Measure deterministic host/runtime latency and memory before target edge-device claims.",
+        ["edge AI", "autonomy", "sensor fusion", "C2"],
+        ["target device", "power/thermal evidence", "hard-real-time validation"],
+    )
+    rejoin_requirement = _requirement(
+        "PRE-RD-2026-0019",
+        "DDIL partition/rejoin reconciliation readiness target",
+        "Reconcile non-conflicting state after partition and surface equal-authority divergence without silent resolution.",
+        ["DDIL", "C2", "autonomy", "configuration custody"],
+        ["distributed deployment", "real network partitions", "consensus validation"],
+    )
+
+    edge = qualify_host_callable(
+        function=_edge_workload,
+        input_value={"values": list(range(1, 129))},
+        requirement=edge_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+        environment={
+            "runtime": "python",
+            "execution_context": "qualification-compiler-host",
+            "device_claim": "NONE",
+        },
+        repetitions=7,
+        warmup=1,
+    )
+    rejoin = qualify_partition_rejoin(
+        requirement=rejoin_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+
+    store = EvidenceStore(out / "echo_store")
+    for name, bundle in {"edge": edge, "ddil_rejoin": rejoin}.items():
+        _write(out / f"{name}_qualification_bundle.json", bundle)
+        index["bundle_digests"][name] = bundle["bundle_digest"]
+        index["custody_digests"][name] = store.put_bundle(bundle)
+        index["failures"][name] = [
+            record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"
+        ]
+
+    readiness = build_readiness_ledger(index["bundle_digests"])
+    horizons = build_horizon_portfolio()
+    _write(out / "capability_readiness_ledger.json", readiness)
+    _write(out / "capability_horizons.json", horizons)
+
+    bundle_manifest = {
+        "schema": "WS-PRE-BUNDLE-MANIFEST-V1",
+        "software_commit": software_commit,
+        "bundle_digests": dict(sorted(index["bundle_digests"].items())),
+    }
+    provenance = BuildProvenance(
+        provenance_id="WS-PRE-BLOOM-BUILD-V1",
+        source_repository="Bdavis1390/Sara_pro",
+        source_commit=software_commit,
+        builder_id=operator,
+        build_environment_digest=canonical_digest(
+            {"builder": operator, "execution_context": "pre-bloom-cli"}
+        ),
+        output_artifact_digest=canonical_digest(bundle_manifest),
+        components=[
+            SoftwareComponent(
+                name="worldshepherd-sara",
+                version="0.1.0",
+                package_type="python",
+                supplier="Worldshepherd internal",
+            )
+        ],
+        metadata={"attested_object": "WS-PRE-BUNDLE-MANIFEST-V1"},
+    )
+    provenance_value = provenance.model_dump(mode="json")
+    provenance_value["provenance_digest"] = provenance.digest()
+    provenance_value["claims_boundary"] = provenance.claims_boundary()
+    _write(out / "software_provenance.json", provenance_value)
+
+    index["custody_verification"] = store.verify_all()
+    index["readiness_ledger_digest"] = readiness["ledger_digest"]
+    index["horizon_portfolio_digest"] = horizons["portfolio_digest"]
+    index["software_provenance_digest"] = provenance.digest()
+    index["bloom_extensions"] = [
+        "edge_host_benchmark",
+        "ddil_partition_rejoin",
+        "capability_readiness_ledger",
+        "0-90D_3-12M_12-24M_PLUS_horizons",
+        "internal_unsigned_software_provenance",
+    ]
+    index["claims_boundary"].extend(
+        [
+            "Edge benchmark metrics are host/runtime specific and do not establish target-device performance.",
+            "DDIL rejoin evidence validates a synthetic conflict policy, not distributed consensus or operational network resilience.",
+            "Capability horizons schedule preparation only and never upgrade readiness claims.",
+            "Software provenance is INTERNAL_UNSIGNED unless a later attestation explicitly records signing/verification evidence.",
+        ]
+    )
+    _write(out / "qualification_index.json", index)
+    return index
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build Worldshepherd PRE full-bloom evidence")
+    parser.add_argument("--fixtures", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--software-commit", default=os.getenv("GITHUB_SHA", "UNKNOWN"))
+    parser.add_argument("--executed-utc", required=True)
+    parser.add_argument("--operator", default="worldshepherd-pre-bloom-cli")
+    args = parser.parse_args()
+    index = build_bloom(
+        fixtures=args.fixtures,
+        out=args.out,
+        software_commit=args.software_commit,
+        executed_utc=args.executed_utc,
+        operator=args.operator,
+    )
+    failed = any(index["failures"].values()) or not all(index["custody_verification"].values())
+    print(json.dumps(index, sort_keys=True))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 
+from .ade_qualification import qualify_synthetic_discovery
 from .apnt_qualification import qualify_synthetic_apnt_timeline
 from .ddil import Envelope
 from .ddil_campaign import run_ddil_campaign
@@ -33,6 +34,7 @@ def _requirement(
     lanes: list[str],
     missing: list[str],
     claims: list[str],
+    source_status: SourceStatus = SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
 ) -> RequirementDeltaRecord:
     return RequirementDeltaRecord(
         requirement_delta_id=requirement_id,
@@ -42,7 +44,7 @@ def _requirement(
             agency=agency,
             url=url,
             solicitation_or_topic=topic,
-            source_status=SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+            source_status=source_status,
             retrieved_utc="2026-08-26T00:00:00Z",
         ),
         statement=statement,
@@ -77,6 +79,7 @@ def build_all(
     apnt_fixture = _load(fixtures / "apnt_destroyer_strait_v1.json")
     mbse_fixture = _load(fixtures / "mbse_legacy_fixture_v1.json")
     ietm_fixture = _load(fixtures / "ietm_synthetic_v1.json")
+    ade_fixture = _load(fixtures / "ade_symbolic_v1.json")
 
     apnt_requirement = _requirement(
         requirement_id="PRE-RD-2026-0001",
@@ -111,6 +114,18 @@ def build_all(
         missing=["S1000D/MIL-standard validation", "Navy viewer compatibility", "production accuracy"],
         claims=["No S1000D, MIL-standard, Navy viewer, or production conversion claim"],
     )
+    ade_requirement = _requirement(
+        requirement_id="PRE-RD-2026-0012",
+        title="DARPA SPEED DIAL automated algorithm-discovery readiness target",
+        agency="DARPA",
+        url="https://www.darpa.mil/research/programs/speed-dial",
+        topic="DPA26TZ05-DV003",
+        statement="Develop measurable automated interpretable algorithm-discovery capability while preserving the distinction between a synthetic internal benchmark and the topic's pre-existing D2P2/SOTA evidence gate.",
+        lanes=["ADE-G", "AI governance", "digital engineering", "simulation governance"],
+        missing=["SOTA benchmark", "real engineering workflow integration", "D2P2 prior discovery evidence", "research-institution partner"],
+        claims=["No SOTA, scientific novelty, real-engineering superiority, or SPEED DIAL D2P2 eligibility claim"],
+        source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED,
+    )
 
     apnt = qualify_synthetic_apnt_timeline(
         fixture=apnt_fixture,
@@ -129,6 +144,13 @@ def build_all(
     ietm = qualify_synthetic_ietm(
         fixture=ietm_fixture,
         requirement=ietm_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    ade = qualify_synthetic_discovery(
+        fixture=ade_fixture,
+        requirement=ade_requirement,
         software_commit=software_commit,
         executed_utc=executed_utc,
         operator=operator,
@@ -154,6 +176,7 @@ def build_all(
         "apnt": apnt,
         "mbse": mbse,
         "ietm": ietm,
+        "ade": ade,
         "ddil": ddil,
     }
     custody_store = EvidenceStore(out / "echo_store")
@@ -178,11 +201,13 @@ def build_all(
             "apnt": canonical_digest(apnt_fixture),
             "mbse": canonical_digest(mbse_fixture),
             "ietm": canonical_digest(ietm_fixture),
+            "ade": canonical_digest(ade_fixture),
         },
         "failures": failures,
         "claims_boundary": [
             "This index records synthetic/internal software evidence only.",
             "The hash-addressed ECHO-style store provides local integrity/custody behavior only; it is not a government records system or legal chain-of-custody service.",
+            "ADE-G evidence in this index is a bounded synthetic interpretability/discovery benchmark and does not establish SOTA or SPEED DIAL D2P2 eligibility.",
             "No physical, platform, government, certification, compliance, clearance, or operational readiness is inferred from these passing bundles.",
         ],
     }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -14,6 +14,7 @@ from .ietm import qualify_synthetic_ietm
 from .mbse_benchmark import qualify_synthetic_mbse
 from .mission_qualification import qualify_synthetic_mission_replay
 from .sensor_fusion_qualification import qualify_synthetic_sensor_fusion
+from .rf_validation import qualify_synthetic_rf_discrepancy
 from .qualification import (
     CapabilityStatus,
     DemandClass,
@@ -30,6 +31,7 @@ def _requirement(
     statement: str, lanes: list[str], missing: list[str], claims: list[str],
     source_status: SourceStatus = SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
     demand_class: DemandClass = DemandClass.CONFIRMED_DEMAND,
+    capability_status: CapabilityStatus = CapabilityStatus.IMPLEMENTED_IN_SOFTWARE,
 ) -> RequirementDeltaRecord:
     return RequirementDeltaRecord(
         requirement_delta_id=requirement_id, demand_class=demand_class,
@@ -40,7 +42,7 @@ def _requirement(
         recurrence="Release-5 capture and reusable PRE readiness requirement",
         forecast_horizon=ForecastHorizon.D0_90, affected_lanes=lanes,
         existing_capability=["claims-controlled software qualification scaffold"],
-        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        capability_status=[capability_status],
         missing_capability=missing,
         experiment_or_demonstration_needed=["frozen synthetic reproducible benchmark"],
         evidence_target=["machine-readable qualification bundle"],
@@ -64,6 +66,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
     ade_fixture = _load(fixtures / "ade_symbolic_v1.json")
     mission_fixture = _load(fixtures / "mission_replay_synthetic_v1.json")
     fusion_fixture = _load(fixtures / "sensor_fusion_synthetic_v1.json")
+    rf_fixture = _load(fixtures / "rf_sparams_synthetic_v1.json")
 
     apnt_requirement = _requirement(requirement_id="PRE-RD-2026-0001", title="NAVWAR APNT operational awareness and decision-support target", agency="NAVWAR", url="https://navysbir.us/n26_5/DON26BX05-NP004.htm", topic="DON26BX05-NP004", statement="Demonstrate modular APNT operational-awareness software using representative synthetic data while retaining source confidence/provenance and bounded recovery decision support.", lanes=["APNT","C2","mission assurance","DDIL"], missing=["ASPN/pntOS/GPNTS validation","Navy operator validation"], claims=["No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim"])
     mbse_requirement = _requirement(requirement_id="PRE-RD-2026-0002", title="NAVSEA AI-to-MBSE reconstruction target", agency="NAVSEA", url="https://navysbir.us/n26_5/DON26BX05-NP003.htm", topic="DON26BX05-NP003", statement="Transform heterogeneous legacy artifacts into a source-traceable system model and measure reconstruction quality against known ground truth.", lanes=["MBSE","digital engineering","configuration provenance"], missing=["general document understanding","SysML/Cameo interoperability","Navy data validation"], claims=["No Navy/Aegis, Cameo/MagicDraw, classified-system, or production reconstruction claim"])
@@ -71,6 +74,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
     ade_requirement = _requirement(requirement_id="PRE-RD-2026-0012", title="DARPA SPEED DIAL automated algorithm-discovery readiness target", agency="DARPA", url="https://www.darpa.mil/research/programs/speed-dial", topic="DPA26TZ05-DV003", statement="Develop measurable automated interpretable algorithm-discovery capability while preserving the distinction between a synthetic internal benchmark and the topic's pre-existing D2P2/SOTA evidence gate.", lanes=["ADE-G","AI governance","digital engineering","simulation governance"], missing=["SOTA benchmark","real engineering workflow integration","D2P2 prior discovery evidence","research-institution partner"], claims=["No SOTA, scientific novelty, real-engineering superiority, or SPEED DIAL D2P2 eligibility claim"], source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED)
     mission_requirement = _requirement(requirement_id="PRE-RD-2026-0013", title="Navy automated post-mission debrief and replanning readiness target", agency="Navy", url="https://www.sbir.gov/", topic="DON26BZ05-NV074", statement="Preserve mission events, reconstruct evidence, derive bounded findings, and generate traceable follow-on COA proposals that remain subject to identified human authorization.", lanes=["OVERWATCH","ECHO","PRIME","autonomy governance","mission replay"], missing=["operational CCA/UAS mission data","validated causal reasoning","operator effectiveness","platform integration"], claims=["No operational CCA/UAS, causal-AI, autonomous replanning, or Navy mission-performance claim"])
     fusion_requirement = _requirement(requirement_id="PRE-RD-2026-0014", title="Distributed sensing and multi-sensor fusion readiness target", agency="Worldshepherd PRE", url="internal://pre/sensor-fusion-v1", topic="PREDICTIVE-DISTRIBUTED-SENSING", statement="Establish a deterministic source-traceable multi-sensor fusion baseline reusable across distributed sensing, edge AI and autonomy opportunities.", lanes=["distributed sensing","sensor fusion","ECHO","edge AI","mission assurance"], missing=["operational sensor data","validated multi-target association","edge deployment","partner sensor interfaces"], claims=["Synthetic 2-D point observations only; no operational sensor-fusion claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND)
+    rf_requirement = _requirement(requirement_id="PRE-RD-2026-0015", title="RF/metasurface simulation-to-measurement readiness target", agency="Worldshepherd PRE", url="internal://pre/rf-discrepancy-v1", topic="PREDICTIVE-RF-VALIDATION", statement="Quantify simulation-to-measurement discrepancy and uncertainty before any physical RF or metasurface performance claim.", lanes=["RF","metasurfaces","simulation governance","qualification evidence"], missing=["fabricated coupon","VNA/chamber measurement","independent physical validation"], claims=["Synthetic S11-like values only; no physical RF performance claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND, capability_status=CapabilityStatus.SIMULATED_ONLY)
 
     bundles = {
         "apnt": qualify_synthetic_apnt_timeline(fixture=apnt_fixture, requirement=apnt_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
@@ -79,6 +83,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
         "ade": qualify_synthetic_discovery(fixture=ade_fixture, requirement=ade_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
         "mission": qualify_synthetic_mission_replay(fixture=mission_fixture, requirement=mission_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
         "fusion": qualify_synthetic_sensor_fusion(fixture=fusion_fixture, requirement=fusion_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "rf": qualify_synthetic_rf_discrepancy(fixture=rf_fixture, requirement=rf_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
     }
     ddil_messages = [Envelope(sequence=i, source="synthetic-apnt-node", payload={"state_index": i}, timestamp_ms=i*100) for i in range(1,7)]
     bundles["ddil"] = run_ddil_campaign(messages=ddil_messages, requirement=apnt_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator)
@@ -90,7 +95,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
         custody_digests[name] = custody_store.put_bundle(bundle)
 
     failures = {name:[record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"] for name,bundle in bundles.items()}
-    fixture_values = {"apnt":apnt_fixture,"mbse":mbse_fixture,"ietm":ietm_fixture,"ade":ade_fixture,"mission":mission_fixture,"fusion":fusion_fixture}
+    fixture_values = {"apnt":apnt_fixture,"mbse":mbse_fixture,"ietm":ietm_fixture,"ade":ade_fixture,"mission":mission_fixture,"fusion":fusion_fixture,"rf":rf_fixture}
     index = {
         "schema":"WS-PRE-QUALIFICATION-INDEX-V1",
         "software_commit":software_commit,"executed_utc":executed_utc,"operator":operator,
@@ -98,7 +103,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
         "custody_digests":custody_digests,"custody_verification":custody_store.verify_all(),
         "fixture_digests":{name:canonical_digest(value) for name,value in fixture_values.items()},
         "failures":failures,
-        "claims_boundary":["This index records synthetic/internal software evidence only.","The ECHO-style store is a local integrity/custody mechanism, not a government records system or legal chain-of-custody service.","Passing bundles do not establish physical, platform, government, certification, compliance, clearance, operational, SOTA, or partner validation."],
+        "claims_boundary":["This index records synthetic/internal software evidence only.","The ECHO-style store is a local integrity/custody mechanism, not a government records system or legal chain-of-custody service.","RF evidence uses synthetic prediction/measurement values and remains SIMULATED_ONLY.","Passing bundles do not establish physical, platform, government, certification, compliance, clearance, operational, SOTA, or partner validation."],
     }
     _write(out / "qualification_index.json", index)
     return index

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -13,6 +13,7 @@ from .evidence_store import EvidenceStore
 from .ietm import qualify_synthetic_ietm
 from .mbse_benchmark import qualify_synthetic_mbse
 from .mission_qualification import qualify_synthetic_mission_replay
+from .sensor_fusion_qualification import qualify_synthetic_sensor_fusion
 from .qualification import (
     CapabilityStatus,
     DemandClass,
@@ -25,33 +26,19 @@ from .qualification import (
 
 
 def _requirement(
-    *,
-    requirement_id: str,
-    title: str,
-    agency: str,
-    url: str,
-    topic: str,
-    statement: str,
-    lanes: list[str],
-    missing: list[str],
-    claims: list[str],
+    *, requirement_id: str, title: str, agency: str, url: str, topic: str,
+    statement: str, lanes: list[str], missing: list[str], claims: list[str],
     source_status: SourceStatus = SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+    demand_class: DemandClass = DemandClass.CONFIRMED_DEMAND,
 ) -> RequirementDeltaRecord:
     return RequirementDeltaRecord(
-        requirement_delta_id=requirement_id,
-        demand_class=DemandClass.CONFIRMED_DEMAND,
-        source=SourceRecord(
-            title=title,
-            agency=agency,
-            url=url,
-            solicitation_or_topic=topic,
-            source_status=source_status,
-            retrieved_utc="2026-08-26T00:00:00Z",
-        ),
+        requirement_delta_id=requirement_id, demand_class=demand_class,
+        source=SourceRecord(title=title, agency=agency, url=url,
+            solicitation_or_topic=topic, source_status=source_status,
+            retrieved_utc="2026-08-26T00:00:00Z"),
         statement=statement,
         recurrence="Release-5 capture and reusable PRE readiness requirement",
-        forecast_horizon=ForecastHorizon.D0_90,
-        affected_lanes=lanes,
+        forecast_horizon=ForecastHorizon.D0_90, affected_lanes=lanes,
         existing_capability=["claims-controlled software qualification scaffold"],
         capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
         missing_capability=missing,
@@ -66,173 +53,52 @@ def _load(path: Path) -> dict:
 
 
 def _write(path: Path, value: dict) -> None:
-    path.write_text(
-        json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    path.write_text(json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 
 
-def build_all(
-    *, fixtures: Path, out: Path, software_commit: str, executed_utc: str, operator: str
-) -> dict:
+def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: str, operator: str) -> dict:
     out.mkdir(parents=True, exist_ok=True)
-
     apnt_fixture = _load(fixtures / "apnt_destroyer_strait_v1.json")
     mbse_fixture = _load(fixtures / "mbse_legacy_fixture_v1.json")
     ietm_fixture = _load(fixtures / "ietm_synthetic_v1.json")
     ade_fixture = _load(fixtures / "ade_symbolic_v1.json")
     mission_fixture = _load(fixtures / "mission_replay_synthetic_v1.json")
+    fusion_fixture = _load(fixtures / "sensor_fusion_synthetic_v1.json")
 
-    apnt_requirement = _requirement(
-        requirement_id="PRE-RD-2026-0001",
-        title="NAVWAR APNT operational awareness and decision-support target",
-        agency="NAVWAR",
-        url="https://navysbir.us/n26_5/DON26BX05-NP004.htm",
-        topic="DON26BX05-NP004",
-        statement="Demonstrate modular APNT operational-awareness software using representative synthetic data while retaining source confidence/provenance and bounded recovery decision support.",
-        lanes=["APNT", "C2", "mission assurance", "DDIL"],
-        missing=["ASPN/pntOS/GPNTS validation", "Navy operator validation"],
-        claims=["No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim"],
-    )
-    mbse_requirement = _requirement(
-        requirement_id="PRE-RD-2026-0002",
-        title="NAVSEA AI-to-MBSE reconstruction target",
-        agency="NAVSEA",
-        url="https://navysbir.us/n26_5/DON26BX05-NP003.htm",
-        topic="DON26BX05-NP003",
-        statement="Transform heterogeneous legacy artifacts into a source-traceable system model and measure reconstruction quality against known ground truth.",
-        lanes=["MBSE", "digital engineering", "configuration provenance"],
-        missing=["general document understanding", "SysML/Cameo interoperability", "Navy data validation"],
-        claims=["No Navy/Aegis, Cameo/MagicDraw, classified-system, or production reconstruction claim"],
-    )
-    ietm_requirement = _requirement(
-        requirement_id="PRE-RD-2026-0003",
-        title="NAVAIR technical-data/IETM transformation target",
-        agency="NAVAIR",
-        url="https://navysbir.us/n26_5/DON26BZ05-NV078.htm",
-        topic="DON26BZ05-NV078",
-        statement="Transform technical data while preserving source structure and distribution markings through a governed, testable conversion pipeline.",
-        lanes=["technical data", "IETM", "provenance", "configuration custody"],
-        missing=["S1000D/MIL-standard validation", "Navy viewer compatibility", "production accuracy"],
-        claims=["No S1000D, MIL-standard, Navy viewer, or production conversion claim"],
-    )
-    ade_requirement = _requirement(
-        requirement_id="PRE-RD-2026-0012",
-        title="DARPA SPEED DIAL automated algorithm-discovery readiness target",
-        agency="DARPA",
-        url="https://www.darpa.mil/research/programs/speed-dial",
-        topic="DPA26TZ05-DV003",
-        statement="Develop measurable automated interpretable algorithm-discovery capability while preserving the distinction between a synthetic internal benchmark and the topic's pre-existing D2P2/SOTA evidence gate.",
-        lanes=["ADE-G", "AI governance", "digital engineering", "simulation governance"],
-        missing=["SOTA benchmark", "real engineering workflow integration", "D2P2 prior discovery evidence", "research-institution partner"],
-        claims=["No SOTA, scientific novelty, real-engineering superiority, or SPEED DIAL D2P2 eligibility claim"],
-        source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED,
-    )
-    mission_requirement = _requirement(
-        requirement_id="PRE-RD-2026-0013",
-        title="Navy automated post-mission debrief and replanning readiness target",
-        agency="Navy",
-        url="https://www.sbir.gov/",
-        topic="DON26BZ05-NV074",
-        statement="Preserve mission events, reconstruct evidence, derive bounded findings, and generate traceable follow-on COA proposals that remain subject to identified human authorization.",
-        lanes=["OVERWATCH", "ECHO", "PRIME", "autonomy governance", "mission replay"],
-        missing=["operational CCA/UAS mission data", "validated causal reasoning", "operator effectiveness", "platform integration"],
-        claims=["No operational CCA/UAS, causal-AI, autonomous replanning, or Navy mission-performance claim"],
-    )
-
-    apnt = qualify_synthetic_apnt_timeline(
-        fixture=apnt_fixture,
-        requirement=apnt_requirement,
-        software_commit=software_commit,
-        executed_utc=executed_utc,
-        operator=operator,
-    )
-    mbse = qualify_synthetic_mbse(
-        fixture=mbse_fixture,
-        requirement=mbse_requirement,
-        software_commit=software_commit,
-        executed_utc=executed_utc,
-        operator=operator,
-    )
-    ietm = qualify_synthetic_ietm(
-        fixture=ietm_fixture,
-        requirement=ietm_requirement,
-        software_commit=software_commit,
-        executed_utc=executed_utc,
-        operator=operator,
-    )
-    ade = qualify_synthetic_discovery(
-        fixture=ade_fixture,
-        requirement=ade_requirement,
-        software_commit=software_commit,
-        executed_utc=executed_utc,
-        operator=operator,
-    )
-    mission = qualify_synthetic_mission_replay(
-        fixture=mission_fixture,
-        requirement=mission_requirement,
-        software_commit=software_commit,
-        executed_utc=executed_utc,
-        operator=operator,
-    )
-    ddil_messages = [
-        Envelope(
-            sequence=i,
-            source="synthetic-apnt-node",
-            payload={"state_index": i},
-            timestamp_ms=i * 100,
-        )
-        for i in range(1, 7)
-    ]
-    ddil = run_ddil_campaign(
-        messages=ddil_messages,
-        requirement=apnt_requirement,
-        software_commit=software_commit,
-        executed_utc=executed_utc,
-        operator=operator,
-    )
+    apnt_requirement = _requirement(requirement_id="PRE-RD-2026-0001", title="NAVWAR APNT operational awareness and decision-support target", agency="NAVWAR", url="https://navysbir.us/n26_5/DON26BX05-NP004.htm", topic="DON26BX05-NP004", statement="Demonstrate modular APNT operational-awareness software using representative synthetic data while retaining source confidence/provenance and bounded recovery decision support.", lanes=["APNT","C2","mission assurance","DDIL"], missing=["ASPN/pntOS/GPNTS validation","Navy operator validation"], claims=["No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim"])
+    mbse_requirement = _requirement(requirement_id="PRE-RD-2026-0002", title="NAVSEA AI-to-MBSE reconstruction target", agency="NAVSEA", url="https://navysbir.us/n26_5/DON26BX05-NP003.htm", topic="DON26BX05-NP003", statement="Transform heterogeneous legacy artifacts into a source-traceable system model and measure reconstruction quality against known ground truth.", lanes=["MBSE","digital engineering","configuration provenance"], missing=["general document understanding","SysML/Cameo interoperability","Navy data validation"], claims=["No Navy/Aegis, Cameo/MagicDraw, classified-system, or production reconstruction claim"])
+    ietm_requirement = _requirement(requirement_id="PRE-RD-2026-0003", title="NAVAIR technical-data/IETM transformation target", agency="NAVAIR", url="https://navysbir.us/n26_5/DON26BZ05-NV078.htm", topic="DON26BZ05-NV078", statement="Transform technical data while preserving source structure and distribution markings through a governed, testable conversion pipeline.", lanes=["technical data","IETM","provenance","configuration custody"], missing=["S1000D/MIL-standard validation","Navy viewer compatibility","production accuracy"], claims=["No S1000D, MIL-standard, Navy viewer, or production conversion claim"])
+    ade_requirement = _requirement(requirement_id="PRE-RD-2026-0012", title="DARPA SPEED DIAL automated algorithm-discovery readiness target", agency="DARPA", url="https://www.darpa.mil/research/programs/speed-dial", topic="DPA26TZ05-DV003", statement="Develop measurable automated interpretable algorithm-discovery capability while preserving the distinction between a synthetic internal benchmark and the topic's pre-existing D2P2/SOTA evidence gate.", lanes=["ADE-G","AI governance","digital engineering","simulation governance"], missing=["SOTA benchmark","real engineering workflow integration","D2P2 prior discovery evidence","research-institution partner"], claims=["No SOTA, scientific novelty, real-engineering superiority, or SPEED DIAL D2P2 eligibility claim"], source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED)
+    mission_requirement = _requirement(requirement_id="PRE-RD-2026-0013", title="Navy automated post-mission debrief and replanning readiness target", agency="Navy", url="https://www.sbir.gov/", topic="DON26BZ05-NV074", statement="Preserve mission events, reconstruct evidence, derive bounded findings, and generate traceable follow-on COA proposals that remain subject to identified human authorization.", lanes=["OVERWATCH","ECHO","PRIME","autonomy governance","mission replay"], missing=["operational CCA/UAS mission data","validated causal reasoning","operator effectiveness","platform integration"], claims=["No operational CCA/UAS, causal-AI, autonomous replanning, or Navy mission-performance claim"])
+    fusion_requirement = _requirement(requirement_id="PRE-RD-2026-0014", title="Distributed sensing and multi-sensor fusion readiness target", agency="Worldshepherd PRE", url="internal://pre/sensor-fusion-v1", topic="PREDICTIVE-DISTRIBUTED-SENSING", statement="Establish a deterministic source-traceable multi-sensor fusion baseline reusable across distributed sensing, edge AI and autonomy opportunities.", lanes=["distributed sensing","sensor fusion","ECHO","edge AI","mission assurance"], missing=["operational sensor data","validated multi-target association","edge deployment","partner sensor interfaces"], claims=["Synthetic 2-D point observations only; no operational sensor-fusion claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND)
 
     bundles = {
-        "apnt": apnt,
-        "mbse": mbse,
-        "ietm": ietm,
-        "ade": ade,
-        "mission": mission,
-        "ddil": ddil,
+        "apnt": qualify_synthetic_apnt_timeline(fixture=apnt_fixture, requirement=apnt_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "mbse": qualify_synthetic_mbse(fixture=mbse_fixture, requirement=mbse_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "ietm": qualify_synthetic_ietm(fixture=ietm_fixture, requirement=ietm_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "ade": qualify_synthetic_discovery(fixture=ade_fixture, requirement=ade_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "mission": qualify_synthetic_mission_replay(fixture=mission_fixture, requirement=mission_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "fusion": qualify_synthetic_sensor_fusion(fixture=fusion_fixture, requirement=fusion_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
     }
+    ddil_messages = [Envelope(sequence=i, source="synthetic-apnt-node", payload={"state_index": i}, timestamp_ms=i*100) for i in range(1,7)]
+    bundles["ddil"] = run_ddil_campaign(messages=ddil_messages, requirement=apnt_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator)
+
     custody_store = EvidenceStore(out / "echo_store")
-    custody_digests: dict[str, str] = {}
+    custody_digests: dict[str,str] = {}
     for name, bundle in bundles.items():
         _write(out / f"{name}_qualification_bundle.json", bundle)
         custody_digests[name] = custody_store.put_bundle(bundle)
 
-    failures = {
-        name: [record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"]
-        for name, bundle in bundles.items()
-    }
+    failures = {name:[record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"] for name,bundle in bundles.items()}
+    fixture_values = {"apnt":apnt_fixture,"mbse":mbse_fixture,"ietm":ietm_fixture,"ade":ade_fixture,"mission":mission_fixture,"fusion":fusion_fixture}
     index = {
-        "schema": "WS-PRE-QUALIFICATION-INDEX-V1",
-        "software_commit": software_commit,
-        "executed_utc": executed_utc,
-        "operator": operator,
-        "bundle_digests": {name: bundle["bundle_digest"] for name, bundle in bundles.items()},
-        "custody_digests": custody_digests,
-        "custody_verification": custody_store.verify_all(),
-        "fixture_digests": {
-            "apnt": canonical_digest(apnt_fixture),
-            "mbse": canonical_digest(mbse_fixture),
-            "ietm": canonical_digest(ietm_fixture),
-            "ade": canonical_digest(ade_fixture),
-            "mission": canonical_digest(mission_fixture),
-        },
-        "failures": failures,
-        "claims_boundary": [
-            "This index records synthetic/internal software evidence only.",
-            "The hash-addressed ECHO-style store provides local integrity/custody behavior only; it is not a government records system or legal chain-of-custody service.",
-            "ADE-G evidence in this index is a bounded synthetic interpretability/discovery benchmark and does not establish SOTA or SPEED DIAL D2P2 eligibility.",
-            "Mission replay evidence is synthetic and all follow-on actions remain proposals pending identified human authorization.",
-            "No physical, platform, government, certification, compliance, clearance, or operational readiness is inferred from these passing bundles.",
-        ],
+        "schema":"WS-PRE-QUALIFICATION-INDEX-V1",
+        "software_commit":software_commit,"executed_utc":executed_utc,"operator":operator,
+        "bundle_digests":{name:bundle["bundle_digest"] for name,bundle in bundles.items()},
+        "custody_digests":custody_digests,"custody_verification":custody_store.verify_all(),
+        "fixture_digests":{name:canonical_digest(value) for name,value in fixture_values.items()},
+        "failures":failures,
+        "claims_boundary":["This index records synthetic/internal software evidence only.","The ECHO-style store is a local integrity/custody mechanism, not a government records system or legal chain-of-custody service.","Passing bundles do not establish physical, platform, government, certification, compliance, clearance, operational, SOTA, or partner validation."],
     }
     _write(out / "qualification_index.json", index)
     return index
@@ -246,14 +112,7 @@ def main() -> int:
     parser.add_argument("--executed-utc", required=True)
     parser.add_argument("--operator", default="worldshepherd-pre-cli")
     args = parser.parse_args()
-
-    index = build_all(
-        fixtures=args.fixtures,
-        out=args.out,
-        software_commit=args.software_commit,
-        executed_utc=args.executed_utc,
-        operator=args.operator,
-    )
+    index = build_all(fixtures=args.fixtures,out=args.out,software_commit=args.software_commit,executed_utc=args.executed_utc,operator=args.operator)
     failed = any(index["failures"].values()) or not all(index["custody_verification"].values())
     print(json.dumps(index, sort_keys=True))
     return 1 if failed else 0

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from .apnt_qualification import qualify_synthetic_apnt_timeline
+from .ddil import Envelope
+from .ddil_campaign import run_ddil_campaign
+from .ietm import qualify_synthetic_ietm
+from .mbse_benchmark import qualify_synthetic_mbse
+from .qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+    canonical_digest,
+)
+
+
+def _requirement(
+    *,
+    requirement_id: str,
+    title: str,
+    agency: str,
+    url: str,
+    topic: str,
+    statement: str,
+    lanes: list[str],
+    missing: list[str],
+    claims: list[str],
+) -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id=requirement_id,
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title=title,
+            agency=agency,
+            url=url,
+            solicitation_or_topic=topic,
+            source_status=SourceStatus.GOVERNMENT_SECONDARY_VERIFIED,
+            retrieved_utc="2026-08-26T00:00:00Z",
+        ),
+        statement=statement,
+        recurrence="Release-5 capture and reusable PRE readiness requirement",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=lanes,
+        existing_capability=["claims-controlled software qualification scaffold"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=missing,
+        experiment_or_demonstration_needed=["frozen synthetic reproducible benchmark"],
+        evidence_target=["machine-readable qualification bundle"],
+        claims_boundary=claims,
+    )
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, value: dict) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_all(
+    *, fixtures: Path, out: Path, software_commit: str, executed_utc: str, operator: str
+) -> dict:
+    out.mkdir(parents=True, exist_ok=True)
+
+    apnt_fixture = _load(fixtures / "apnt_destroyer_strait_v1.json")
+    mbse_fixture = _load(fixtures / "mbse_legacy_fixture_v1.json")
+    ietm_fixture = _load(fixtures / "ietm_synthetic_v1.json")
+
+    apnt_requirement = _requirement(
+        requirement_id="PRE-RD-2026-0001",
+        title="NAVWAR APNT operational awareness and decision-support target",
+        agency="NAVWAR",
+        url="https://navysbir.us/n26_5/DON26BX05-NP004.htm",
+        topic="DON26BX05-NP004",
+        statement="Demonstrate modular APNT operational-awareness software using representative synthetic data while retaining source confidence/provenance and bounded recovery decision support.",
+        lanes=["APNT", "C2", "mission assurance", "DDIL"],
+        missing=["ASPN/pntOS/GPNTS validation", "Navy operator validation"],
+        claims=["No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim"],
+    )
+    mbse_requirement = _requirement(
+        requirement_id="PRE-RD-2026-0002",
+        title="NAVSEA AI-to-MBSE reconstruction target",
+        agency="NAVSEA",
+        url="https://navysbir.us/n26_5/DON26BX05-NP003.htm",
+        topic="DON26BX05-NP003",
+        statement="Transform heterogeneous legacy artifacts into a source-traceable system model and measure reconstruction quality against known ground truth.",
+        lanes=["MBSE", "digital engineering", "configuration provenance"],
+        missing=["general document understanding", "SysML/Cameo interoperability", "Navy data validation"],
+        claims=["No Navy/Aegis, Cameo/MagicDraw, classified-system, or production reconstruction claim"],
+    )
+    ietm_requirement = _requirement(
+        requirement_id="PRE-RD-2026-0003",
+        title="NAVAIR technical-data/IETM transformation target",
+        agency="NAVAIR",
+        url="https://navysbir.us/n26_5/DON26BZ05-NV078.htm",
+        topic="DON26BZ05-NV078",
+        statement="Transform technical data while preserving source structure and distribution markings through a governed, testable conversion pipeline.",
+        lanes=["technical data", "IETM", "provenance", "configuration custody"],
+        missing=["S1000D/MIL-standard validation", "Navy viewer compatibility", "production accuracy"],
+        claims=["No S1000D, MIL-standard, Navy viewer, or production conversion claim"],
+    )
+
+    apnt = qualify_synthetic_apnt_timeline(
+        fixture=apnt_fixture,
+        requirement=apnt_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    mbse = qualify_synthetic_mbse(
+        fixture=mbse_fixture,
+        requirement=mbse_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    ietm = qualify_synthetic_ietm(
+        fixture=ietm_fixture,
+        requirement=ietm_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    ddil_messages = [
+        Envelope(
+            sequence=i,
+            source="synthetic-apnt-node",
+            payload={"state_index": i},
+            timestamp_ms=i * 100,
+        )
+        for i in range(1, 7)
+    ]
+    ddil = run_ddil_campaign(
+        messages=ddil_messages,
+        requirement=apnt_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+
+    bundles = {
+        "apnt": apnt,
+        "mbse": mbse,
+        "ietm": ietm,
+        "ddil": ddil,
+    }
+    for name, bundle in bundles.items():
+        _write(out / f"{name}_qualification_bundle.json", bundle)
+
+    failures = {
+        name: [record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"]
+        for name, bundle in bundles.items()
+    }
+    index = {
+        "schema": "WS-PRE-QUALIFICATION-INDEX-V1",
+        "software_commit": software_commit,
+        "executed_utc": executed_utc,
+        "operator": operator,
+        "bundle_digests": {name: bundle["bundle_digest"] for name, bundle in bundles.items()},
+        "fixture_digests": {
+            "apnt": canonical_digest(apnt_fixture),
+            "mbse": canonical_digest(mbse_fixture),
+            "ietm": canonical_digest(ietm_fixture),
+        },
+        "failures": failures,
+        "claims_boundary": [
+            "This index records synthetic/internal software evidence only.",
+            "No physical, platform, government, certification, compliance, clearance, or operational readiness is inferred from these passing bundles.",
+        ],
+    }
+    _write(out / "qualification_index.json", index)
+    return index
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build claims-controlled PRE qualification evidence")
+    parser.add_argument("--fixtures", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--software-commit", default=os.getenv("GITHUB_SHA", "UNKNOWN"))
+    parser.add_argument("--executed-utc", required=True)
+    parser.add_argument("--operator", default="worldshepherd-pre-cli")
+    args = parser.parse_args()
+
+    index = build_all(
+        fixtures=args.fixtures,
+        out=args.out,
+        software_commit=args.software_commit,
+        executed_utc=args.executed_utc,
+        operator=args.operator,
+    )
+    failed = any(index["failures"].values())
+    print(json.dumps(index, sort_keys=True))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from .apnt_qualification import qualify_synthetic_apnt_timeline
 from .ddil import Envelope
 from .ddil_campaign import run_ddil_campaign
+from .evidence_store import EvidenceStore
 from .ietm import qualify_synthetic_ietm
 from .mbse_benchmark import qualify_synthetic_mbse
 from .qualification import (
@@ -155,8 +156,11 @@ def build_all(
         "ietm": ietm,
         "ddil": ddil,
     }
+    custody_store = EvidenceStore(out / "echo_store")
+    custody_digests: dict[str, str] = {}
     for name, bundle in bundles.items():
         _write(out / f"{name}_qualification_bundle.json", bundle)
+        custody_digests[name] = custody_store.put_bundle(bundle)
 
     failures = {
         name: [record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"]
@@ -168,6 +172,8 @@ def build_all(
         "executed_utc": executed_utc,
         "operator": operator,
         "bundle_digests": {name: bundle["bundle_digest"] for name, bundle in bundles.items()},
+        "custody_digests": custody_digests,
+        "custody_verification": custody_store.verify_all(),
         "fixture_digests": {
             "apnt": canonical_digest(apnt_fixture),
             "mbse": canonical_digest(mbse_fixture),
@@ -176,6 +182,7 @@ def build_all(
         "failures": failures,
         "claims_boundary": [
             "This index records synthetic/internal software evidence only.",
+            "The hash-addressed ECHO-style store provides local integrity/custody behavior only; it is not a government records system or legal chain-of-custody service.",
             "No physical, platform, government, certification, compliance, clearance, or operational readiness is inferred from these passing bundles.",
         ],
     }
@@ -199,7 +206,7 @@ def main() -> int:
         executed_utc=args.executed_utc,
         operator=args.operator,
     )
-    failed = any(index["failures"].values())
+    failed = any(index["failures"].values()) or not all(index["custody_verification"].values())
     print(json.dumps(index, sort_keys=True))
     return 1 if failed else 0
 

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -12,6 +12,7 @@ from .ddil_campaign import run_ddil_campaign
 from .evidence_store import EvidenceStore
 from .ietm import qualify_synthetic_ietm
 from .mbse_benchmark import qualify_synthetic_mbse
+from .mission_qualification import qualify_synthetic_mission_replay
 from .qualification import (
     CapabilityStatus,
     DemandClass,
@@ -80,6 +81,7 @@ def build_all(
     mbse_fixture = _load(fixtures / "mbse_legacy_fixture_v1.json")
     ietm_fixture = _load(fixtures / "ietm_synthetic_v1.json")
     ade_fixture = _load(fixtures / "ade_symbolic_v1.json")
+    mission_fixture = _load(fixtures / "mission_replay_synthetic_v1.json")
 
     apnt_requirement = _requirement(
         requirement_id="PRE-RD-2026-0001",
@@ -126,6 +128,17 @@ def build_all(
         claims=["No SOTA, scientific novelty, real-engineering superiority, or SPEED DIAL D2P2 eligibility claim"],
         source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED,
     )
+    mission_requirement = _requirement(
+        requirement_id="PRE-RD-2026-0013",
+        title="Navy automated post-mission debrief and replanning readiness target",
+        agency="Navy",
+        url="https://www.sbir.gov/",
+        topic="DON26BZ05-NV074",
+        statement="Preserve mission events, reconstruct evidence, derive bounded findings, and generate traceable follow-on COA proposals that remain subject to identified human authorization.",
+        lanes=["OVERWATCH", "ECHO", "PRIME", "autonomy governance", "mission replay"],
+        missing=["operational CCA/UAS mission data", "validated causal reasoning", "operator effectiveness", "platform integration"],
+        claims=["No operational CCA/UAS, causal-AI, autonomous replanning, or Navy mission-performance claim"],
+    )
 
     apnt = qualify_synthetic_apnt_timeline(
         fixture=apnt_fixture,
@@ -155,6 +168,13 @@ def build_all(
         executed_utc=executed_utc,
         operator=operator,
     )
+    mission = qualify_synthetic_mission_replay(
+        fixture=mission_fixture,
+        requirement=mission_requirement,
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
     ddil_messages = [
         Envelope(
             sequence=i,
@@ -177,6 +197,7 @@ def build_all(
         "mbse": mbse,
         "ietm": ietm,
         "ade": ade,
+        "mission": mission,
         "ddil": ddil,
     }
     custody_store = EvidenceStore(out / "echo_store")
@@ -202,12 +223,14 @@ def build_all(
             "mbse": canonical_digest(mbse_fixture),
             "ietm": canonical_digest(ietm_fixture),
             "ade": canonical_digest(ade_fixture),
+            "mission": canonical_digest(mission_fixture),
         },
         "failures": failures,
         "claims_boundary": [
             "This index records synthetic/internal software evidence only.",
             "The hash-addressed ECHO-style store provides local integrity/custody behavior only; it is not a government records system or legal chain-of-custody service.",
             "ADE-G evidence in this index is a bounded synthetic interpretability/discovery benchmark and does not establish SOTA or SPEED DIAL D2P2 eligibility.",
+            "Mission replay evidence is synthetic and all follow-on actions remain proposals pending identified human authorization.",
             "No physical, platform, government, certification, compliance, clearance, or operational readiness is inferred from these passing bundles.",
         ],
     }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_cli.py
@@ -7,14 +7,16 @@ from pathlib import Path
 
 from .ade_qualification import qualify_synthetic_discovery
 from .apnt_qualification import qualify_synthetic_apnt_timeline
+from .cbm_qualification import qualify_synthetic_cbm
 from .ddil import Envelope
 from .ddil_campaign import run_ddil_campaign
 from .evidence_store import EvidenceStore
 from .ietm import qualify_synthetic_ietm
+from .manufacturing_qualification import qualify_synthetic_manufacturing_thread
 from .mbse_benchmark import qualify_synthetic_mbse
 from .mission_qualification import qualify_synthetic_mission_replay
-from .sensor_fusion_qualification import qualify_synthetic_sensor_fusion
 from .rf_validation import qualify_synthetic_rf_discrepancy
+from .sensor_fusion_qualification import qualify_synthetic_sensor_fusion
 from .qualification import (
     CapabilityStatus,
     DemandClass,
@@ -67,6 +69,8 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
     mission_fixture = _load(fixtures / "mission_replay_synthetic_v1.json")
     fusion_fixture = _load(fixtures / "sensor_fusion_synthetic_v1.json")
     rf_fixture = _load(fixtures / "rf_sparams_synthetic_v1.json")
+    cbm_fixture = _load(fixtures / "cbm_twin_synthetic_v1.json")
+    mfg_fixture = _load(fixtures / "manufacturing_thread_synthetic_v1.json")
 
     apnt_requirement = _requirement(requirement_id="PRE-RD-2026-0001", title="NAVWAR APNT operational awareness and decision-support target", agency="NAVWAR", url="https://navysbir.us/n26_5/DON26BX05-NP004.htm", topic="DON26BX05-NP004", statement="Demonstrate modular APNT operational-awareness software using representative synthetic data while retaining source confidence/provenance and bounded recovery decision support.", lanes=["APNT","C2","mission assurance","DDIL"], missing=["ASPN/pntOS/GPNTS validation","Navy operator validation"], claims=["No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim"])
     mbse_requirement = _requirement(requirement_id="PRE-RD-2026-0002", title="NAVSEA AI-to-MBSE reconstruction target", agency="NAVSEA", url="https://navysbir.us/n26_5/DON26BX05-NP003.htm", topic="DON26BX05-NP003", statement="Transform heterogeneous legacy artifacts into a source-traceable system model and measure reconstruction quality against known ground truth.", lanes=["MBSE","digital engineering","configuration provenance"], missing=["general document understanding","SysML/Cameo interoperability","Navy data validation"], claims=["No Navy/Aegis, Cameo/MagicDraw, classified-system, or production reconstruction claim"])
@@ -75,6 +79,8 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
     mission_requirement = _requirement(requirement_id="PRE-RD-2026-0013", title="Navy automated post-mission debrief and replanning readiness target", agency="Navy", url="https://www.sbir.gov/", topic="DON26BZ05-NV074", statement="Preserve mission events, reconstruct evidence, derive bounded findings, and generate traceable follow-on COA proposals that remain subject to identified human authorization.", lanes=["OVERWATCH","ECHO","PRIME","autonomy governance","mission replay"], missing=["operational CCA/UAS mission data","validated causal reasoning","operator effectiveness","platform integration"], claims=["No operational CCA/UAS, causal-AI, autonomous replanning, or Navy mission-performance claim"])
     fusion_requirement = _requirement(requirement_id="PRE-RD-2026-0014", title="Distributed sensing and multi-sensor fusion readiness target", agency="Worldshepherd PRE", url="internal://pre/sensor-fusion-v1", topic="PREDICTIVE-DISTRIBUTED-SENSING", statement="Establish a deterministic source-traceable multi-sensor fusion baseline reusable across distributed sensing, edge AI and autonomy opportunities.", lanes=["distributed sensing","sensor fusion","ECHO","edge AI","mission assurance"], missing=["operational sensor data","validated multi-target association","edge deployment","partner sensor interfaces"], claims=["Synthetic 2-D point observations only; no operational sensor-fusion claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND)
     rf_requirement = _requirement(requirement_id="PRE-RD-2026-0015", title="RF/metasurface simulation-to-measurement readiness target", agency="Worldshepherd PRE", url="internal://pre/rf-discrepancy-v1", topic="PREDICTIVE-RF-VALIDATION", statement="Quantify simulation-to-measurement discrepancy and uncertainty before any physical RF or metasurface performance claim.", lanes=["RF","metasurfaces","simulation governance","qualification evidence"], missing=["fabricated coupon","VNA/chamber measurement","independent physical validation"], claims=["Synthetic S11-like values only; no physical RF performance claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND, capability_status=CapabilityStatus.SIMULATED_ONLY)
+    cbm_requirement = _requirement(requirement_id="PRE-RD-2026-0016", title="CBM+ and digital-twin readiness target", agency="Worldshepherd PRE", url="internal://pre/cbm-v1", topic="PREDICTIVE-CBM", statement="Establish source-traceable synthetic health-state classification before predictive-maintenance or RUL claims.", lanes=["CBM+","digital twins","maintenance","ECHO"], missing=["real asset telemetry","failure labels","RUL validation","maintainer validation"], claims=["Synthetic telemetry only; no predictive-maintenance claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND)
+    mfg_requirement = _requirement(requirement_id="PRE-RD-2026-0017", title="DED/manufacturing digital-thread readiness target", agency="Worldshepherd PRE", url="internal://pre/mfg-thread-v1", topic="PREDICTIVE-MFG-QUALIFICATION", statement="Establish machine-readable material/process/build/specimen provenance before physical manufacturing qualification claims.", lanes=["DED","additive manufacturing","digital thread","manufacturing provenance"], missing=["physical coupon","machine calibration evidence","property measurement","partner lab validation"], claims=["Digital thread only; no alloy/process/property claim"], source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE, demand_class=DemandClass.EMERGING_DEMAND)
 
     bundles = {
         "apnt": qualify_synthetic_apnt_timeline(fixture=apnt_fixture, requirement=apnt_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
@@ -84,6 +90,8 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
         "mission": qualify_synthetic_mission_replay(fixture=mission_fixture, requirement=mission_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
         "fusion": qualify_synthetic_sensor_fusion(fixture=fusion_fixture, requirement=fusion_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
         "rf": qualify_synthetic_rf_discrepancy(fixture=rf_fixture, requirement=rf_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "cbm": qualify_synthetic_cbm(fixture=cbm_fixture, requirement=cbm_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
+        "manufacturing": qualify_synthetic_manufacturing_thread(fixture=mfg_fixture, requirement=mfg_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator),
     }
     ddil_messages = [Envelope(sequence=i, source="synthetic-apnt-node", payload={"state_index": i}, timestamp_ms=i*100) for i in range(1,7)]
     bundles["ddil"] = run_ddil_campaign(messages=ddil_messages, requirement=apnt_requirement, software_commit=software_commit, executed_utc=executed_utc, operator=operator)
@@ -95,7 +103,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
         custody_digests[name] = custody_store.put_bundle(bundle)
 
     failures = {name:[record["test_id"] for record in bundle["evidence"] if record["result"] != "PASS"] for name,bundle in bundles.items()}
-    fixture_values = {"apnt":apnt_fixture,"mbse":mbse_fixture,"ietm":ietm_fixture,"ade":ade_fixture,"mission":mission_fixture,"fusion":fusion_fixture,"rf":rf_fixture}
+    fixture_values = {"apnt":apnt_fixture,"mbse":mbse_fixture,"ietm":ietm_fixture,"ade":ade_fixture,"mission":mission_fixture,"fusion":fusion_fixture,"rf":rf_fixture,"cbm":cbm_fixture,"manufacturing":mfg_fixture}
     index = {
         "schema":"WS-PRE-QUALIFICATION-INDEX-V1",
         "software_commit":software_commit,"executed_utc":executed_utc,"operator":operator,
@@ -103,7 +111,7 @@ def build_all(*, fixtures: Path, out: Path, software_commit: str, executed_utc: 
         "custody_digests":custody_digests,"custody_verification":custody_store.verify_all(),
         "fixture_digests":{name:canonical_digest(value) for name,value in fixture_values.items()},
         "failures":failures,
-        "claims_boundary":["This index records synthetic/internal software evidence only.","The ECHO-style store is a local integrity/custody mechanism, not a government records system or legal chain-of-custody service.","RF evidence uses synthetic prediction/measurement values and remains SIMULATED_ONLY.","Passing bundles do not establish physical, platform, government, certification, compliance, clearance, operational, SOTA, or partner validation."],
+        "claims_boundary":["This index records synthetic/internal software evidence only.","The ECHO-style store is a local integrity/custody mechanism, not a government records system or legal chain-of-custody service.","RF evidence uses synthetic prediction/measurement values and remains SIMULATED_ONLY.","CBM+ evidence does not establish predictive maintenance or RUL performance.","Manufacturing evidence establishes digital lineage only and no physical material/process performance.","Passing bundles do not establish physical, platform, government, certification, compliance, clearance, operational, SOTA, or partner validation."],
     }
     _write(out / "qualification_index.json", index)
     return index

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_portfolio.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_portfolio.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .horizons import CapabilityHorizonPortfolio, CapabilityHorizonRecord
+from .qualification import ForecastHorizon, canonical_digest
+from .readiness import CapabilityReadinessRecord, ReadinessRung
+
+
+def _software_readiness(capability_id: str, name: str, bundle_digest: str, fixture_ref: str) -> CapabilityReadinessRecord:
+    return CapabilityReadinessRecord(
+        capability_id=capability_id,
+        capability_name=name,
+        highest_supported_rung=ReadinessRung.INTERNAL_SOFTWARE,
+        evidence_refs={
+            ReadinessRung.SCHEMA: ["qualification.py"],
+            ReadinessRung.FIXTURE: [fixture_ref],
+            ReadinessRung.INTERNAL_SOFTWARE: [bundle_digest],
+        },
+        blocked_next_rung=ReadinessRung.SIMULATION,
+        missing_evidence=["representative validated simulation beyond frozen synthetic fixture"],
+        claims_boundary=["Readiness applies only to the bounded implementation and evidence references listed here."],
+    )
+
+
+def build_readiness_ledger(bundle_digests: dict[str, str]) -> dict[str, Any]:
+    records = [
+        _software_readiness("CAP-APNT", "Synthetic APNT bounded awareness", bundle_digests["apnt"], "WS-APNT-SYNTH-001"),
+        _software_readiness("CAP-MBSE", "Synthetic source-traceable MBSE extraction", bundle_digests["mbse"], "WS-MBSE-SYNTH-001"),
+        _software_readiness("CAP-IETM", "Synthetic technical-data XML projection", bundle_digests["ietm"], "WS-IETM-SYNTH-001"),
+        _software_readiness("CAP-ADE", "Synthetic interpretable algorithm discovery", bundle_digests["ade"], "WS-ADE-SYNTH-001"),
+        _software_readiness("CAP-MISSION", "Synthetic mission replay/debrief", bundle_digests["mission"], "WS-MISSION-REPLAY-SYNTH-001"),
+        _software_readiness("CAP-FUSION", "Synthetic provenance-preserving sensor fusion", bundle_digests["fusion"], "WS-FUSION-SYNTH-001"),
+        _software_readiness("CAP-CBM", "Synthetic CBM+ health-state classification", bundle_digests["cbm"], "WS-CBM-SYNTH-001"),
+        _software_readiness("CAP-MFG", "Manufacturing digital-thread lineage", bundle_digests["manufacturing"], "WS-MFG-THREAD-SYNTH-001"),
+        _software_readiness("CAP-DDIL", "Synthetic DDIL transport-fault handling", bundle_digests["ddil"], "DDIL_SYNTHETIC_V1"),
+    ]
+    rf = CapabilityReadinessRecord(
+        capability_id="CAP-RF-DISCREPANCY",
+        capability_name="Synthetic RF simulation-to-measurement discrepancy accounting",
+        highest_supported_rung=ReadinessRung.SIMULATION,
+        evidence_refs={
+            ReadinessRung.SCHEMA: ["qualification.py", "discrepancy.py"],
+            ReadinessRung.FIXTURE: ["WS-RF-SYNTH-001"],
+            ReadinessRung.INTERNAL_SOFTWARE: ["rf_validation.py"],
+            ReadinessRung.SIMULATION: [bundle_digests["rf"]],
+        },
+        blocked_next_rung=ReadinessRung.HIL,
+        missing_evidence=["fabricated RF coupon", "VNA/chamber measurements", "measurement-system calibration evidence"],
+        claims_boundary=["Synthetic RF values only; no physical measurement or fabricated metasurface evidence."],
+    )
+    records.append(rf)
+    value = {
+        "schema": "WS-CAPABILITY-READINESS-LEDGER-V1",
+        "records": [record.model_dump(mode="json") for record in records],
+        "claims_boundary": [
+            "Readiness rungs are evidence gates, not marketing maturity scores.",
+            "No record may inherit a higher rung without corresponding evidence.",
+        ],
+    }
+    value["ledger_digest"] = canonical_digest(value)
+    return value
+
+
+def build_horizon_portfolio() -> dict[str, Any]:
+    records = [
+        CapabilityHorizonRecord(horizon_id="H-APNT-0-90", capability_id="CAP-APNT", horizon=ForecastHorizon.D0_90, prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE, target_rung=ReadinessRung.SIMULATION, requirement_delta_ids=["PRE-RD-2026-0001"], build_actions=["implement authoritative-spec-gated APNT mapping contract using actual ASPN/pntOS definitions"], experiments=["representative source-fault simulation and operator workflow study"], partner_actions=["secure APNT interface/validation partner"], evidence_targets=["simulation qualification bundle", "interface conformance record"], blocking_conditions=["authoritative interface definitions and partner data required"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-DDIL-0-90", capability_id="CAP-DDIL", horizon=ForecastHorizon.D0_90, prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE, target_rung=ReadinessRung.SIMULATION, requirement_delta_ids=["PRE-RD-2026-0019"], build_actions=["integrate partition/rejoin reconciliation into mission/C2 simulation"], experiments=["network partition, delayed event, conflict and rejoin campaign"], evidence_targets=["reconciliation qualification bundle"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-MBSE-0-90", capability_id="CAP-MBSE", horizon=ForecastHorizon.D0_90, prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE, target_rung=ReadinessRung.SIMULATION, requirement_delta_ids=["PRE-RD-2026-0002"], build_actions=["add authorized PDF/image/diagram ingestion", "complete neutral-model validation before SysML export"], experiments=["holdout reconstruction benchmark with unsupported-inference scoring"], partner_actions=["obtain representative legacy-engineering artifact set"], evidence_targets=["holdout benchmark bundle"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-ADE-0-90", capability_id="CAP-ADE", horizon=ForecastHorizon.D0_90, prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE, target_rung=ReadinessRung.SIMULATION, requirement_delta_ids=["PRE-RD-2026-0012"], build_actions=["add noisy holdout, multivariable and constrained symbolic-discovery benchmarks"], experiments=["compare against fixed polynomial/symbolic baselines"], partner_actions=["identify research-institution independent benchmark partner"], evidence_targets=["multi-family discovery benchmark"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-FUSION-0-90", capability_id="CAP-FUSION", horizon=ForecastHorizon.D0_90, prerequisite_rung=ReadinessRung.INTERNAL_SOFTWARE, target_rung=ReadinessRung.SIMULATION, requirement_delta_ids=["PRE-RD-2026-0014"], build_actions=["add crossing tracks, false alarms, missed detections and covariance propagation"], experiments=["DDIL out-of-sequence fusion benchmark"], evidence_targets=["multi-target simulation bundle"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-CBM-3-12", capability_id="CAP-CBM", horizon=ForecastHorizon.M3_12, prerequisite_rung=ReadinessRung.SIMULATION, target_rung=ReadinessRung.HIL, build_actions=["adapter for real test-asset telemetry"], experiments=["sensor-in-loop fault injection"], partner_actions=["maintenance/test-asset partner"], evidence_targets=["HIL telemetry provenance bundle"], blocking_conditions=["requires prior representative simulation gate"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-MFG-3-12", capability_id="CAP-MFG", horizon=ForecastHorizon.M3_12, prerequisite_rung=ReadinessRung.HIL, target_rung=ReadinessRung.PHYSICAL_LAB, build_actions=["bind machine telemetry and material certificates to coupon lineage"], experiments=["fabricate and measure controlled coupons"], partner_actions=["DED machine/material characterization facility"], evidence_targets=["physical coupon measurement bundle"], blocking_conditions=["machine access, calibrated measurement and material lot evidence"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-RF-3-12", capability_id="CAP-RF-DISCREPANCY", horizon=ForecastHorizon.HIL if False else ForecastHorizon.M3_12, prerequisite_rung=ReadinessRung.HIL, target_rung=ReadinessRung.PHYSICAL_LAB, build_actions=["fabricate controlled RF/metasurface coupon"], experiments=["calibrated VNA/chamber comparison against frozen simulation"], partner_actions=["RF measurement/fabrication partner"], evidence_targets=["physical discrepancy bundle with calibration provenance"], blocking_conditions=["fabrication and calibrated RF facility"], forecast_only=True),
+        CapabilityHorizonRecord(horizon_id="H-CROSS-12-24", capability_id="CAP-CROSS-DOMAIN", horizon=ForecastHorizon.M12_24_PLUS, prerequisite_rung=ReadinessRung.PARTNER, target_rung=ReadinessRung.INDEPENDENT, build_actions=["standardize independent reproduction packages across mature lanes"], experiments=["third-party blind reruns"], partner_actions=["independent labs/testbeds/government-authorized evaluators"], evidence_targets=["independent validation records"], blocking_conditions=["requires partner-rung evidence first"], forecast_only=True),
+    ]
+    portfolio = CapabilityHorizonPortfolio(records=records)
+    value = {
+        "schema": "WS-PRE-CAPABILITY-HORIZONS-V1",
+        "records": [record.model_dump(mode="json") for record in portfolio.records],
+        "immediate_actions": portfolio.immediate_actions(),
+        "claims_boundary": [
+            "Forecast horizon records schedule preparation only and never upgrade capability status.",
+            "Every planned readiness transition remains blocked until the stated prerequisite evidence exists.",
+        ],
+    }
+    value["portfolio_digest"] = canonical_digest(value)
+    return value

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ActionState(str, Enum):
+    PROPOSED = "PROPOSED"
+    APPROVED = "APPROVED"
+    DENIED = "DENIED"
+    OVERRIDDEN = "OVERRIDDEN"
+    REVOKED = "REVOKED"
+
+
+class ActionProposal(BaseModel):
+    proposal_id: str = Field(min_length=1)
+    action: str = Field(min_length=1)
+    rationale: list[str] = Field(default_factory=list)
+    authority_required: str = Field(min_length=1)
+    state: ActionState = ActionState.PROPOSED
+    reviewer: str | None = None
+    decision_utc: str | None = None
+    decision_reason: str | None = None
+
+    @model_validator(mode="after")
+    def decided_states_require_reviewer(self) -> "ActionProposal":
+        if self.state != ActionState.PROPOSED and not self.reviewer:
+            raise ValueError("decided action states require an identified reviewer")
+        return self
+
+
+def decide_action(
+    proposal: ActionProposal,
+    *,
+    reviewer: str,
+    state: ActionState,
+    reason: str,
+) -> ActionProposal:
+    if proposal.state != ActionState.PROPOSED:
+        raise ValueError("only PROPOSED actions may be decided")
+    if state not in {ActionState.APPROVED, ActionState.DENIED, ActionState.OVERRIDDEN}:
+        raise ValueError("decision must be APPROVED, DENIED, or OVERRIDDEN")
+    return proposal.model_copy(
+        update={
+            "state": state,
+            "reviewer": reviewer,
+            "decision_utc": datetime.now(timezone.utc).isoformat(),
+            "decision_reason": reason,
+        }
+    )
+
+
+def revoke_action(proposal: ActionProposal, *, reviewer: str, reason: str) -> ActionProposal:
+    if proposal.state not in {ActionState.APPROVED, ActionState.OVERRIDDEN}:
+        raise ValueError("only approved/overridden actions may be revoked")
+    return proposal.model_copy(
+        update={
+            "state": ActionState.REVOKED,
+            "reviewer": reviewer,
+            "decision_utc": datetime.now(timezone.utc).isoformat(),
+            "decision_reason": reason,
+        }
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/qualification.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class SourceStatus(str, Enum):
+    OFFICIAL_SOURCE_VERIFIED = "OFFICIAL_SOURCE_VERIFIED"
+    GOVERNMENT_SECONDARY_VERIFIED = "GOVERNMENT_SECONDARY_VERIFIED"
+    PRIMARY_TECHNICAL_SOURCE = "PRIMARY_TECHNICAL_SOURCE"
+    THIRD_PARTY_DISCOVERY_ONLY = "THIRD_PARTY_DISCOVERY_ONLY"
+    CONFLICTING_SOURCES = "CONFLICTING_SOURCES"
+    UNVERIFIED = "UNVERIFIED"
+
+
+class CapabilityStatus(str, Enum):
+    PROVEN_INTERNALLY = "PROVEN_INTERNALLY"
+    IMPLEMENTED_IN_SOFTWARE = "IMPLEMENTED_IN_SOFTWARE"
+    SUPPORTED_BY_LITERATURE = "SUPPORTED_BY_LITERATURE"
+    SIMULATED_ONLY = "SIMULATED_ONLY"
+    HYPOTHESIS = "HYPOTHESIS"
+    SPECULATIVE_EXTENSION = "SPECULATIVE_EXTENSION"
+    REQUIRES_LAB_VALIDATION = "REQUIRES_LAB_VALIDATION"
+    REQUIRES_PARTNER_VALIDATION = "REQUIRES_PARTNER_VALIDATION"
+    REQUIRES_LEGAL_REVIEW = "REQUIRES_LEGAL_REVIEW"
+    NOT_CURRENTLY_CLAIMED = "NOT_CURRENTLY_CLAIMED"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class DemandClass(str, Enum):
+    CONFIRMED_DEMAND = "CONFIRMED_DEMAND"
+    EMERGING_DEMAND = "EMERGING_DEMAND"
+    WORLDSHEPHERD_FORECAST = "WORLDSHEPHERD_FORECAST"
+
+
+class ForecastHorizon(str, Enum):
+    D0_90 = "0-90D"
+    M3_12 = "3-12M"
+    M12_24_PLUS = "12-24M_PLUS"
+
+
+class EvidenceScope(str, Enum):
+    SOFTWARE = "SOFTWARE"
+    SIMULATION = "SIMULATION"
+    PHYSICAL = "PHYSICAL"
+    ADMINISTRATIVE = "ADMINISTRATIVE"
+
+
+class ResultStatus(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    INCONCLUSIVE = "INCONCLUSIVE"
+
+
+class ReviewStatus(str, Enum):
+    UNREVIEWED = "UNREVIEWED"
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+class SupersessionState(str, Enum):
+    CURRENT = "CURRENT"
+    SUPERSEDED = "SUPERSEDED"
+    REVOKED = "REVOKED"
+
+
+class SourceRecord(BaseModel):
+    title: str = Field(min_length=1)
+    agency: str = Field(min_length=1)
+    url: str = Field(min_length=1)
+    solicitation_or_topic: str | None = None
+    source_status: SourceStatus
+    retrieved_utc: str
+
+
+class RequirementDeltaRecord(BaseModel):
+    requirement_delta_id: str = Field(pattern=r"^PRE-RD-[0-9]{4}-[0-9]{4,}$")
+    demand_class: DemandClass
+    source: SourceRecord
+    statement: str = Field(min_length=1)
+    recurrence: str = Field(min_length=1)
+    forecast_horizon: ForecastHorizon
+    affected_lanes: list[str] = Field(default_factory=list)
+    existing_capability: list[str] = Field(default_factory=list)
+    capability_status: list[CapabilityStatus] = Field(default_factory=list)
+    missing_capability: list[str] = Field(default_factory=list)
+    experiment_or_demonstration_needed: list[str] = Field(default_factory=list)
+    partner_needed: list[str] = Field(default_factory=list)
+    evidence_target: list[str] = Field(default_factory=list)
+    likely_future_programs: list[str] = Field(default_factory=list)
+    claims_boundary: list[str] = Field(default_factory=list)
+
+    def capture_ready(self) -> bool:
+        return self.source.source_status not in {
+            SourceStatus.UNVERIFIED,
+            SourceStatus.THIRD_PARTY_DISCOVERY_ONLY,
+            SourceStatus.CONFLICTING_SOURCES,
+        }
+
+
+class EvidenceGraphNode(BaseModel):
+    node_id: str = Field(min_length=1)
+    node_type: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    source_ref: str | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceGraphEdge(BaseModel):
+    edge_id: str = Field(min_length=1)
+    source_node_id: str = Field(min_length=1)
+    target_node_id: str = Field(min_length=1)
+    relation: str = Field(min_length=1)
+    source_ref: str | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceGraph(BaseModel):
+    graph_id: str = Field(min_length=1)
+    nodes: list[EvidenceGraphNode] = Field(default_factory=list)
+    edges: list[EvidenceGraphEdge] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def edges_reference_known_nodes(self) -> "EvidenceGraph":
+        node_ids = {node.node_id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source_node_id not in node_ids or edge.target_node_id not in node_ids:
+                raise ValueError(f"edge {edge.edge_id} references unknown node")
+        return self
+
+
+class ReviewRecord(BaseModel):
+    status: ReviewStatus = ReviewStatus.UNREVIEWED
+    reviewer: str | None = None
+    reviewed_utc: str | None = None
+
+
+class SupersessionRecord(BaseModel):
+    state: SupersessionState = SupersessionState.CURRENT
+    superseded_by: str | None = None
+
+
+class QualificationEvidenceRecord(BaseModel):
+    qualification_id: str = Field(pattern=r"^WS-QE-[0-9]{4}-[0-9]{4,}$")
+    requirement_id: str = Field(min_length=1)
+    test_id: str = Field(min_length=1)
+    evidence_scope: EvidenceScope
+    capability_status: CapabilityStatus
+    environment_digest: str = Field(min_length=1)
+    configuration_digest: str = Field(min_length=1)
+    inputs: list[dict[str, Any]] = Field(default_factory=list)
+    outputs: list[dict[str, Any]] = Field(default_factory=list)
+    metrics: list[dict[str, Any]] = Field(default_factory=list)
+    uncertainty: list[dict[str, Any]] = Field(default_factory=list)
+    result: ResultStatus
+    rationale: str = Field(min_length=1)
+    negative_evidence: list[dict[str, Any]] = Field(default_factory=list)
+    software_commit: str | None = None
+    executed_utc: str
+    operator: str = Field(min_length=1)
+    physical_validation_performed: bool = False
+    review: ReviewRecord = Field(default_factory=ReviewRecord)
+    supersession: SupersessionRecord = Field(default_factory=SupersessionRecord)
+
+    @model_validator(mode="after")
+    def prevent_unvalidated_physical_proof(self) -> "QualificationEvidenceRecord":
+        if (
+            self.evidence_scope == EvidenceScope.PHYSICAL
+            and self.capability_status == CapabilityStatus.PROVEN_INTERNALLY
+            and not self.physical_validation_performed
+        ):
+            raise ValueError(
+                "physical PROVEN_INTERNALLY status requires physical validation evidence"
+            )
+        return self
+
+
+def canonical_digest(value: BaseModel | dict[str, Any] | list[Any]) -> str:
+    if isinstance(value, BaseModel):
+        payload: Any = value.model_dump(mode="json")
+    else:
+        payload = value
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def compile_qualification_bundle(
+    requirement: RequirementDeltaRecord,
+    evidence: list[QualificationEvidenceRecord],
+    graph: EvidenceGraph | None = None,
+) -> dict[str, Any]:
+    records = [item.model_dump(mode="json") for item in evidence]
+    bundle = {
+        "requirement": requirement.model_dump(mode="json"),
+        "evidence": records,
+        "evidence_graph": graph.model_dump(mode="json") if graph else None,
+        "capture_ready_source": requirement.capture_ready(),
+        "claims_boundary": requirement.claims_boundary,
+    }
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/qualification_eval.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/qualification_eval.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .evidence_artifacts import ComparisonOperator, ExpectedResult
+
+
+def evaluate_expected_result(expected: ExpectedResult, observed: dict[str, Any]) -> bool:
+    if expected.metric not in observed:
+        return False
+    value = observed[expected.metric]
+    target = expected.target
+    operator = expected.operator
+
+    if operator == ComparisonOperator.EQ:
+        return value == target
+    if operator == ComparisonOperator.NE:
+        return value != target
+    if operator == ComparisonOperator.LT:
+        return value < target
+    if operator == ComparisonOperator.LE:
+        return value <= target
+    if operator == ComparisonOperator.GT:
+        return value > target
+    if operator == ComparisonOperator.GE:
+        return value >= target
+    raise ValueError(f"unsupported comparison operator: {operator}")
+
+
+def evaluate_all_expected_results(
+    expected_results: list[ExpectedResult], observed: dict[str, Any]
+) -> tuple[bool, dict[str, bool]]:
+    outcomes = {
+        expected.metric: evaluate_expected_result(expected, observed)
+        for expected in expected_results
+    }
+    return all(outcomes.values()), outcomes

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/readiness.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/readiness.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from pydantic import BaseModel, Field, model_validator
+
+
+class ReadinessRung(IntEnum):
+    SCHEMA = 1
+    FIXTURE = 2
+    INTERNAL_SOFTWARE = 3
+    SIMULATION = 4
+    HIL = 5
+    PHYSICAL_LAB = 6
+    PARTNER = 7
+    INDEPENDENT = 8
+    COMPLIANCE_CERTIFICATION = 9
+    OPERATIONAL = 10
+
+
+class CapabilityReadinessRecord(BaseModel):
+    capability_id: str = Field(min_length=1)
+    capability_name: str = Field(min_length=1)
+    highest_supported_rung: ReadinessRung
+    evidence_refs: dict[ReadinessRung, list[str]] = Field(default_factory=dict)
+    blocked_next_rung: ReadinessRung | None = None
+    missing_evidence: list[str] = Field(default_factory=list)
+    claims_boundary: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def evidence_required_for_claimed_rung(self) -> "CapabilityReadinessRecord":
+        for rung in ReadinessRung:
+            if rung <= self.highest_supported_rung and not self.evidence_refs.get(rung):
+                raise ValueError(f"evidence reference required for supported rung {rung.name}")
+        if self.blocked_next_rung is not None and self.blocked_next_rung <= self.highest_supported_rung:
+            raise ValueError("blocked_next_rung must be above highest_supported_rung")
+        return self
+
+    def can_claim(self, rung: ReadinessRung) -> bool:
+        return rung <= self.highest_supported_rung and bool(self.evidence_refs.get(rung))
+
+    def next_rung(self) -> ReadinessRung | None:
+        value = int(self.highest_supported_rung) + 1
+        return ReadinessRung(value) if value <= int(ReadinessRung.OPERATIONAL) else None

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/rf_validation.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/rf_validation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .discrepancy import PairedMeasurement, compare_prediction_to_measurement
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+def qualify_synthetic_rf_discrepancy(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    pairs = [
+        PairedMeasurement(
+            key=f"s11_{point['frequency_ghz']}ghz",
+            predicted=float(point["predicted_s11_db"]),
+            measured=float(point["measured_s11_db"]),
+            uncertainty=float(point["measurement_uncertainty_db"]),
+            units="dB",
+        )
+        for point in fixture["points"]
+    ]
+    summary = compare_prediction_to_measurement(pairs)
+    expected = fixture["expected"]
+    within_fraction = summary.within_uncertainty_fraction
+    passed = (
+        summary.max_absolute_error <= float(expected["max_absolute_error_db"])
+        and within_fraction is not None
+        and within_fraction >= float(expected["minimum_within_uncertainty_fraction"])
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-7001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="rf_synthetic_discrepancy_v1",
+        evidence_scope=EvidenceScope.SIMULATION,
+        capability_status=CapabilityStatus.SIMULATED_ONLY,
+        environment_digest=canonical_digest(
+            {"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}
+        ),
+        configuration_digest=canonical_digest({"comparison": "paired_s11_db_v1"}),
+        inputs=[{"point_count": len(fixture["points"])}],
+        outputs=[
+            {
+                "mean_absolute_error_db": summary.mean_absolute_error,
+                "max_absolute_error_db": summary.max_absolute_error,
+                "within_uncertainty_fraction": summary.within_uncertainty_fraction,
+                "metrics": [
+                    {
+                        "key": metric.key,
+                        "absolute_error": metric.absolute_error,
+                        "relative_error": metric.relative_error,
+                        "normalized_error": metric.normalized_error,
+                        "units": metric.units,
+                    }
+                    for metric in summary.metrics
+                ],
+            }
+        ],
+        metrics=[
+            {"name": "max_absolute_error_db", "value": summary.max_absolute_error, "target_max": expected["max_absolute_error_db"]},
+            {"name": "within_uncertainty_fraction", "value": summary.within_uncertainty_fraction, "target_min": expected["minimum_within_uncertainty_fraction"]},
+        ],
+        uncertainty=[
+            {"name": "physical_measurement_validity", "state": "NOT_EVALUATED", "note": "fixture measurements are synthetic"},
+            {"name": "fabrication_variability", "state": "NOT_EVALUATED"},
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Synthetic predicted/measured S11-like values met frozen discrepancy targets"
+            if passed
+            else "Synthetic predicted/measured S11-like values exceeded one or more frozen discrepancy targets"
+        ),
+        negative_evidence=[] if passed else [{"max_absolute_error_db": summary.max_absolute_error, "within_uncertainty_fraction": summary.within_uncertainty_fraction}],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+        physical_validation_performed=False,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence])
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = (
+        "Synthetic RF simulation-to-measurement discrepancy exercise only; no VNA/chamber/fabricated metasurface/material/RF performance claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/sensor_fusion.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/sensor_fusion.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import hypot
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .qualification import EvidenceGraph, EvidenceGraphEdge, EvidenceGraphNode
+
+
+class Observation(BaseModel):
+    observation_id: str = Field(min_length=1)
+    sensor_id: str = Field(min_length=1)
+    t_seconds: float
+    x: float
+    y: float
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+@dataclass(frozen=True)
+class FusedTrack:
+    track_id: str
+    x: float
+    y: float
+    t_seconds: float
+    confidence: float
+    source_observation_ids: tuple[str, ...]
+    source_sensor_ids: tuple[str, ...]
+
+
+def _distance(a: Observation, b: Observation) -> float:
+    return hypot(a.x - b.x, a.y - b.y)
+
+
+def associate_observations(
+    observations: list[Observation],
+    *,
+    max_spatial_distance: float,
+    max_time_delta_seconds: float,
+) -> tuple[tuple[Observation, ...], ...]:
+    """Greedy deterministic association for the frozen synthetic benchmark.
+
+    This is not an operational tracker, JPDA/MHT implementation, or validated
+    aerospace sensor-fusion algorithm.
+    """
+    ordered = sorted(observations, key=lambda item: (item.t_seconds, item.observation_id))
+    groups: list[list[Observation]] = []
+    for observation in ordered:
+        placed = False
+        for group in groups:
+            anchor = group[0]
+            if (
+                abs(observation.t_seconds - anchor.t_seconds) <= max_time_delta_seconds
+                and _distance(observation, anchor) <= max_spatial_distance
+            ):
+                group.append(observation)
+                placed = True
+                break
+        if not placed:
+            groups.append([observation])
+    return tuple(tuple(group) for group in groups)
+
+
+def fuse_group(group: tuple[Observation, ...], *, track_id: str) -> FusedTrack:
+    total_weight = sum(max(obs.confidence, 1e-9) for obs in group)
+    x = sum(obs.x * max(obs.confidence, 1e-9) for obs in group) / total_weight
+    y = sum(obs.y * max(obs.confidence, 1e-9) for obs in group) / total_weight
+    t_seconds = sum(obs.t_seconds * max(obs.confidence, 1e-9) for obs in group) / total_weight
+    confidence = min(1.0, sum(obs.confidence for obs in group) / len(group))
+    return FusedTrack(
+        track_id=track_id,
+        x=x,
+        y=y,
+        t_seconds=t_seconds,
+        confidence=confidence,
+        source_observation_ids=tuple(sorted(obs.observation_id for obs in group)),
+        source_sensor_ids=tuple(sorted({obs.sensor_id for obs in group})),
+    )
+
+
+def fuse_observations(
+    observations: list[Observation],
+    *,
+    max_spatial_distance: float,
+    max_time_delta_seconds: float,
+) -> tuple[FusedTrack, ...]:
+    groups = associate_observations(
+        observations,
+        max_spatial_distance=max_spatial_distance,
+        max_time_delta_seconds=max_time_delta_seconds,
+    )
+    tracks = [fuse_group(group, track_id=f"F{index:03d}") for index, group in enumerate(groups, start=1)]
+    return tuple(sorted(tracks, key=lambda track: (track.x, track.y, track.track_id)))
+
+
+def fusion_graph(
+    *,
+    graph_id: str,
+    observations: list[Observation],
+    tracks: tuple[FusedTrack, ...],
+) -> EvidenceGraph:
+    nodes: list[EvidenceGraphNode] = []
+    edges: list[EvidenceGraphEdge] = []
+    for observation in observations:
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=f"obs:{observation.observation_id}",
+                node_type="sensor_observation",
+                label=observation.observation_id,
+                source_ref=f"sensor:{observation.sensor_id}",
+                confidence=observation.confidence,
+                attributes=observation.model_dump(mode="json"),
+            )
+        )
+    for track in tracks:
+        nodes.append(
+            EvidenceGraphNode(
+                node_id=f"track:{track.track_id}",
+                node_type="synthetic_fused_track",
+                label=track.track_id,
+                confidence=track.confidence,
+                attributes={
+                    "x": track.x,
+                    "y": track.y,
+                    "t_seconds": track.t_seconds,
+                    "source_observation_ids": list(track.source_observation_ids),
+                    "source_sensor_ids": list(track.source_sensor_ids),
+                },
+            )
+        )
+        for observation_id in track.source_observation_ids:
+            edges.append(
+                EvidenceGraphEdge(
+                    edge_id=f"edge:{observation_id}:{track.track_id}",
+                    source_node_id=f"obs:{observation_id}",
+                    target_node_id=f"track:{track.track_id}",
+                    relation="contributes_to",
+                    source_ref=f"observation:{observation_id}",
+                    confidence=1.0,
+                )
+            )
+    return EvidenceGraph(graph_id=graph_id, nodes=nodes, edges=edges)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/sensor_fusion_qualification.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/sensor_fusion_qualification.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from math import hypot
+from typing import Any
+
+from .qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+from .sensor_fusion import Observation, fuse_observations, fusion_graph
+
+
+def qualify_synthetic_sensor_fusion(
+    *,
+    fixture: dict[str, Any],
+    requirement: RequirementDeltaRecord,
+    software_commit: str,
+    executed_utc: str,
+    operator: str,
+) -> dict[str, Any]:
+    observations = [Observation.model_validate(item) for item in fixture["observations"]]
+    association = fixture["association"]
+    tracks = fuse_observations(
+        observations,
+        max_spatial_distance=float(association["max_spatial_distance"]),
+        max_time_delta_seconds=float(association["max_time_delta_seconds"]),
+    )
+    truth = sorted(fixture["truth"], key=lambda item: (float(item["x"]), float(item["y"])))
+    ordered_tracks = sorted(tracks, key=lambda track: (track.x, track.y))
+    position_errors = [
+        hypot(track.x - float(target["x"]), track.y - float(target["y"]))
+        for track, target in zip(ordered_tracks, truth)
+    ]
+    preserved = sorted(
+        observation_id
+        for track in tracks
+        for observation_id in track.source_observation_ids
+    ) == sorted(item["observation_id"] for item in fixture["observations"])
+    max_error = max(position_errors) if position_errors else float("inf")
+    expected = fixture["expected"]
+    passed = (
+        len(tracks) == int(expected["fused_track_count"])
+        and max_error <= float(expected["max_position_error"])
+        and preserved is bool(expected["all_source_observations_preserved"])
+    )
+    graph = fusion_graph(
+        graph_id=fixture["fixture_id"], observations=observations, tracks=tracks
+    )
+
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-6001",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="sensor_fusion_synthetic_v1",
+        evidence_scope=EvidenceScope.SOFTWARE,
+        capability_status=CapabilityStatus.PROVEN_INTERNALLY,
+        environment_digest=canonical_digest(
+            {"fixture_id": fixture["fixture_id"], "classification": fixture["classification"]}
+        ),
+        configuration_digest=canonical_digest(association),
+        inputs=[{"observation_count": len(observations), "truth_count": len(truth)}],
+        outputs=[
+            {
+                "fused_track_count": len(tracks),
+                "position_errors": position_errors,
+                "max_position_error": max_error,
+                "source_observations_preserved": preserved,
+                "tracks": [
+                    {
+                        "track_id": track.track_id,
+                        "x": track.x,
+                        "y": track.y,
+                        "t_seconds": track.t_seconds,
+                        "confidence": track.confidence,
+                        "source_observation_ids": list(track.source_observation_ids),
+                        "source_sensor_ids": list(track.source_sensor_ids),
+                    }
+                    for track in tracks
+                ],
+            }
+        ],
+        metrics=[
+            {"name": "fused_track_count", "value": len(tracks), "expected": expected["fused_track_count"]},
+            {"name": "max_position_error", "value": max_error, "target_max": expected["max_position_error"]},
+            {"name": "source_observations_preserved", "value": preserved},
+        ],
+        uncertainty=[
+            {"name": "operational_sensor_validity", "state": "NOT_EVALUATED"},
+            {"name": "track_association_generalization", "state": "NOT_EVALUATED"},
+        ],
+        result=ResultStatus.PASS if passed else ResultStatus.FAIL,
+        rationale=(
+            "Deterministic synthetic association/fusion met frozen truth and provenance targets"
+            if passed
+            else "Synthetic fusion diverged from one or more frozen truth/provenance targets"
+        ),
+        negative_evidence=[] if passed else [
+            {
+                "observed_track_count": len(tracks),
+                "max_position_error": max_error,
+                "source_observations_preserved": preserved,
+            }
+        ],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence], graph)
+    bundle.pop("bundle_digest", None)
+    bundle["fixture_id"] = fixture["fixture_id"]
+    bundle["scope_note"] = (
+        "Synthetic deterministic 2-D sensor-fusion evidence only; no AESA, EO/IR, NAVAIR, classified-sensor, operational tracking, or field-performance claim."
+    )
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/software_provenance.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/software_provenance.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import canonical_digest
+
+
+class AttestationState(str, Enum):
+    INTERNAL_UNSIGNED = "INTERNAL_UNSIGNED"
+    INTERNALLY_SIGNED = "INTERNALLY_SIGNED"
+    EXTERNALLY_VERIFIED = "EXTERNALLY_VERIFIED"
+
+
+class SoftwareComponent(BaseModel):
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    package_type: str = Field(min_length=1)
+    supplier: str | None = None
+    purl: str | None = None
+    artifact_digest: str | None = None
+
+
+class BuildProvenance(BaseModel):
+    provenance_id: str = Field(min_length=1)
+    source_repository: str = Field(min_length=1)
+    source_commit: str = Field(min_length=1)
+    builder_id: str = Field(min_length=1)
+    build_environment_digest: str = Field(min_length=1)
+    output_artifact_digest: str = Field(min_length=1)
+    components: list[SoftwareComponent] = Field(default_factory=list)
+    sbom_digest: str | None = None
+    attestation_state: AttestationState = AttestationState.INTERNAL_UNSIGNED
+    signature_ref: str | None = None
+    external_verifier: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def verification_requires_evidence(self) -> "BuildProvenance":
+        if self.attestation_state == AttestationState.INTERNALLY_SIGNED and not self.signature_ref:
+            raise ValueError("internally signed attestation requires signature_ref")
+        if self.attestation_state == AttestationState.EXTERNALLY_VERIFIED:
+            if not self.signature_ref or not self.external_verifier:
+                raise ValueError("external verification requires signature_ref and external_verifier")
+        return self
+
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+    def claims_boundary(self) -> str:
+        if self.attestation_state == AttestationState.EXTERNALLY_VERIFIED:
+            return "External verifier is recorded; verification scope and signer trust still govern use."
+        return "Internal software provenance evidence only; no external signing, SLSA level, government acceptance, or supply-chain certification is claimed."

--- a/docs/CODEX_BLOOM_PRE_EXECUTABLE_V1.md
+++ b/docs/CODEX_BLOOM_PRE_EXECUTABLE_V1.md
@@ -1,0 +1,159 @@
+# Worldshepherd Codex Bloom — Executable PRE Architecture v1
+
+Status: IMPLEMENTED IN SOFTWARE where named modules/tests exist on `pre/release5-ingest-build`; all domain, physical, compliance, certification, partner and operational claims remain separately evidence-gated.
+
+## Canonical governed pipeline
+
+`source -> adapter -> normalization -> Evidence Graph -> bounded algorithm/domain projection -> PRIME action/release gate -> Qualification Evidence -> OVERWATCH/replay -> human review`
+
+The same chain is intended to serve APNT, MBSE, technical data/IETM, mission replay, sensor fusion, digital twins, autonomy, RF analytics and manufacturing provenance without allowing evidence from one domain to silently validate another.
+
+## Core executable services
+
+### PRE requirement model
+- `qualification.py`
+- independent SOURCE STATUS and WORLDSHEPHERD CAPABILITY STATUS
+- requirement-delta records
+- evidence scopes and supersession states
+- deterministic bundle digest
+- fail-closed physical `PROVEN_INTERNALLY` rule
+
+### Evidence Graph
+- node/edge model
+- source references
+- confidence fields
+- referential-integrity validation
+- graph precision/recall scorer
+
+### Artifact and expected-result contracts
+- `evidence_artifacts.py`
+- SHA-256 artifact identity
+- required input/output/log/config/source roles
+- explicit expected-result operators and thresholds
+- tamper detection
+- `qualification_eval.py` fail-closes missing metrics
+
+### PRIME bounded action gate
+- `prime.py`
+- PROPOSED -> APPROVED / DENIED / OVERRIDDEN
+- identified reviewer required for decisions
+- approved/overridden actions can be REVOKED
+- not a government authorization or certified safety controller
+
+### DDIL qualification harness
+- `ddil.py`, `ddil_campaign.py`
+- packet drop
+- added latency
+- reordering
+- stale data
+- duplication
+- deterministic replay evidence
+- synthetic software transport behavior only; no RF/tactical-network readiness claim
+
+### Dynamic Mission Enclave / Common Services contract
+- `common_services.py`
+- versioned service manifests
+- interface version
+- software/SBOM digests
+- authority requirement
+- platform-adapter registration
+- rollback history
+- prototype registry only; no flight/platform certification
+
+### Compliance readiness evidence
+- `compliance.py`
+- UNKNOWN default
+- PRESENT requires evidence refs
+- GAP and NOT_APPLICABLE states
+- authoritative assessment reference separated from internal readiness
+- no CMMC/NIST 800-171 compliance claim without authoritative evidence
+
+## APNT projection
+
+Modules:
+- `apnt_adapter.py`
+- `apnt.py`
+- `apnt_qualification.py`
+- fixture `WS-APNT-SYNTH-001`
+
+Implemented:
+- normalized synthetic GNSS/INS/alternate-PNT-like source contract
+- explicit ASPN mapping stub that fails closed
+- nominal/degraded/GNSS-denied/recovery awareness model
+- recovery-option candidate set
+- source -> state -> recovery Evidence Graph
+- replayable synthetic qualification bundle
+
+Not established:
+- ASPN/pntOS/GPNTS interoperability
+- navigation solution accuracy
+- sensor fusion performance
+- Navy operator effectiveness
+- shipboard deployment
+- CMMC/authorization
+
+## MBSE projection
+
+Modules:
+- `legacy_normalization.py`
+- `mbse_extract.py`
+- `graph_metrics.py`
+- fixture `WS-MBSE-SYNTH-001`
+
+Implemented:
+- source-preserving normalization for current synthetic text/BOM/network/cable artifact types
+- conservative rule-based extraction of only explicit supported relationships
+- source refs and confidence on extracted edges
+- graph construction
+- precision/recall/unsupported/missed scoring framework
+
+Not established:
+- general AI/ML document understanding
+- PDF/image/diagram extraction
+- SysML/XMI export
+- Cameo/MagicDraw interoperability
+- Navy/Aegis reconstruction performance
+- classified-data handling
+
+## Qualification ladder
+
+1. SCHEMA — object validates.
+2. FIXTURE — frozen synthetic input and expected result exist.
+3. INTERNAL SOFTWARE — deterministic test passes and evidence bundle is retained.
+4. SIMULATION — representative simulation is validated against stated limits.
+5. HIL — real hardware interface is exercised.
+6. PHYSICAL LAB — measured physical performance exists.
+7. PARTNER — external hardware/data/facility evidence is retained.
+8. INDEPENDENT — third-party/government test evidence exists.
+9. COMPLIANCE/CERTIFICATION — authoritative assessment/certification applies to defined scope.
+10. OPERATIONAL — relevant operational environment evidence exists.
+
+No rung inherits the next rung automatically.
+
+## Cross-opportunity reuse matrix
+
+| Capability | APNT | MBSE | IETM | C2/MOSA | Sensor Fusion | Autonomy | CBM+/Twin | RF | Manufacturing |
+|---|---|---|---|---|---|---|---|---|---|
+| Evidence Graph | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| Qualification Compiler | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| PRIME gate | yes | release | release | yes | yes | yes | maintenance | model release | process release |
+| DDIL harness | yes | optional | optional | yes | yes | yes | yes | yes | remote ops |
+| Artifact hashing | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| Common Services | yes | ingest | ingest | primary | primary | primary | primary | deployment | provenance |
+
+## Current P0 gaps
+
+1. real APNT adapter mapping using authoritative ASPN/pntOS definitions
+2. APNT operator UI and scripted human-effectiveness study
+3. packet partition/rejoin and conflict-reconciliation DDIL cases
+4. persistent Common Services registry integrated with SARA storage/audit
+5. MBSE PDF/image/diagram parsers
+6. MBSE neutral intermediate model + SysML/XMI export
+7. IETM/S1000D projection and marking inheritance
+8. CMMC/NIST control-evidence inventory from authoritative company records
+9. third live-opportunity demonstrator consuming the same qualification schema
+10. independent clean-environment reproduction artifact
+
+## Claims-control rule
+
+Prediction drives preparation. Synthetic evidence can establish only synthetic software behavior. Internal software tests can establish only the exact implemented/tested software behavior. Physical, platform, operator, compliance, certification and operational claims require corresponding evidence and are not inferred from architectural fit.

--- a/docs/PRE_RELEASE5_INGEST_2026-08-25.md
+++ b/docs/PRE_RELEASE5_INGEST_2026-08-25.md
@@ -1,0 +1,67 @@
+# PRE Release-5 Ingest — 2026-08-25
+
+Claims-controlled ingest. Navy pages below identify themselves as unofficial copies of the DoW BAA; operative submission requirements must be checked against DSIP/DoW before proposal freeze.
+
+## PRE-RD-2026-0001 — APNT operator decision assurance
+- Demand: CONFIRMED_DEMAND
+- Topic: DON26BX05-NP004
+- Source status: GOVERNMENT_SECONDARY_VERIFIED pending direct DSIP freeze check
+- Horizon: 0-90D
+- Requirement: modular/API-first APNT awareness software; containerization-ready; health/confidence/threat/degradation/operational-impact/recovery presentation; operator decision support.
+- Existing WS capability: SARA workflow/registry, ECHO provenance model, PRIME authorization, OVERWATCH visualization patterns — IMPLEMENTED IN SOFTWARE where retained evidence exists.
+- Missing: ASPN/pntOS/GPNTS integration, calibrated APNT data, Navy operator validation.
+- Build now: synthetic APNT scenario + confidence/provenance graph + DDIL campaign + recovery authorization + operator-task metrics.
+
+## PRE-RD-2026-0002 — Legacy evidence to MBSE
+- Demand: CONFIRMED_DEMAND
+- Topic: DON26BX05-NP003
+- Source status: GOVERNMENT_SECONDARY_VERIFIED pending direct DSIP freeze check
+- Horizon: 0-90D
+- Requirement: ingest heterogeneous legacy artifacts and generate accurate SysML/Cameo models supporting design, cyber, interfaces, test, configuration, reliability and certification.
+- Existing WS capability: workflow/provenance/governance primitives — IMPLEMENTED IN SOFTWARE.
+- Missing: validated automatic SysML reconstruction and Cameo/MagicDraw interoperability — NOT CURRENTLY CLAIMED.
+- Build now: synthetic ground-truth system + mixed artifact corpus + evidence graph + relationship extraction + neutral model + SysML export + precision/recall/coverage metrics.
+- Qualification dependencies: projected CMMC L2 Self; ITAR/EAR; advanced phases may require Secret FCL/PCL and U.S.-owned/operated/no-foreign-influence conditions or approved mitigation.
+
+## PRE-RD-2026-0003 — Technical-data transformation/IETM
+- Demand: CONFIRMED_DEMAND
+- Topic: DON26BZ05-NV078
+- Source status: GOVERNMENT_SECONDARY_VERIFIED pending direct DSIP freeze check
+- Horizon: 0-90D
+- Requirement: transform diverse Navy TMs to XML/IETM-compatible output while preserving distribution/DFARS markings; support PDF, MIL-STD-3001-1, MIL-DTL-81310, S1000D 3.0/4.0; later NLP/search and step-by-step AR/XR workflows.
+- Existing WS capability: ingestion/workflow/provenance/review patterns — IMPLEMENTED IN SOFTWARE where evidenced.
+- Missing: standards conversion coverage, viewer compatibility, production accuracy — NOT CURRENTLY CLAIMED.
+- Build now: shared evidence graph with MBSE lane + XML/schema adapter + marking inheritance + human ambiguity review + conversion metrics.
+- Government Phase-II target captured: >=95% conversion accuracy and <=1% error after correction; this is a future validation target, not current WS performance.
+
+## PRE-RD-2026-0004 — Digitally enhanced weapon-system technical data
+- Demand: CONFIRMED_DEMAND
+- Topic: DON26BZ05-NV072
+- Source status: GOVERNMENT_SECONDARY_VERIFIED pending full topic ingest
+- Horizon: 0-90D / 3-12M reuse
+- Signal: Digital Engineering, MBSE, IETM, Digital Twin, Technical Data Management and Predictive Maintenance recur together.
+- Action: ingest full topic before role determination; reuse Evidence Graph + Technical Data Transformation Pipeline.
+
+## PRE-RD-2026-0005 — Post-mission autonomy evidence/replanning
+- Demand: CONFIRMED_DEMAND
+- Topic: DON26BZ05-NV074
+- Source status: GOVERNMENT_SECONDARY_VERIFIED pending full topic ingest
+- Horizon: 0-90D / 3-12M reuse
+- Signal: automated post-mission debrief and replanning for collaborative/autonomous platforms reinforces mission replay, provenance and controlled replanning as reusable PRE capabilities.
+- Action: ingest full topic and benchmark against OVERWATCH replay + ECHO event lineage + PRIME replanning authorization.
+
+## Cross-topic forecast
+Demand recurrence supports building one governed Evidence Graph / Qualification Compiler rather than one-off opportunity implementations.
+
+Shared canonical pipeline:
+`source artifact/sensor/event -> normalized evidence graph -> domain projection -> validation -> PRIME review/release -> replayable qualification bundle`
+
+Domain projections currently prioritized:
+1. APNT operational picture
+2. SysML/MBSE
+3. XML/IETM
+4. mission replay/replanning
+5. digital twin/CBM+
+6. network/configuration assurance
+
+No domain projection inherits physical, operational, compliance or certification validity merely because the shared software pipeline exists.

--- a/docs/PRE_REQUIREMENT_DELTA_SCHEMA_V1.md
+++ b/docs/PRE_REQUIREMENT_DELTA_SCHEMA_V1.md
@@ -1,0 +1,95 @@
+# Worldshepherd Predictive Requirements Engine — Requirement Delta Schema v1
+
+Status: IMPLEMENTED AS GOVERNANCE/SCHEMA; domain performance remains evidence-gated.
+
+## Evidence taxonomy separation
+Every record MUST contain independent `source_status` and `worldshepherd_capability_status` fields.
+
+### source_status
+- OFFICIAL_SOURCE_VERIFIED
+- GOVERNMENT_SECONDARY_VERIFIED
+- PRIMARY_TECHNICAL_SOURCE
+- THIRD_PARTY_DISCOVERY_ONLY
+- CONFLICTING_SOURCES
+- UNVERIFIED
+
+### worldshepherd_capability_status
+- PROVEN INTERNALLY
+- IMPLEMENTED IN SOFTWARE
+- SUPPORTED BY LITERATURE
+- SIMULATED ONLY
+- HYPOTHESIS
+- SPECULATIVE EXTENSION
+- REQUIRES LAB VALIDATION
+- REQUIRES PARTNER VALIDATION
+- REQUIRES LEGAL REVIEW
+- NOT CURRENTLY CLAIMED
+- NOT_APPLICABLE
+
+## Requirement Delta Record
+```yaml
+requirement_delta_id: PRE-RD-YYYY-NNNN
+demand_class: CONFIRMED_DEMAND | EMERGING_DEMAND | WORLDSHEPHERD_FORECAST
+source:
+  title:
+  agency:
+  url:
+  solicitation_or_topic:
+  source_status:
+  retrieved_utc:
+requirement:
+  statement:
+  recurrence:
+  forecast_horizon: 0-90D | 3-12M | 12-24M_PLUS
+  affected_lanes: []
+worldshepherd:
+  existing_capability: []
+  capability_status: []
+  missing_capability: []
+readiness:
+  experiment_or_demonstration_needed: []
+  partner_needed: []
+  evidence_target: []
+  likely_future_programs: []
+claims_boundary: []
+```
+
+## Qualification Evidence Record
+Canonical chain:
+`requirement -> test -> configuration -> result -> uncertainty -> pass/fail -> provenance -> identified-human review`
+
+```yaml
+qualification_id: WS-QE-YYYY-NNNN
+requirement_id:
+test_id:
+environment_digest:
+configuration_digest:
+inputs: []
+outputs: []
+metrics: []
+uncertainty: []
+result: PASS | FAIL | INCONCLUSIVE
+rationale:
+negative_evidence: []
+provenance:
+  software_commit:
+  executed_utc:
+  operator:
+review:
+  status: UNREVIEWED | ACCEPTED | REJECTED
+  reviewer:
+  reviewed_utc:
+supersession:
+  state: CURRENT | SUPERSEDED | REVOKED
+  superseded_by:
+```
+
+## Fail-closed rules
+1. Missing source status => record cannot become a capture requirement.
+2. Prediction never upgrades capability maturity.
+3. Generated output without source lineage is unqualified.
+4. Physical performance cannot be inferred from software implementation.
+5. Partner brochures/outreach are not partner validation.
+6. Internal controls do not establish CMMC, NIST 800-171, government authorization, certification, clearance, or operational readiness.
+7. Negative and anomalous evidence is retained, not discarded.
+8. Superseded evidence remains addressable and auditable.


### PR DESCRIPTION
Implements the next claims-controlled PRE foundation from the active Release-5 capture work.

Adds governance + executable scaffolding:
- independent SOURCE STATUS vs WORLDSHEPHERD CAPABILITY STATUS schema;
- Requirement Delta Record;
- Qualification Evidence Record with fail-closed physical-proof rule;
- Evidence Graph node/edge model with referential-integrity validation;
- deterministic qualification-bundle digest;
- Release-5 ingest wave 1 + wave 2;
- frozen synthetic APNT degraded-navigation fixture;
- bounded APNT awareness/recovery derivation + provenance graph;
- frozen synthetic MBSE legacy-artifact/ground-truth fixture;
- graph precision/recall + unsupported/missed inference metrics;
- tests for source readiness, graph integrity, physical-claim gating, bundle reproducibility, APNT state/replay graph, and MBSE scoring;
- setuptools discovery fix so non-package fixture directories remain test data rather than accidental Python packages.

Shared architecture direction:
`source artifact/sensor/event -> Evidence Graph -> domain projection -> validation -> PRIME review/release -> replayable Qualification Evidence bundle`

Claims boundary:
This PR does NOT establish ASPN/pntOS/GPNTS integration, Navy operator effectiveness, physical APNT validity, automatic SysML reconstruction accuracy, Cameo/MagicDraw interoperability, IETM conversion performance, CMMC/NIST 800-171 compliance, clearance, RF performance, hardware maturity, or government validation. Synthetic fixtures validate only bounded internal software behavior.

Tracked by issues #17-#21.