### PR TITLE
Close destructive backup/restore recovery gate

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -21,7 +21,7 @@ defaults:
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository
@@ -79,6 +79,16 @@ jobs:
 
       - name: Run patched deployment verifier
         run: scripts/verify_deployment.sh
+
+      - name: Run destructive backup and restore exercise
+        run: bash scripts/recovery_exercise.sh
+
+      - name: Upload recovery evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-recovery-exercise-evidence
+          path: deployments/sara_verified_local_v1/recovery_evidence
+          if-no-files-found: error
 
       - name: Capture container logs on failure
         if: failure()

--- a/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
+++ b/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
@@ -8,14 +8,16 @@ rm -f "$RECOVERY_DIR"/sara-data.tar.gz "$RECOVERY_DIR"/before.json "$RECOVERY_DI
 
 docker compose up -d --build
 
-docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+# Recovery helpers run as root only to read the app-owned named volume and write
+# CI evidence to the host bind mount. The long-running SARA service remains UID 10001.
+docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
 import hashlib,json,pathlib
 root=pathlib.Path("/var/lib/sara"); rows=[]
 for p in sorted(x for x in root.rglob("*") if x.is_file()): rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
 pathlib.Path("/recovery/before.json").write_text(json.dumps(rows,sort_keys=True,indent=2)+"\n")
 '
 
-docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
 import pathlib,tarfile
 root=pathlib.Path("/var/lib/sara")
 with tarfile.open("/recovery/sara-data.tar.gz","w:gz") as tf:
@@ -25,7 +27,7 @@ sha256sum "$RECOVERY_DIR/sara-data.tar.gz" > "$RECOVERY_DIR/sara-data.tar.gz.sha
 
 docker compose down -v
 docker compose create sara >/dev/null
-docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
 import pathlib,tarfile
 root=pathlib.Path("/var/lib/sara"); root.mkdir(parents=True,exist_ok=True)
 with tarfile.open("/recovery/sara-data.tar.gz","r:gz") as tf: tf.extractall(root,filter="data")
@@ -34,7 +36,7 @@ docker compose up -d
 for _ in $(seq 1 30); do if curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null; then break; fi; sleep 1; done
 curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null
 
-docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
 import hashlib,json,pathlib
 root=pathlib.Path("/var/lib/sara"); rows=[]
 for p in sorted(x for x in root.rglob("*") if x.is_file()): rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})

--- a/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
+++ b/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
@@ -4,49 +4,69 @@ cd "$(dirname "$0")/.."
 RECOVERY_DIR="${RECOVERY_DIR:-recovery_evidence}"
 export RECOVERY_DIR
 mkdir -p "$RECOVERY_DIR"
-rm -f "$RECOVERY_DIR"/sara-data.tar.gz "$RECOVERY_DIR"/before.json "$RECOVERY_DIR"/after.json "$RECOVERY_DIR"/result.json
+rm -f "$RECOVERY_DIR"/sara-data.tar.gz "$RECOVERY_DIR"/sara-data.tar.gz.sha256 "$RECOVERY_DIR"/before.json "$RECOVERY_DIR"/after.json "$RECOVERY_DIR"/result.json
 
 docker compose up -d --build
 
-# Recovery helpers run as root only to read the app-owned named volume and write
-# CI evidence to the host bind mount. The long-running SARA service remains UID 10001.
-docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+# Recovery helpers run as root only to read/write the app-owned named volume.
+# The runner owns all evidence files; helper output is streamed over stdio.
+# The long-running SARA service remains UID 10001.
+docker compose run --rm --no-deps --user 0 -T --entrypoint python sara -c '
 import hashlib,json,pathlib
 root=pathlib.Path("/var/lib/sara"); rows=[]
-for p in sorted(x for x in root.rglob("*") if x.is_file()): rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
-pathlib.Path("/recovery/before.json").write_text(json.dumps(rows,sort_keys=True,indent=2)+"\n")
-'
+for p in sorted(x for x in root.rglob("*") if x.is_file()):
+    rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
+print(json.dumps(rows,sort_keys=True,indent=2))
+' > "$RECOVERY_DIR/before.json"
 
-docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
-import pathlib,tarfile
+docker compose run --rm --no-deps --user 0 -T --entrypoint python sara -c '
+import pathlib,sys,tarfile
 root=pathlib.Path("/var/lib/sara")
