### PR TITLE
Reproducible build hardening: pinned image and dependency resolution

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -32,12 +32,21 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install package and test dependencies
+      - name: Install pinned package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[test]'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+          python -m pip freeze --all | sort > dependency-freeze.txt
           command -v ws-pre-bloom
           ws-pre-bloom --help >/dev/null
+
+      - name: Upload dependency resolution evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-dependency-freeze-evidence
+          path: deployments/sara_verified_local_v1/dependency-freeze.txt
+          if-no-files-found: error
 
       - name: Validate operations policy
         run: |

--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install pinned package and test dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install 'pip==26.2.1'
           python -m pip install -c constraints-ci.txt -e '.[test]'
           python -m pip check
           python -m pip freeze --all | sort > dependency-freeze.txt

--- a/deployments/sara_verified_local_v1/Dockerfile
+++ b/deployments/sara_verified_local_v1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:7a8b475003c4fe15a2cd4e55e5cfc2f3560bdc9333d624f24cdd6d4340fd7a17
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -8,9 +8,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 RUN useradd --create-home --uid 10001 sara
 WORKDIR /app
-COPY pyproject.toml README.md ./
+COPY pyproject.toml README.md constraints-runtime.txt ./
 COPY worldshepherd_sara ./worldshepherd_sara
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir --disable-pip-version-check -c constraints-runtime.txt .
 RUN mkdir -p /var/lib/sara && chown -R sara:sara /var/lib/sara /app && chmod 0700 /var/lib/sara
 USER sara
 EXPOSE 9530

--- a/deployments/sara_verified_local_v1/constraints-ci.txt
+++ b/deployments/sara_verified_local_v1/constraints-ci.txt
@@ -1,0 +1,11 @@
+-c constraints-runtime.txt
+
+# Test-only resolution pinned from green CI environment on 2026-08-26.
+certifi==2026.7.22
+httpcore==1.0.9
+httpx==0.28.1
+iniconfig==2.3.0
+packaging==26.3
+pluggy==1.6.0
+Pygments==2.21.0
+pytest==8.4.2

--- a/deployments/sara_verified_local_v1/constraints-runtime.txt
+++ b/deployments/sara_verified_local_v1/constraints-runtime.txt
@@ -1,0 +1,21 @@
+# WS-SARA runtime constraints — pinned from green CI environment on 2026-08-26.
+# Version pinning improves repeatability; package-file hash locking remains a future hardening gate.
+annotated-doc==0.0.5
+annotated-types==0.8.0
+anyio==4.14.2
+click==8.5.0
+fastapi==0.141.1
+h11==0.16.0
+httptools==0.8.0
+idna==3.19
+pydantic==2.13.4
+pydantic-core==2.46.4
+python-dotenv==1.2.3
+PyYAML==6.0.3
+starlette==1.6.0
+typing-extensions==4.16.0
+typing-inspection==0.4.4
+uvicorn==0.52.4
+uvloop==0.22.1
+watchfiles==1.2.0
+websockets==17.1

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools==80.9.0", "wheel==0.45.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/deployments/sara_verified_local_v1/tests/test_pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_pre_bloom_cli.py
@@ -27,7 +27,14 @@ def test_full_bloom_compiler_emits_cross_domain_evidence_readiness_horizons_and_
     assert (out / "capability_readiness_ledger.json").is_file()
     assert (out / "capability_horizons.json").is_file()
     assert (out / "software_provenance.json").is_file()
+
     provenance = json.loads((out / "software_provenance.json").read_text())
     assert provenance["attestation_state"] == "INTERNAL_UNSIGNED"
+    policy = provenance["metadata"]["build_policy_inputs"]
+    for name in ("pyproject.toml", "constraints-runtime.txt", "constraints-ci.txt", "Dockerfile"):
+        assert policy["files"][name].startswith("sha256:")
+    assert "@sha256:" in policy["container_base_reference"]
+    assert "build_policy_input_digests" in index["bloom_extensions"]
+
     horizons = json.loads((out / "capability_horizons.json").read_text())
     assert {record["horizon"] for record in horizons["records"]} >= {"0-90D", "3-12M", "12-24M_PLUS"}

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -30,6 +31,28 @@ def _write(path: Path, value: dict[str, Any]) -> None:
         json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
     )
+
+
+def _file_sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _build_policy_inputs() -> dict[str, Any]:
+    cwd = Path.cwd()
+    paths = ["pyproject.toml", "constraints-runtime.txt", "constraints-ci.txt", "Dockerfile"]
+    values: dict[str, Any] = {
+        "files": {name: _file_sha256(cwd / name) for name in paths},
+        "capture_root": str(cwd),
+    }
+    dockerfile = cwd / "Dockerfile"
+    if dockerfile.is_file():
+        first_line = dockerfile.read_text(encoding="utf-8").splitlines()[0].strip()
+        values["container_base_reference"] = first_line[5:].strip() if first_line.startswith("FROM ") else None
+    else:
+        values["container_base_reference"] = None
+    return values
 
 
 def _requirement(
@@ -120,6 +143,7 @@ def build_bloom(
         "machine": platform.machine(),
         "execution_context": "pre-bloom-cli",
     }
+    build_policy_inputs = _build_policy_inputs()
 
     edge = qualify_host_callable(
         function=_edge_workload,
@@ -178,6 +202,7 @@ def build_bloom(
                 "builder": operator,
                 "runtime_identity": runtime_identity,
                 "components": [component.model_dump(mode="json") for component in components],
+                "build_policy_inputs": build_policy_inputs,
             }
         ),
         output_artifact_digest=canonical_digest(bundle_manifest),
@@ -185,6 +210,7 @@ def build_bloom(
         metadata={
             "attested_object": "WS-PRE-BUNDLE-MANIFEST-V1",
             "runtime_identity": runtime_identity,
+            "build_policy_inputs": build_policy_inputs,
         },
     )
     provenance_value = provenance.model_dump(mode="json")
@@ -202,6 +228,7 @@ def build_bloom(
         "capability_readiness_ledger",
         "0-90D_3-12M_12-24M_PLUS_horizons",
         "internal_unsigned_software_provenance",
+        "build_policy_input_digests",
     ]
     index["claims_boundary"].extend(
         [
@@ -209,6 +236,7 @@ def build_bloom(
             "DDIL rejoin evidence validates a synthetic conflict policy, not distributed consensus or operational network resilience.",
             "Capability horizons schedule preparation only and never upgrade readiness claims.",
             "Software provenance is INTERNAL_UNSIGNED unless a later attestation explicitly records signing/verification evidence.",
+            "Pinned versions and base-image digests improve repeatability but do not constitute a hermetic or independently verified software supply chain.",
         ]
     )
     _write(out / "qualification_index.json", index)


### PR DESCRIPTION
Pins the Python container base by digest, constrains resolved runtime and CI dependency versions, pins Python build-backend versions, runs `pip check`, captures the exact CI dependency freeze, and continues the full deployment/recovery/operations gates. This improves repeatability and supply-chain evidence. It does not claim fully hermetic builds or package-file hash verification; artifact/wheel hash locking and an independent package mirror remain future hardening.