### PR TITLE
Post-merge integrity hardening: live tracked subtree inventory

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e '.[test]'
+          command -v ws-pre-bloom
+          ws-pre-bloom --help >/dev/null
 
       - name: Compile package
         run: python -m compileall -q worldshepherd_sara
@@ -46,7 +48,7 @@ jobs:
       - name: Compile PRE full-bloom qualification evidence
         run: |
           rm -rf qualification_evidence_ci
-          python -m worldshepherd_sara.pre_bloom_cli \
+          ws-pre-bloom \
             --fixtures fixtures \
             --out qualification_evidence_ci \
             --software-commit "$GITHUB_SHA" \

--- a/deployments/sara_verified_local_v1/MANIFEST.json
+++ b/deployments/sara_verified_local_v1/MANIFEST.json
@@ -1,19 +1,24 @@
 {
-  "artifact": "Worldshepherd SARA / SSPADAWANZZ namespaced repository promotion candidate",
-  "version": "v1-repository-promotion",
-  "generated_utc": "2026-07-29T01:42:26Z",
-  "derived_from": {
-    "artifact": "Worldshepherd SARA / SSPADAWANZZ verified local deployment candidate",
-    "source_manifest_sha256": "c201426d441ddaea908f99e755fbfc43de4767749d5e68dc28d44bebf1210275"
+  "schema": "WS-SARA-DEPLOYMENT-METADATA-V2",
+  "artifact": "Worldshepherd SARA / SSPADAWANZZ verified local deployment and PRE qualification package",
+  "version": "v2-live-tracked-inventory",
+  "updated_utc": "2026-08-26T03:40:00Z",
+  "integrity_model": {
+    "static_file_hash_inventory": "SUPERSEDED",
+    "operative_inventory": "scripts/verify_deployment.sh generates tracked-files.json from every Git-tracked file in the deployment subtree at verification time",
+    "commit_binding": "baseline.txt records git_head and tracked_files_sha256",
+    "evidence_binding": "SHA256SUMS covers emitted deployment evidence files",
+    "pre_qualification": "GitHub Actions invokes the full-bloom PRE compiler and uploads its hash-addressed qualification evidence artifact"
   },
   "security_boundary": [
-    "localhost-only port binding",
-    "separate host and container ports",
-    "separate operator and administrator bearer tokens",
+    "localhost-only service publication",
+    "separate relay and administrator bearer tokens",
+    "persistent local storage with restrictive file modes",
     "no external scanning",
     "no broadcasting",
     "no arbitrary command execution",
-    "no self-expanding network behavior"
+    "no self-expanding network behavior",
+    "AI proposals and bounded automation remain subject to explicit policy/authorization rules"
   ],
   "port_model": {
     "container_port": 9530,
@@ -21,164 +26,38 @@
     "parallel_validation_host_port": 19530,
     "host_binding": "127.0.0.1 only"
   },
-  "source_validation": {
-    "pytest": "29 passed with 0 failures, 0 errors, and 0 skips under Python 3.12; application and test code unchanged by the CI evidence-root correction",
-    "compileall": "passed; Python source unchanged by the CI evidence-root correction",
-    "shell_syntax": "passed after CI clean-checkout evidence-root correction",
-    "runtime_verifier": "passed after CI clean-checkout evidence-root correction in isolated Docker Compose project sara_orl4_hardening_20260728 on localhost port 19532 with independently verified evidence at .deployment-evidence/20260729T014206Z"
-  },
-  "repository_promotion_validation": {
-    "status": "passed_local_isolated_orl4_validation",
-    "required_checks": [
-      "manifest digest verification",
-      "shell syntax validation",
-      "Python compilation",
-      "unit and API tests",
-      "Compose rendering",
-      "parallel-port deployment verification"
-    ],
-    "completed_utc": "2026-07-29T01:42:26Z",
-    "evidence_directory": ".deployment-evidence/20260729T014206Z",
-    "completed_checks": [
-      "29-test Python 3.12 unit and API suite retained; application and test code unchanged",
-      "all 22 manifest hashes, sizes, JSON validity, and canonical inventory verification",
-      "final shell syntax and git diff validation",
-      "clean-checkout verification with an initially absent .deployment-evidence parent",
-      "fail-closed evidence-root type and permission validation",
-      "isolated localhost build, startup, health, readiness, role separation, self-test, restart, and persistence verification",
-      "evidence directory and file permission validation",
-      "SHA256SUMS, redacted Compose YAML, and baseline provenance validation",
-      "Git HEAD, dirty precommit state, and canonical manifest inventory binding",
-      "CI failure analysis and evidence-root initialization correction"
-    ],
-    "claims_boundary": [
-      "isolated localhost validation only",
-      "committed-revision CI and remote publication are tracked outside this precommit evidence record",
-      "merge approval remains pending",
-      "rollback and replacement-host recovery remain pending",
-      "off-host evidence retention remains pending",
-      "immutable audit is not provided by the application-appended local audit log",
-      "production and public-network readiness remain pending"
-    ],
-    "validated_git_head": "b683a6470358e15f0480bef851db8a97bc47d2c6",
-    "validated_git_worktree_state": "dirty_precommit_ci_evidence_root_correction",
-    "manifest_files_sha256": "a3b62edb85877d99474c7601a3cbebb99f287100090bf0740a2887c875744bbb"
+  "internal_release_gate": [
+    "Python package installation",
+    "Python compilation",
+    "unit and API tests",
+    "PRE full-bloom qualification compiler",
+    "required machine-readable evidence outputs",
+    "ECHO-style custody verification",
+    "Docker Compose validation",
+    "ephemeral local deployment",
+    "health and readiness checks",
+    "role-separated administrator/relay smoke testing",
+    "restart and persistence verification",
+    "live Git-tracked subtree inventory capture"
+  ],
+  "claims_boundary": [
+    "Internal software conformance and localhost deployment evidence only unless a separate evidence package establishes more.",
+    "CMMC certification is not claimed.",
+    "NIST SP 800-171 organizational conformity is not claimed.",
+    "SAM/UEI/CAGE/SBIR/STTR eligibility is not established by this software artifact.",
+    "ITAR/EAR, FOCI, security clearance, ATO/RMF, and government interoperability certification require external authoritative review/evidence.",
+    "Synthetic qualification does not establish physical hardware, RF, material, navigation, autonomy, maintenance, or operational performance.",
+    "External partner/customer/laboratory validation remains distinct from internal CI evidence."
+  ],
+  "documentation": {
+    "quick_start": "README.md",
+    "deployment": "docs/VERIFIED_DEPLOYMENT.md",
+    "pre_full_bloom": "docs/PRE_FULL_BLOOM.md",
+    "compliance_boundary": "docs/COMPLIANCE_BOUNDARY.md"
   },
   "repository_integration": {
     "workflow_path": ".github/workflows/sara-verified-local-v1.yml",
-    "workflow_sha256": "4402aa4eb5e15a8c3d76850c0606dea0acd2a4fa8e7df8a8a095e773206a32cc",
-    "workflow_location": "repository root; outside namespaced artifact directory"
+    "workflow_behavior": "push and pull-request changes to the deployment subtree execute the full internal release gate"
   },
-  "files": [
-    {
-      "path": ".dockerignore",
-      "sha256": "1c4c38fccd94b5e0fc6ba515dd8f73b01e43bdb2aa40d83b0d45cc1b31ca6a5b",
-      "size_bytes": 68
-    },
-    {
-      "path": ".env.example",
-      "sha256": "7f6aba4bf3e0f036dd93c8ef5669fe9ba848ff0189428ccf7a58334a1347c357",
-      "size_bytes": 398
-    },
-    {
-      "path": ".gitignore",
-      "sha256": "fc89910178057d6906682425fda8bd638fdd66930a8662f9f4975c1f066dd880",
-      "size_bytes": 78
-    },
-    {
-      "path": "Dockerfile",
-      "sha256": "c04967cbc183459fc72c8e5cfd10db9de2de87a4e777b150ff72462cb43ac0ea",
-      "size_bytes": 681
-    },
-    {
-      "path": "README.md",
-      "sha256": "aaf8fa97286d743af29433caf893698c0059cbfb82423fb9e0aac111663a2275",
-      "size_bytes": 1289
-    },
-    {
-      "path": "SECURITY.md",
-      "sha256": "38b0ed3f90107a36908d6d7a5bb1e8b35b673cb1eee097c4dca360cb0fd5a5b6",
-      "size_bytes": 1186
-    },
-    {
-      "path": "compose.yaml",
-      "sha256": "972a3eced169a3423a1f9d55b87cf0c5bb07772edaa3b4041b2619f55eeb9ec6",
-      "size_bytes": 712
-    },
-    {
-      "path": "docs/QUARANTINED_LEGACY.md",
-      "sha256": "b9254518953105211f07b0416f039b62e2b36c67958b9e6d8c0712e2e39203d9",
-      "size_bytes": 783
-    },
-    {
-      "path": "docs/VERIFIED_DEPLOYMENT.md",
-      "sha256": "58c4a354a67c1ead29485ac37215b5c6a9ce5dadda5865d102dbe8792b293cc2",
-      "size_bytes": 2873
-    },
-    {
-      "path": "pyproject.toml",
-      "sha256": "fa9485131a1b58a16d72c2ea7c4a0dfa86a47337304c657fb88178cbde6aa5ee",
-      "size_bytes": 533
-    },
-    {
-      "path": "scripts/admin_smoke_test.sh",
-      "sha256": "a1ac8ce42bac7a897d6957651322dd863efefa33417fffb58d5a68c4504b97eb",
-      "size_bytes": 2181
-    },
-    {
-      "path": "scripts/start_interface.sh",
-      "sha256": "52f0c160682e25483296a46dac4cabd0fdb9988678b40eb32e18baf4f5bf3b7c",
-      "size_bytes": 448
-    },
-    {
-      "path": "scripts/verify_deployment.sh",
-      "sha256": "05719fe88628e76cf9ac333aab8a729756964cc0c0c5e54f514c2ccd7bf740b1",
-      "size_bytes": 4812
-    },
-    {
-      "path": "tests/conftest.py",
-      "sha256": "9ad6f28c00775584d23bc2d0c19d68b4c41a70819698ebd7885cb78d9a2ee5ca",
-      "size_bytes": 600
-    },
-    {
-      "path": "tests/test_api.py",
-      "sha256": "b2715bc2510128c32be96b7cf85b8aa63545e8fcf13996b0376bd4a28b1477ce",
-      "size_bytes": 11603
-    },
-    {
-      "path": "worldshepherd_sara/__init__.py",
-      "sha256": "bf9af3222f06eb997a73c4b8b55f26cf33be438d3415c5d7e327a4363b5fd231",
-      "size_bytes": 78
-    },
-    {
-      "path": "worldshepherd_sara/__main__.py",
-      "sha256": "1372ecb7d44cc521e33f21f9eadbe093558b3e10d2b0283f78ab155c206552af",
-      "size_bytes": 332
-    },
-    {
-      "path": "worldshepherd_sara/app.py",
-      "sha256": "b4fc951c3e6c9d2df85b8a89a3a9af305a0583cc5764a0c3c48117b3b1558ae0",
-      "size_bytes": 9410
-    },
-    {
-      "path": "worldshepherd_sara/auth.py",
-      "sha256": "53c91c40a428fdbad63a921e8ffd14c048afc3c9ae111cd0f0f25ee197ef0de6",
-      "size_bytes": 2102
-    },
-    {
-      "path": "worldshepherd_sara/models.py",
-      "sha256": "105f82c252a1206a0145d3bf0f797c2f1938cf751096adce8199284c11561823",
-      "size_bytes": 1383
-    },
-    {
-      "path": "worldshepherd_sara/limits.py",
-      "sha256": "db24ac92005c081f61f0c81dfb34a3a9b536cce667f680f29a2875def9251f4f",
-      "size_bytes": 1889
-    },
-    {
-      "path": "worldshepherd_sara/storage.py",
-      "sha256": "0e8be29217099bfe8dd69d282a2d0bf97ce9cb4aa1d514d0c76ec6f2421c5e84",
-      "size_bytes": 10032
-    }
-  ]
+  "historical_note": "The July 2026 v1 static file-hash inventory and pre-merge status were retired because the deployment expanded substantially. Historical evidence remains available through Git history; this V2 manifest is metadata, while the operative file inventory is generated live during verification."
 }

--- a/deployments/sara_verified_local_v1/SECURITY.md
+++ b/deployments/sara_verified_local_v1/SECURITY.md
@@ -4,6 +4,8 @@
 
 Only the validated localhost package is supported. Public Internet exposure is not supported by this repository.
 
+This public repository and its default local/CI workflows are approved only for synthetic, public, or otherwise explicitly releasable test data. Do **not** place CUI, classified information, export-controlled technical data, proprietary partner data, credentials, controlled government datasets, or operational mission data in this repository, GitHub Actions artifacts, public issues, fixtures, logs, or the default ECHO-style evidence store. Handling any such data requires a separately scoped and authorized environment, access-control model, contractual/security review, retention policy, and applicable encryption/audit controls.
+
 ## Security controls
 
 - Separate relay and administrator bearer tokens
@@ -15,14 +17,17 @@ Only the validated localhost package is supported. Public Internet exposure is n
 - Application-appended local audit records with restrictive file permissions
 - Descriptor-based rejection of registry and audit symlink substitution
 - Persistent-storage readiness verification
+- Claims-controlled PRE qualification evidence and hash-addressed local evidence custody
+- Synthetic DDIL/degraded-state and bounded authorization testing
 - No arbitrary command execution
 - No outbound network discovery or broadcast behavior
 
-The audit file is writable by the service account and therefore is not an
-immutable or tamper-proof record. Protect the host and volume, restrict
-operator access, and export logs to a separately controlled system if stronger
-assurance is required.
+The audit file is writable by the service account and therefore is not an immutable or tamper-proof record. The ECHO-style content-addressed store detects local content mismatch but is likewise not a legal chain-of-custody system, government records system, WORM archive, or external attestation service. Protect the host and volume, restrict operator access, and export approved logs/evidence to a separately controlled system if stronger assurance is required.
+
+## Compliance boundary
+
+A green repository gate does not certify CMMC, organizational NIST SP 800-171 conformity, SPRS status, FedRAMP, RMF/ATO, FIPS validation, government interoperability, ITAR/EAR compliance, FOCI status, or security clearance. Those statuses require the applicable scoped environment and authoritative evidence. See `docs/COMPLIANCE_BOUNDARY.md`.
 
 ## Reporting
 
-Do not post credentials, private logs, personal information, or protected technical data in public issues. Revoke exposed tokens immediately and rotate both deployment credentials after any suspected compromise.
+Do not post credentials, private logs, personal information, protected technical data, CUI, classified information, or export-controlled content in public issues. Revoke exposed tokens immediately and rotate both deployment credentials after any suspected compromise. If protected information is exposed, follow the applicable organizational/contractual incident procedure rather than attempting to preserve it in a public issue.

--- a/deployments/sara_verified_local_v1/docs/VERIFIED_DEPLOYMENT.md
+++ b/deployments/sara_verified_local_v1/docs/VERIFIED_DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 ## Deployment boundary
 
-This release is a local administration, audit, registry, and relay-recording service. The relay endpoint records approved local actions; it does not scan networks, broadcast to third parties, awaken external agents, or execute arbitrary commands.
+This release is a local administration, audit, registry, relay-recording, and PRE qualification service. The relay endpoint records approved local actions; it does not scan networks, broadcast to third parties, awaken external agents, or execute arbitrary commands.
 
 The service binds to `127.0.0.1:${SARA_HOST_PORT:-9530}` through Docker Compose while retaining internal container port `9530`. Do not expose it publicly without a separate reverse proxy, TLS, identity provider, threat model, security review, and authorization.
 
@@ -20,31 +20,33 @@ Open `http://127.0.0.1:<SARA_HOST_PORT>/ui` after the verification script passes
 
 ## Required acceptance evidence
 
-A promoted deployment is verified only when all of the following are bound to the same committed revision. Pre-commit local validation may instead be bound to a recorded Git HEAD, dirty-worktree state, and canonical manifest file-inventory digest:
+A promoted local deployment is internally verified only when all of the following are bound to the tested committed revision:
 
-1. Local unit and API tests pass; CI must also pass for the committed revision before promotion.
-2. The container image builds.
-3. Compatibility health, liveness, persistent-storage readiness, and UI checks pass.
-4. Relay authorization works.
-5. Relay credentials are denied administrator access.
-6. Registry changes persist.
-7. Audit records persist after restart.
+1. Python compilation and the complete unit/API suite pass.
+2. The PRE full-bloom qualification compiler exits zero and required machine-readable outputs are retained.
+3. ECHO-style custody verification passes for the compiled qualification bundles.
+4. Docker Compose renders successfully and the container image builds.
+5. Compatibility health, liveness, persistent-storage readiness, and UI checks pass.
+6. Relay authorization works and relay credentials are denied administrator access.
+7. Registry changes and audit records persist after restart.
 8. The administrator self-test passes.
-9. Deployment logs and evidence checksums are retained.
-10. An authorized reviewer reviews and approves the evidence package before promotion.
+9. The verifier emits `tracked-files.json` from every Git-tracked file in this deployment subtree and records its canonical `tracked_files_sha256` together with `git_head` in `baseline.txt`.
+10. Deployment logs, rendered/redacted Compose evidence, and SHA-256 evidence checksums are retained.
+11. The corresponding GitHub Actions gate passes for the committed revision before it is called internally release-ready.
 
-The rendered Compose evidence replaces the resolved `SARA_ADMIN_TOKEN` and
-`SARA_RELAY_TOKEN` values with `<REDACTED>` while preserving valid YAML.
-Evidence checksums are generated only after that redacted file is in place.
+The rendered Compose evidence replaces the resolved `SARA_ADMIN_TOKEN` and `SARA_RELAY_TOKEN` values with `<REDACTED>` while preserving valid YAML. Evidence checksums are generated only after that redacted file is in place.
 
-The audit is an application-appended local log. The service account can write
-it, so this deployment does not claim immutability, tamper-proof retention, or
-independent verification of the log or of external dispatch controls.
+`MANIFEST.json` is deployment metadata and claims-boundary documentation. The historical July 2026 static file-hash list is superseded. The operative integrity inventory is generated at verification time from the tested Git-tracked subtree, preventing later expansion of the package from silently inheriting stale file hashes.
+
+The audit is an application-appended local log. The service account can write it, so this deployment does not claim immutability, tamper-proof retention, or independent verification of the log or of external dispatch controls.
+
+## Claims boundary
+
+A successful local verifier and CI gate establish only the tested internal software/deployment behavior. They do not establish CMMC certification, organizational NIST SP 800-171 conformity, SPRS status, SAM/UEI/CAGE status, SBIR/STTR eligibility, ITAR/EAR compliance, FOCI determination, security clearance, ATO/RMF authorization, government interoperability certification, physical hardware performance, material qualification, RF performance, or operational effectiveness. See `COMPLIANCE_BOUNDARY.md`.
 
 ## Rollback
 
-Rollback validation remains pending. The commands below are an operator
-procedure, not evidence that rollback has been exercised.
+The application supports configuration/service rollback evidence in bounded internal tests, but full deployment rollback to a previous approved Git/container release has not yet been independently exercised as a production recovery demonstration. The commands below remain an operator procedure:
 
 ```bash
 docker compose down
@@ -54,6 +56,4 @@ docker compose up -d --build
 
 The named Docker volume is not deleted by `docker compose down`. Do not use `-v` during an operational rollback unless destruction of local evidence is explicitly approved.
 
-Replacement-host recovery and production readiness also remain pending and
-require separately retained backups, a tested restore exercise, operational
-monitoring, and an approved production threat model.
+Replacement-host recovery and production/public-network readiness remain separate gates and require separately retained backups, a tested restore exercise, operational monitoring, identity/TLS architecture, threat modeling, and explicit authorization.

--- a/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
+++ b/deployments/sara_verified_local_v1/scripts/verify_deployment.sh
@@ -45,35 +45,52 @@ if ! mkdir -m 0700 "$evidence_dir"; then
 fi
 
 git_head="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-manifest_files_sha256="$(
-  python3 - <<'PY_MANIFEST'
+
+# Build a live inventory from every Git-tracked file in this deployment subtree.
+# This supersedes the historical static file-hash list in MANIFEST.json and binds
+# deployment evidence to the files actually present at the tested commit.
+tracked_files_sha256="$(
+  python3 - "$evidence_dir/tracked-files.json" <<'PY_TRACKED'
 import hashlib
 import json
+import subprocess
+import sys
 from pathlib import Path
 
-manifest = json.loads(
-    Path("MANIFEST.json").read_text(encoding="utf-8")
-)
-payload = json.dumps(
-    manifest["files"],
-    sort_keys=True,
-    separators=(",", ":"),
-).encode("utf-8")
+out = Path(sys.argv[1])
+raw = subprocess.check_output(["git", "ls-files", "-z", "--", "."])
+paths = sorted(p.decode("utf-8") for p in raw.split(b"\0") if p)
+records = []
+for value in paths:
+    path = Path(value)
+    data = path.read_bytes()
+    records.append(
+        {
+            "path": value,
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "size_bytes": len(data),
+        }
+    )
+payload = json.dumps(records, sort_keys=True, separators=(",", ":")).encode("utf-8")
+out.write_text(json.dumps({"schema": "WS-TRACKED-SUBTREE-INVENTORY-V1", "files": records}, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 print(hashlib.sha256(payload).hexdigest())
-PY_MANIFEST
+PY_TRACKED
 )"
 
-if git diff --quiet -- .   && git diff --cached --quiet -- .   && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
-  git_worktree_state="clean"
+manifest_metadata_sha256="$(sha256sum MANIFEST.json | awk '{print $1}')"
+
+if git diff --quiet -- . && git diff --cached --quiet -- .; then
+  tracked_worktree_state="clean"
 else
-  git_worktree_state="dirty"
+  tracked_worktree_state="dirty"
 fi
 
 {
   echo "timestamp_utc=${stamp}"
   echo "git_head=${git_head}"
-  echo "git_worktree_state=${git_worktree_state}"
-  echo "manifest_files_sha256=${manifest_files_sha256}"
+  echo "tracked_worktree_state=${tracked_worktree_state}"
+  echo "tracked_files_sha256=${tracked_files_sha256}"
+  echo "manifest_metadata_sha256=${manifest_metadata_sha256}"
   echo "docker_version=$(docker --version)"
   echo "compose_version=$(docker compose version)"
   echo "sara_host_port=${host_port}"
@@ -101,6 +118,7 @@ docker compose config | awk '
 ' > "$redacted_compose"
 mv "$redacted_compose" "${evidence_dir}/compose.rendered.yaml"
 trap - EXIT
+
 docker compose build --pull | tee "${evidence_dir}/build.log"
 docker compose up -d
 
@@ -156,13 +174,16 @@ if [ "${restart_ready}" -ne 1 ]; then
   docker compose logs --no-color --tail=100 sara >&2
   exit 1
 fi
+
 curl --fail --silent --show-error -H "Authorization: Bearer ${SARA_ADMIN_TOKEN}" \
   "${base_url}/admin/registry" | tee "${evidence_dir}/registry.after-restart.json" | grep -q "SARA_CORE"
 scripts/admin_smoke_test.sh | tee "${evidence_dir}/smoke.after-restart.log"
+
 if ! wait_for_healthy; then
   echo "ERROR: Docker health was not healthy before evidence capture." >&2
   exit 1
 fi
+
 docker compose ps > "${evidence_dir}/compose.ps.txt"
 docker compose logs --no-color > "${evidence_dir}/service.log"
 

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import platform
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
@@ -70,6 +72,20 @@ def _edge_workload(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _installed_component(name: str, *, supplier: str | None = None) -> SoftwareComponent:
+    try:
+        installed_version = version(name)
+    except PackageNotFoundError:
+        installed_version = "UNKNOWN"
+    return SoftwareComponent(
+        name=name,
+        version=installed_version,
+        package_type="python",
+        supplier=supplier,
+        purl=None if installed_version == "UNKNOWN" else f"pkg:pypi/{name}@{installed_version}",
+    )
+
+
 def build_bloom(
     *, fixtures: Path, out: Path, software_commit: str, executed_utc: str, operator: str
 ) -> dict[str, Any]:
@@ -96,6 +112,15 @@ def build_bloom(
         ["distributed deployment", "real network partitions", "consensus validation"],
     )
 
+    runtime_identity = {
+        "python_version": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "execution_context": "pre-bloom-cli",
+    }
+
     edge = qualify_host_callable(
         function=_edge_workload,
         input_value={"values": list(range(1, 129))},
@@ -104,8 +129,8 @@ def build_bloom(
         executed_utc=executed_utc,
         operator=operator,
         environment={
+            **runtime_identity,
             "runtime": "python",
-            "execution_context": "qualification-compiler-host",
             "device_claim": "NONE",
         },
         repetitions=7,
@@ -137,24 +162,30 @@ def build_bloom(
         "software_commit": software_commit,
         "bundle_digests": dict(sorted(index["bundle_digests"].items())),
     }
+    components = [
+        _installed_component("worldshepherd-sara", supplier="Worldshepherd internal"),
+        _installed_component("fastapi"),
+        _installed_component("uvicorn"),
+        _installed_component("pydantic"),
+    ]
     provenance = BuildProvenance(
         provenance_id="WS-PRE-BLOOM-BUILD-V1",
         source_repository="Bdavis1390/Sara_pro",
         source_commit=software_commit,
         builder_id=operator,
         build_environment_digest=canonical_digest(
-            {"builder": operator, "execution_context": "pre-bloom-cli"}
+            {
+                "builder": operator,
+                "runtime_identity": runtime_identity,
+                "components": [component.model_dump(mode="json") for component in components],
+            }
         ),
         output_artifact_digest=canonical_digest(bundle_manifest),
-        components=[
-            SoftwareComponent(
-                name="worldshepherd-sara",
-                version="0.1.0",
-                package_type="python",
-                supplier="Worldshepherd internal",
-            )
-        ],
-        metadata={"attested_object": "WS-PRE-BUNDLE-MANIFEST-V1"},
+        components=components,
+        metadata={
+            "attested_object": "WS-PRE-BUNDLE-MANIFEST-V1",
+            "runtime_identity": runtime_identity,
+        },
     )
     provenance_value = provenance.model_dump(mode="json")
     provenance_value["provenance_digest"] = provenance.digest()


### PR DESCRIPTION
Hardens the merged PRE full-bloom release by removing a stale July static-manifest assumption.

Changes:
- verifier now generates `tracked-files.json` from every Git-tracked file in the tested deployment subtree;
- records canonical `tracked_files_sha256` and `git_head` in deployment baseline evidence;
- retains metadata-manifest digest separately;
- replaces the stale July static file hash list and historical `merge pending` language with V2 deployment metadata;
- updates deployment acceptance documentation to match the operative Bloom gate and external-compliance boundary.

Claims boundary remains unchanged: this is internal software/deployment integrity evidence, not CMMC/NIST certification, ATO, government interoperability certification, physical qualification, or operational validation.