-with tarfile.open("/recovery/sara-data.tar.gz","w:gz") as tf:
-    for p in sorted(root.rglob("*")): tf.add(p,arcname=str(p.relative_to(root)),recursive=False)
-'
+with tarfile.open(fileobj=sys.stdout.buffer,mode="w|gz") as tf:
+    for p in sorted(root.rglob("*")):
+        tf.add(p,arcname=str(p.relative_to(root)),recursive=False)
+' > "$RECOVERY_DIR/sara-data.tar.gz"
 sha256sum "$RECOVERY_DIR/sara-data.tar.gz" > "$RECOVERY_DIR/sara-data.tar.gz.sha256"
 
 docker compose down -v
 docker compose create sara >/dev/null
-docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
-import pathlib,tarfile
+
+docker compose run --rm --no-deps --user 0 -T --entrypoint python sara -c '
+import pathlib,sys,tarfile
 root=pathlib.Path("/var/lib/sara"); root.mkdir(parents=True,exist_ok=True)
-with tarfile.open("/recovery/sara-data.tar.gz","r:gz") as tf: tf.extractall(root,filter="data")
-'
+with tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz") as tf:
+    tf.extractall(root,filter="data")
+' < "$RECOVERY_DIR/sara-data.tar.gz"
+
 docker compose up -d
-for _ in $(seq 1 30); do if curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null; then break; fi; sleep 1; done
+for _ in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null; then break; fi
+  sleep 1
+done
 curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null
 
-docker compose run --rm --no-deps --user 0 -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+docker compose run --rm --no-deps --user 0 -T --entrypoint python sara -c '
 import hashlib,json,pathlib
 root=pathlib.Path("/var/lib/sara"); rows=[]
-for p in sorted(x for x in root.rglob("*") if x.is_file()): rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
-pathlib.Path("/recovery/after.json").write_text(json.dumps(rows,sort_keys=True,indent=2)+"\n")
-'
+for p in sorted(x for x in root.rglob("*") if x.is_file()):
+    rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
+print(json.dumps(rows,sort_keys=True,indent=2))
+' > "$RECOVERY_DIR/after.json"
+
 cmp "$RECOVERY_DIR/before.json" "$RECOVERY_DIR/after.json"
 python - <<'PY'
 import hashlib,json,pathlib,subprocess,datetime,os
 p=pathlib.Path(os.environ["RECOVERY_DIR"]); archive=p/"sara-data.tar.gz"
-result={"status":"PASS","exercise":"destructive_named_volume_backup_restore","archive_sha256":hashlib.sha256(archive.read_bytes()).hexdigest(),"git_head":subprocess.check_output(["git","rev-parse","HEAD"],text=True).strip(),"executed_utc":datetime.datetime.now(datetime.timezone.utc).isoformat(),"scope":"synthetic/public local deployment data only","external_compliance_claim":"NONE"}
+result={
+  "status":"PASS",
+  "exercise":"destructive_named_volume_backup_restore",
+  "archive_sha256":hashlib.sha256(archive.read_bytes()).hexdigest(),
+  "git_head":subprocess.check_output(["git","rev-parse","HEAD"],text=True).strip(),
+  "executed_utc":datetime.datetime.now(datetime.timezone.utc).isoformat(),
+  "scope":"synthetic/public local deployment data only",
+  "helper_privilege":"root for recovery helper containers only; SARA service remains non-root UID 10001",
+  "external_compliance_claim":"NONE"
+}
 (p/"result.json").write_text(json.dumps(result,sort_keys=True,indent=2)+"\n")
 PY
 echo "RECOVERY_EXERCISE: PASS"

--- a/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
+++ b/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 RECOVERY_DIR="${RECOVERY_DIR:-recovery_evidence}"
 export RECOVERY_DIR
+HOST_PORT="${SARA_HOST_PORT:-$(awk -F= '$1=="SARA_HOST_PORT" {print $2}' .env 2>/dev/null || true)}"
+HOST_PORT="${HOST_PORT:-9530}"
 mkdir -p "$RECOVERY_DIR"
 rm -f "$RECOVERY_DIR"/sara-data.tar.gz "$RECOVERY_DIR"/sara-data.tar.gz.sha256 "$RECOVERY_DIR"/before.json "$RECOVERY_DIR"/after.json "$RECOVERY_DIR"/result.json
 
