### PR TITLE
Operational readiness: incident runbook and evidence snapshots

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -39,6 +39,11 @@ jobs:
           command -v ws-pre-bloom
           ws-pre-bloom --help >/dev/null
 
+      - name: Validate operations policy
+        run: |
+          python -m json.tool ops_policy.json >/dev/null
+          test -s docs/OPERATIONS.md
+
       - name: Compile package
         run: python -m compileall -q worldshepherd_sara
 
@@ -83,11 +88,21 @@ jobs:
       - name: Run destructive backup and restore exercise
         run: bash scripts/recovery_exercise.sh
 
+      - name: Capture operational snapshot after recovery
+        run: bash scripts/ops_snapshot.sh
+
       - name: Upload recovery evidence
         uses: actions/upload-artifact@v4
         with:
           name: sara-recovery-exercise-evidence
           path: deployments/sara_verified_local_v1/recovery_evidence
+          if-no-files-found: error
+
+      - name: Upload operational snapshot evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-operational-snapshot-evidence
+          path: deployments/sara_verified_local_v1/operations_evidence
           if-no-files-found: error
 
       - name: Capture container logs on failure

--- a/deployments/sara_verified_local_v1/docs/OPERATIONS.md
+++ b/deployments/sara_verified_local_v1/docs/OPERATIONS.md
@@ -1,0 +1,71 @@
+# SARA Verified Local v1 — Operations & Incident Runbook
+
+## Scope
+This runbook applies to the localhost-only `sara_verified_local_v1` deployment and synthetic/public/releasable data. It does **not** authorize CUI, classified, export-controlled, partner-proprietary, or operational mission data and does not establish CMMC, NIST SP 800-171 compliance, RMF/ATO, or customer operational approval.
+
+## Supported operating state
+- Service must remain bound to loopback on the host unless a separately reviewed production profile is approved.
+- The application container runs non-root, read-only root filesystem, dropped Linux capabilities, and `no-new-privileges`.
+- Persistent application state resides in the named `sara_data` volume.
+- Relay and admin credentials are separate; relay credentials must not authorize admin endpoints.
+- `/livez` establishes process liveness. `/readyz` establishes application/storage readiness. `/health` is compatibility/status information, not an authorization decision.
+
+## Operational checks
+At start of shift or after deployment/recovery:
+1. Run `docker compose config --quiet`.
+2. Run `scripts/verify_deployment.sh`.
+3. Confirm `/livez` and `/readyz` are healthy.
+4. Confirm relay token remains blocked from admin endpoints.
+5. Confirm audit append/self-test succeeds.
+6. Capture `scripts/ops_snapshot.sh` output and retain with the relevant release/incident record.
+
+## Incident classes
+- **SEV-1:** suspected credential compromise, unauthorized admin action, integrity/custody failure, prohibited-data exposure, or inability to trust audit/configuration state.
+- **SEV-2:** service unavailable, readiness failure, persistent-data corruption, repeated authorization failures, or recovery failure without evidence of compromise.
+- **SEV-3:** degraded/non-critical function, performance regression, warning-level dependency/runtime issue, or documentation/configuration drift.
+
+## Fail-closed response
+For SEV-1:
+1. Stop consequential automation and do not approve new external actions.
+2. Preserve logs/evidence before destructive remediation when safe.
+3. Rotate affected credentials outside version control.
+4. Isolate the localhost deployment from any external integration path.
+5. Record incident UTC start, operator, Git commit, configuration digest, evidence digests, observed symptoms, containment action, and recovery decision.
+6. Restore only from an approved evidence-backed state; do not silently repair an untrusted history.
+7. Require explicit human closure/re-authorization before resuming consequential workflows.
+
+For SEV-2:
+1. Capture operations snapshot and container logs.
+2. Run readiness/self-test.
+3. If persistent state is suspect, run the recovery procedure against a verified backup artifact.
+4. Verify exact evidence/data inventory after restore.
+5. Record discrepancy and root cause before returning to normal operation.
+
+For SEV-3:
+1. Record the regression/warning and affected version.
+2. Open a tracked corrective issue.
+3. Do not promote evidence maturity merely because the service remains available.
+
+## Evidence retention baseline
+The public CI evidence retention period is a convenience baseline, not a federal records schedule. For this local profile:
+- Qualification and recovery artifacts should be retained for at least 90 days when CI storage permits.
+- Release acceptance records should retain commit SHA, artifact SHA-256, workflow/run identity, and claims boundary even after ephemeral artifacts expire.
+- Incidents remain open until evidence identifies containment, restoration state, residual risk, and authorized closure.
+- Deletion or retention changes involving regulated/customer records require separate legal/contract review.
+
+## Recovery
+`scripts/recovery_exercise.sh` proves a destructive named-volume backup/restore loop for synthetic/public local data. It does **not** prove replacement-host recovery, off-host independent retention, disaster recovery across regions, or controlled-data restoration.
+
+## Rollback
+A rollback is authorized only to a specifically identified prior release whose code/evidence state is known. Rollback must preserve an immutable record of:
+- source release commit;
+- target prior commit/image;
+- data/schema compatibility decision;
+- pre-rollback backup digest;
+- post-rollback readiness and smoke-test results;
+- operator approval.
+
+Until a CI rollback drill against a frozen prior release is green, full deployment rollback remains an open production-readiness gate.
+
+## Escalation / claims rule
+When uncertainty exists, classify the state as `UNVERIFIED` or the applicable `REQUIRES_*` category and escalate. No operational procedure may convert internal evidence into external certification, physical validation, government acceptance, or legal eligibility.

