### PR TITLE
Release identity: bind runtime image to tested commit

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -83,9 +83,11 @@ jobs:
 
       - name: Create ephemeral CI environment
         run: |
-          printf 'SARA_RELAY_TOKEN=%s\nSARA_ADMIN_TOKEN=%s\nSARA_PORT=9530\nSARA_HOST_PORT=19530\n' \
+          printf 'SARA_RELAY_TOKEN=%s\nSARA_ADMIN_TOKEN=%s\nSARA_PORT=9530\nSARA_HOST_PORT=19530\nSARA_BUILD_COMMIT=%s\nSARA_RELEASE_ID=%s\n' \
             "$(openssl rand -hex 32)" \
-            "$(openssl rand -hex 32)" > .env
+            "$(openssl rand -hex 32)" \
+            "$GITHUB_SHA" \
+            "ci-${GITHUB_SHA}" > .env
           chmod 600 .env
 
       - name: Validate Compose configuration
@@ -99,6 +101,16 @@ jobs:
 
       - name: Capture operational snapshot after recovery
         run: bash scripts/ops_snapshot.sh
+
+      - name: Verify observable release identity
+        run: |
+          python - <<'PY'
+          import json, pathlib, os
+          record=json.loads(pathlib.Path('operations_evidence/snapshot.json').read_text())
+          identity=record['release_identity']
+          assert identity['build_commit'] == os.environ['GITHUB_SHA']
+          assert identity['release_id'] == 'ci-' + os.environ['GITHUB_SHA']
+          PY
 
       - name: Upload recovery evidence
         uses: actions/upload-artifact@v4

--- a/deployments/sara_verified_local_v1/.env.example
+++ b/deployments/sara_verified_local_v1/.env.example
@@ -8,3 +8,7 @@ SARA_HOST_PORT=9530
 SARA_DATA_DIR=./data
 SARA_MODE=local-verified
 SARA_LOG_LEVEL=info
+# For an accepted build, set these to the exact tested source commit and release/baseline identifier.
+# UNKNOWN/UNVERIFIED must never be represented as an approved release identity.
+SARA_BUILD_COMMIT=UNKNOWN
+SARA_RELEASE_ID=UNVERIFIED

--- a/deployments/sara_verified_local_v1/Dockerfile
+++ b/deployments/sara_verified_local_v1/Dockerfile
@@ -1,10 +1,19 @@
 FROM python:3.12-slim@sha256:7a8b475003c4fe15a2cd4e55e5cfc2f3560bdc9333d624f24cdd6d4340fd7a17
 
+ARG SARA_BUILD_COMMIT=UNKNOWN
+ARG SARA_RELEASE_ID=UNVERIFIED
+
+LABEL org.opencontainers.image.title="Worldshepherd SARA Verified Local v1" \
+      org.opencontainers.image.revision="${SARA_BUILD_COMMIT}" \
+      org.opencontainers.image.version="${SARA_RELEASE_ID}"
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     SARA_BIND_HOST=0.0.0.0 \
     SARA_PORT=9530 \
-    SARA_DATA_DIR=/var/lib/sara
+    SARA_DATA_DIR=/var/lib/sara \
+    SARA_BUILD_COMMIT=${SARA_BUILD_COMMIT} \
+    SARA_RELEASE_ID=${SARA_RELEASE_ID}
 
 RUN useradd --create-home --uid 10001 sara
 WORKDIR /app

--- a/deployments/sara_verified_local_v1/compose.yaml
+++ b/deployments/sara_verified_local_v1/compose.yaml
@@ -2,6 +2,9 @@ services:
   sara:
     build:
       context: .
+      args:
+        SARA_BUILD_COMMIT: ${SARA_BUILD_COMMIT:-UNKNOWN}
+        SARA_RELEASE_ID: ${SARA_RELEASE_ID:-UNVERIFIED}
     restart: unless-stopped
     env_file:
       - .env

--- a/deployments/sara_verified_local_v1/scripts/ops_snapshot.sh
+++ b/deployments/sara_verified_local_v1/scripts/ops_snapshot.sh
@@ -17,12 +17,18 @@ out=pathlib.Path(os.environ['OUT_DIR'])
 inspect=json.loads(subprocess.check_output(['docker','inspect',os.environ['CONTAINER_ID']], text=True))[0]
 state=inspect.get('State',{})
 image_id=inspect.get('Image','')
+labels=(inspect.get('Config') or {}).get('Labels') or {}
 record={
-  'schema':'WS-SARA-OPS-SNAPSHOT-V1',
+  'schema':'WS-SARA-OPS-SNAPSHOT-V2',
   'executed_utc':datetime.datetime.now(datetime.timezone.utc).isoformat(),
   'git_head':subprocess.check_output(['git','rev-parse','HEAD'], text=True).strip(),
   'compose_config_sha256':'sha256:'+os.environ['CONFIG_SHA'],
   'container_image_id':image_id,
+  'release_identity':{
+    'build_commit':labels.get('org.opencontainers.image.revision','UNKNOWN'),
+    'release_id':labels.get('org.opencontainers.image.version','UNVERIFIED'),
+    'image_title':labels.get('org.opencontainers.image.title','UNKNOWN')
+  },
   'container_running':bool(state.get('Running')),
   'container_health':(state.get('Health') or {}).get('Status','not_configured'),
   'host_binding':'127.0.0.1:'+os.environ['HOST_PORT'],
@@ -36,4 +42,11 @@ record={
 PY
 
 test -s "$OUT_DIR/snapshot.json"
+python - <<'PY'
+import json, pathlib, sys
+record=json.loads(pathlib.Path('operations_evidence/snapshot.json').read_text())
+identity=record['release_identity']
+if identity['build_commit'] in ('UNKNOWN','') or identity['release_id'] in ('UNVERIFIED',''):
+    raise SystemExit('release identity is not observable')
+PY
 echo "OPS_SNAPSHOT: PASS"


### PR DESCRIPTION
Adds observable release identity to SARA container builds using OCI revision/version labels and matching runtime environment values. Compose passes `SARA_BUILD_COMMIT` and `SARA_RELEASE_ID`; CI binds them to the exact tested Git SHA, operational snapshot evidence records them, and the gate requires they match. This enables a future rollback drill to prove which build is actually running. It does not itself close rollback, production release approval, signing, or external attestation.