@@ -40,10 +42,10 @@ with tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz") as tf:
 
 docker compose up -d
 for _ in $(seq 1 30); do
-  if curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null; then break; fi
+  if curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" >/dev/null; then break; fi
   sleep 1
 done
-curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null
+curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" >/dev/null
 
 docker compose run --rm --no-deps --user 0 -T --entrypoint python sara -c '
 import hashlib,json,pathlib

--- a/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
+++ b/deployments/sara_verified_local_v1/scripts/recovery_exercise.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+RECOVERY_DIR="${RECOVERY_DIR:-recovery_evidence}"
+export RECOVERY_DIR
+mkdir -p "$RECOVERY_DIR"
+rm -f "$RECOVERY_DIR"/sara-data.tar.gz "$RECOVERY_DIR"/before.json "$RECOVERY_DIR"/after.json "$RECOVERY_DIR"/result.json
+
+docker compose up -d --build
+
+docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+import hashlib,json,pathlib
+root=pathlib.Path("/var/lib/sara"); rows=[]
+for p in sorted(x for x in root.rglob("*") if x.is_file()): rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
+pathlib.Path("/recovery/before.json").write_text(json.dumps(rows,sort_keys=True,indent=2)+"\n")
+'
+
+docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+import pathlib,tarfile
+root=pathlib.Path("/var/lib/sara")
+with tarfile.open("/recovery/sara-data.tar.gz","w:gz") as tf:
+    for p in sorted(root.rglob("*")): tf.add(p,arcname=str(p.relative_to(root)),recursive=False)
+'
+sha256sum "$RECOVERY_DIR/sara-data.tar.gz" > "$RECOVERY_DIR/sara-data.tar.gz.sha256"
+
+docker compose down -v
+docker compose create sara >/dev/null
+docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+import pathlib,tarfile
+root=pathlib.Path("/var/lib/sara"); root.mkdir(parents=True,exist_ok=True)
+with tarfile.open("/recovery/sara-data.tar.gz","r:gz") as tf: tf.extractall(root,filter="data")
+'
+docker compose up -d
+for _ in $(seq 1 30); do if curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null; then break; fi; sleep 1; done
+curl -fsS http://127.0.0.1:${SARA_HOST_PORT:-9530}/readyz >/dev/null
+
+docker compose run --rm --no-deps -v "$PWD/$RECOVERY_DIR:/recovery" --entrypoint python sara -c '
+import hashlib,json,pathlib
+root=pathlib.Path("/var/lib/sara"); rows=[]
+for p in sorted(x for x in root.rglob("*") if x.is_file()): rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
+pathlib.Path("/recovery/after.json").write_text(json.dumps(rows,sort_keys=True,indent=2)+"\n")
+'
+cmp "$RECOVERY_DIR/before.json" "$RECOVERY_DIR/after.json"
+python - <<'PY'
+import hashlib,json,pathlib,subprocess,datetime,os
+p=pathlib.Path(os.environ["RECOVERY_DIR"]); archive=p/"sara-data.tar.gz"
+result={"status":"PASS","exercise":"destructive_named_volume_backup_restore","archive_sha256":hashlib.sha256(archive.read_bytes()).hexdigest(),"git_head":subprocess.check_output(["git","rev-parse","HEAD"],text=True).strip(),"executed_utc":datetime.datetime.now(datetime.timezone.utc).isoformat(),"scope":"synthetic/public local deployment data only","external_compliance_claim":"NONE"}
+(p/"result.json").write_text(json.dumps(result,sort_keys=True,indent=2)+"\n")
+PY
+echo "RECOVERY_EXERCISE: PASS"


### PR DESCRIPTION
Adds a CI-gated destructive named-volume backup/restore exercise for the verified local SARA deployment. The exercise inventories persistent files by SHA-256, archives the data, destroys the named volume, restores into a newly created volume, proves readiness, compares before/after inventories byte-for-byte, and emits retained recovery evidence bound to the tested Git commit. Scope remains synthetic/public local data only; this does not claim off-host retention, replacement-host recovery, CMMC/NIST certification, ATO, or external compliance.