--- a/deployments/sara_verified_local_v1/ops_policy.json
+++ b/deployments/sara_verified_local_v1/ops_policy.json
@@ -1,0 +1,34 @@
+{
+  "schema": "WS-SARA-OPS-POLICY-V1",
+  "profile": "sara_verified_local_v1",
+  "network_scope": "localhost_only",
+  "data_scope": ["synthetic", "public", "releasable"],
+  "prohibited_by_default": [
+    "CUI",
+    "classified",
+    "export_controlled_technical_data",
+    "partner_proprietary",
+    "operational_mission_data",
+    "credentials_in_repo_or_artifacts"
+  ],
+  "health_endpoints": {
+    "liveness": "/livez",
+    "readiness": "/readyz",
+    "compatibility": "/health"
+  },
+  "incident_classes": {
+    "SEV-1": "integrity, credential, unauthorized-admin, prohibited-data or evidence-trust failure",
+    "SEV-2": "availability, readiness, persistent-data or recovery failure",
+    "SEV-3": "degraded non-critical behavior, warning or drift"
+  },
+  "artifact_retention_days_minimum": 90,
+  "human_closure_required_for_sev1": true,
+  "claims_boundary": [
+    "internal operational policy only",
+    "not CMMC certification",
+    "not NIST SP 800-171 compliance determination",
+    "not RMF/ATO",
+    "not government operational approval",
+    "not a regulated records schedule"
+  ]
+}

--- a/deployments/sara_verified_local_v1/scripts/ops_snapshot.sh
+++ b/deployments/sara_verified_local_v1/scripts/ops_snapshot.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+OUT_DIR="${OPS_EVIDENCE_DIR:-operations_evidence}"
+mkdir -p "$OUT_DIR"
+HOST_PORT="${SARA_HOST_PORT:-$(awk -F= '$1=="SARA_HOST_PORT" {print $2}' .env 2>/dev/null || true)}"
+HOST_PORT="${HOST_PORT:-9530}"
+
+curl -fsS "http://127.0.0.1:${HOST_PORT}/livez" > "$OUT_DIR/livez.json"
+curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" > "$OUT_DIR/readyz.json"
+CONFIG_SHA="$(docker compose config | sha256sum | awk '{print $1}')"
+CONTAINER_ID="$(docker compose ps -q sara)"
+export OUT_DIR CONFIG_SHA CONTAINER_ID HOST_PORT
+python - <<'PY'
+import datetime, hashlib, json, os, pathlib, subprocess
+out=pathlib.Path(os.environ['OUT_DIR'])
+inspect=json.loads(subprocess.check_output(['docker','inspect',os.environ['CONTAINER_ID']], text=True))[0]
+state=inspect.get('State',{})
+image_id=inspect.get('Image','')
+record={
+  'schema':'WS-SARA-OPS-SNAPSHOT-V1',
+  'executed_utc':datetime.datetime.now(datetime.timezone.utc).isoformat(),
+  'git_head':subprocess.check_output(['git','rev-parse','HEAD'], text=True).strip(),
+  'compose_config_sha256':'sha256:'+os.environ['CONFIG_SHA'],
+  'container_image_id':image_id,
+  'container_running':bool(state.get('Running')),
+  'container_health':(state.get('Health') or {}).get('Status','not_configured'),
+  'host_binding':'127.0.0.1:'+os.environ['HOST_PORT'],
+  'livez_sha256':'sha256:'+hashlib.sha256((out/'livez.json').read_bytes()).hexdigest(),
+  'readyz_sha256':'sha256:'+hashlib.sha256((out/'readyz.json').read_bytes()).hexdigest(),
+  'data_scope':'synthetic/public/releasable only',
+  'secret_material_in_snapshot':False,
+  'external_compliance_claim':'NONE'
+}
+(out/'snapshot.json').write_text(json.dumps(record,sort_keys=True,indent=2)+'\n')
+PY
+
+test -s "$OUT_DIR/snapshot.json"
+echo "OPS_SNAPSHOT: PASS"


### PR DESCRIPTION
Adds a claims-controlled localhost operations/incident runbook, machine-readable operations policy, and non-secret operational snapshot evidence. CI validates policy syntax, runs the existing deployment/recovery gates, captures a post-recovery liveness/readiness/configuration/container snapshot, and retains it as an artifact. This remains synthetic/public local operational evidence only and does not claim CMMC, NIST SP 800-171 compliance, RMF/ATO, customer operational approval, or regulated-records compliance.