### PR TITLE
Add SPACEGHOST public lead evidence ledger

### DIFF
--- a/docs/SPACEGHOST_NAMING_PATTERN_ADDENDUM_2026-08-29.md
+++ b/docs/SPACEGHOST_NAMING_PATTERN_ADDENDUM_2026-08-29.md
@@ -1,0 +1,45 @@
+# SPACEGHOST Public Audit — Naming Pattern Addendum
+
+**Parent package:** `WS-SG-PUBLIC-AUDIT-2026-08-29`  
+**Canonical Library ledger:** `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md`
+
+This addendum records two additional methodological controls discovered after the 21-lead GitHub ledger revision. They are incorporated into the canonical Worldshepherd Library ledger and JSON manifest, which now contain **23 public-source leads**.
+
+## SG-PUB-022 — SpaceX operational drone ships use Iain M. Banks Culture spacecraft names
+
+**Date:** 2015-01-29 / operational through 2026  
+**Status:** CONFIRMED PUBLIC FACT / HIGH METHODOLOGICAL RELEVANCE
+
+SpaceX's autonomous spaceport drone ships include **Of Course I Still Love You**, **Just Read the Instructions**, and **A Shortfall of Gravitas**. Contemporary reporting tied Musk's naming of the first two ships to spacecraft in Iain M. Banks's *Culture* fiction. SpaceX's 2026 prospectus lists all three as operational recovery vessels.
+
+**Why it matters:** this confirms that science-fiction spacecraft/system names have been transferred into real SpaceX operational infrastructure. It strengthens the audit method of preserving alternate/cultural names such as **Skynet, Cyberdyne, and Colossus** as searchable leads rather than dismissing them as one-off jokes.
+
+**Boundary:** the naming habit does **not** show that SPACEGHOST was an alias, codename, acknowledgement, or protocol name.
+
+**PB/PD test:** the operational ship-name string was tested under PB `13524` and PD `34521` word/normalized-character blocks across offsets and non-identity orbit steps. No new non-source target string was found.
+
+Sources:
+- https://content.spacex.com/cms-assets/FINAL_Documents%20and%20Updates/SpaceX%20-%20EU%20Prospectus%20%28Approved%20by%20Bafin%29%20-%20June%205%2C%202026.pdf
+- https://www.space.com/28445-spacex-elon-musk-drone-ships-names.html
+
+## SG-PUB-023 — Musk proposed Heart of Gold for the first SpaceX Mars ship
+
+**Date:** 2016-09-27  
+**Status:** CONFIRMED PUBLIC FACT / HIGH METHODOLOGICAL RELEVANCE
+
+During SpaceX's 2016 Mars architecture presentation, Musk said the first ship to Mars would probably be named **Heart of Gold**, explicitly invoking the spacecraft from Douglas Adams's *The Hitchhiker's Guide to the Galaxy* and its improbability motif.
+
+**Why it matters:** this is an independent example of Musk mapping a fictional spacecraft name onto proposed real SpaceX hardware. Together with the Culture-named drone ships and xAI's real **Colossus** supercomputer, it makes alternate-name recurrence an evidence-based search strategy.
+
+**Boundary:** it establishes no SPACEGHOST or coded-message relationship; the reference was explicit and public.
+
+**PB/PD test:** the Heart of Gold/Mars naming sentence was tested under PB/PD word and normalized-character blocks across offsets/orbits. No new non-source target string was found.
+
+Source:
+- https://www.space.com/34220-spacex-first-mars-ship-hitchhikers-guide-galaxy.html
+
+## Effect on current assessment
+
+The naming-pattern hypothesis has strengthened: Musk/SpaceX/xAI have multiple verified examples of fictional or culturally derived system/spacecraft names being applied to real or proposed technical systems. That justifies searching alternate names and callbacks as **leads**. It does not justify mapping any particular alternate name to SPACEGHOST without direct or reproducibly coded evidence.
+
+The only retained coded-text candidate remains `SG-CODE-001`: PD `34521`, first step, offset 0 → `LASER` in the 2015 Seattle Skynet paragraph. It remains **not authenticated** because matched controls show nonzero accidental-word production.

--- a/docs/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md
+++ b/docs/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md
@@ -3,13 +3,13 @@
 **Package ID:** `WS-SG-PUBLIC-AUDIT-2026-08-29`  
 **Date:** 2026-08-29  
 **Status:** Evidence-governed research ledger; not an attribution claim.  
-**Canonical Worldshepherd Library package:** `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/`
+**Canonical Library package:** `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/`
 
 ## Current conclusion
 
-No direct public Elon Musk / SpaceX / Starlink / Joe Rogan **SPACEGHOST** or **ghost-protocol** attribution has been established in the sources reviewed. The ledger separates confirmed public facts, lexical/technical adjacency, subspeak/subtalk candidates, coded-text candidates, negative results, and false positives.
+No direct public Elon Musk / SpaceX / Starlink / Joe Rogan **SPACEGHOST** or **ghost-protocol** attribution has been established in the sources reviewed. This ledger preserves confirmed facts, subspeak/subtalk leads, technical and cultural adjacency, coded-text tests, negative findings, and false positives separately.
 
-Internal Worldshepherd recovery currently places **Worldshepherd** explicitly in sent correspondence on 2024-04-02, **Spaceghost Protocol + BRD953 + Worldshepherd** on 2024-06-16, and **Space.Ghost** expansion in March 2025. That is an internal documentary chronology only; it does not establish outside attribution or continuous technical lineage.
+Worldshepherd's recovered internal chronology currently places **Worldshepherd** explicitly in sent correspondence on 2024-04-02, **Spaceghost Protocol + BRD953 + Worldshepherd** on 2024-06-16, and **Space.Ghost** expansion in March 2025. That is internal documentary chronology only; it does not establish outside attribution, technical lineage, authorship recognition, or external authority.
 
 ## Search / coding method
 
@@ -17,89 +17,122 @@ Evidence channels: literal mention; spelling variants; **subspeak**; **subtalk**
 
 - **PB:** `12345→13524` = `[1,3,5,2,4]`; non-identity orbit `13524 → 15432 → 14253`.
 - **PD:** `12345→34521` = `[3,4,5,2,1]`; non-identity orbit `34521 → 52143 → 14325 → 32541 → 54123`.
-- Preserve exact source text first. Then test 5-word blocks and normalized 5-character blocks, offsets 0–4, and all non-identity PB/PD orbit steps.
-- Readable output is not treated as intentional unless it survives matched controls and independently recurs under a preregistered rule.
+- Preserve exact source text before normalization.
+- Test 5-word and normalized 5-character blocks, offsets 0–4, and every non-identity PB/PD orbit step.
+- Compare readable outputs to neighboring passages, matched controls, all 120 five-position permutations, and shuffled-text controls where practical.
+- A readable fragment is **not** evidence of an intentional message without independent recurrence under a preregistered rule.
 
 ## Public lead register
 
 ### SG-PUB-001 — 2012 Total Ghost / Space Station / SpaceX
-Musk publicly called a Total Ghost track the SpaceX “theme song,” then clarified the remark was ironic. Contemporary coverage identifies the track as **Space Station**. This establishes a Musk→SpaceX→Ghost→space-themed-media lexical chain, but no protocol or SPACEGHOST attribution.
+Musk publicly called a Total Ghost track the SpaceX “theme song,” then clarified that the remark was ironic. Contemporary coverage identifies the track as **Space Station**. This establishes a documented Musk→SpaceX→Ghost→space-themed-media lexical chain, but no protocol or SPACEGHOST attribution.
 
 Sources:
 - https://www.elonmuskarchive.org/posts?page=2&sort=old&year=2012
 - https://boingboing.net/2012/02/10/your-weekend-space-jam-spac.html
 
-Permutation: no high-confidence PB/PD coded result retained.
+PB/PD: no high-confidence coded output retained.
 
-### SG-PUB-002 — 2013 SpaceX Skynet / Cyberdyne naming
-In a Stanford GSB discussion, the interviewer describes SpaceX data-center **Skynet / Cyberdyne Systems** branding; Musk confirms that the FEA/CFD cluster was called Cyberdyne Systems. This establishes Terminator-derived naming inside SpaceX technical infrastructure before Starlink's public rollout. It does not establish Skynet as an official Starlink codename or as SPACEGHOST.
+### SG-PUB-002 — 2013 SpaceX Skynet / Cyberdyne technical naming
+At a Stanford GSB discussion, the interviewer describes SpaceX data-center **Skynet / Cyberdyne Systems** branding; Musk confirms the FEA/CFD compute cluster was called Cyberdyne Systems. This documents Terminator-derived naming inside SpaceX infrastructure before Starlink's public rollout. It does not establish Skynet as an official Starlink codename or SPACEGHOST alias.
 
 Source: https://elonmuskarchive.org/video/stanford-gsb-encore-award-2013-10-02
 
-Permutation: a transformed `CODE` fragment under PD is retained only as a rejected weak/noise result.
+PB/PD: transformed `CODE` under one PD alignment rejected as weak/noise.
 
 ### SG-PUB-003 — 2013 Dragon recode / upload new code in orbit
-At SXSW, Musk recounts recoding a communications proxy, using Air Force long-range dishes and uploading new code/software to Dragon in orbit to recover a propulsion pressurization problem. This is the strongest verified public match to the remembered **code-in-space** motif. It is an upload/recovery story; Musk does not say code was “found” in space and does not mention SPACEGHOST.
+At SXSW, Musk recounts recoding a communications proxy, routing through U.S. Air Force long-range dishes and uploading new software/code to Dragon in orbit to recover a propulsion pressurization problem. This is the strongest verified match to the remembered **code-in-space** motif. It is an upload/recovery account, not a claim that code was found in space, and contains no SPACEGHOST wording.
 
 Sources:
 - https://elonmuskarchive.org/de/video/sxsw-2013-03-09
 - https://singjupost.com/transcript-of-elon-musk-interview-sxsw-live-march-9-2013/
 
-Permutation: CODE/NODE-like fragments under some alignments are source-derived/weak and not retained as coded evidence.
+PB/PD: CODE/NODE-like fragments are source-derived/weak and not coded evidence.
+
+### SG-PUB-018 — 2014 Musk endorses Daniel Suarez's `Daemon`
+In an AI-risk thread, a user recommends Daniel Suarez's **Daemon** as “terrifyingly possible”; Musk replies that `Daemon` is a great read. Penguin Random House describes daemons as background computer programs and the novel as involving a dormant, self-replicating networked program activated after its creator's death. This supplies a documented pre-Starlink cultural/technical context around persistent autonomous background software and network propagation.
+
+Sources:
+- https://www.elonmuskarchive.org/posts?page=4&year=2014
+- https://www.penguinrandomhouse.com/books/304687/daemon-by-daniel-suarez/
+
+Boundary: this is a book recommendation; `daemon` is standard computing terminology and provides no SpaceX/Starlink/SPACEGHOST attribution.
+
+PB/PD: exact Musk phrase `Yeah, Daemon is a great read` tested as 5-word and normalized 5-character blocks across offsets/orbits. No new high-confidence target string; only source word `DAEMON` persists under word permutation.
 
 ### SG-PUB-004 — 2015 Seattle satellite Internet / Skynet / software / security / code
-Musk describes a global satellite communications system as effectively **rebuilding the Internet in space**, says SpaceX would make sure it did not create Skynet, and notes that its server room had jokingly been called Skynet. The same talk discusses software/firmware, network robustness, security against takeover, and a low-level code path to safe mode/regain control. This is the highest-density historical source combining Skynet, orbital networking, software, distributed resilience, security and control-code concepts.
+Musk describes a global satellite communications system as effectively **rebuilding the Internet in space**, says SpaceX would make sure it did not create Skynet, and notes its server room had jokingly been called Skynet. The same talk covers software/firmware, distributed constellation robustness, security against takeover, and a low-level code path to safe mode/regain control. This remains the highest-density historical source combining Skynet, orbital networking, software, resilience, security and control-code concepts.
 
 Sources:
 - https://www.geekwire.com/2015/elon-musk-plans-get-mars-via-seattle-spacex-founder-said-private-event/
 - https://starpath.global/news/how-elon-musk-plans-get-mars-via-seattle-what-the-spacex-founder-said-at-that-private-event/
 
-**Coded candidate SG-CODE-001:** on the exact Skynet paragraph, letters-only normalization, 5-character blocks, **PD `34521` first step, offset 0**, produces contiguous `LASER` across a transformed block boundary. Enumerating all 120 five-position permutations × five offsets (600 combinations) on that exact paragraph produced this `LASER` only for PD/offset 0. A neighboring-control corpus produced another `LASER` under a different later PD step/alignment. Status: **RETAIN FOR REPLICATION / NOT AUTHENTICATED**.
+**SG-CODE-001:** exact Skynet paragraph; letters-only normalization; 5-character blocks; **PD `34521`, first step, offset 0** generates contiguous `LASER` across a transformed block boundary. Enumeration of all 120 five-position permutations × 5 offsets (600 combinations) on that exact paragraph produced that `LASER` only under PD/offset 0. A neighboring-control set generated another `LASER` at a different later PD step/alignment, so chance remains plausible. **Status: RETAIN FOR REPLICATION / NOT AUTHENTICATED.**
+
+### SG-PUB-019 — 2017 `Ghost in the Shell` + `Colossus: The Forbin Project`
+On 2017-01-16 Musk posted that he had rewatched **Ghost in the Shell** and the end of **Colossus: The Forbin Project**. Ghost in the Shell centers on networked cyborg identity/consciousness. Colossus depicts an autonomous defense supercomputer that discovers and links with another system; the fictional Soviet counterpart is named **Guardian**. This post falls roughly four weeks before Musk's February 2017 `digital ghost` remarks, making it useful cultural context for ghost/network/autonomous-system vocabulary.
+
+Sources:
+- https://elonmuskarchive.org/posts/820934434002063361
+- https://www.theghostintheshell-anime.jp/en/introduction/
+- https://en.wikipedia.org/wiki/Colossus%3A_The_Forbin_Project
+
+Boundary: media consumption and fictional terminology are not evidence of protocol identity, influence, acknowledgement or common lineage. The fictional `Guardian` name is retained as context only.
+
+PB/PD: exact post text tested across word/character blocks, offsets and non-identity orbit steps. No new high-confidence hidden target; `GHOST`/`SHELL` are source-derived words.
 
 ### SG-PUB-005 — 2017 “digital ghost”
-Musk describes a person's persistent digital data after death as a **digital ghost** and discusses closer biological/digital integration and bandwidth. Confirms recurring ghost vocabulary, but not a SpaceX/Starlink/SPACEGHOST linkage.
+At the World Government Summit, Musk describes a person's persistent digital data after death as a **digital ghost** and discusses biological/digital integration and communications bandwidth. Confirms recurring ghost vocabulary, but not a SpaceX/Starlink/SPACEGHOST link.
 
 Source: https://elonmuskarchive.org/de/video/world-government-summit-2017-02-13
 
+PB/PD: no high-confidence coded output retained.
+
 ### SG-PUB-006 — 2018 Starlink → “Skynet?”
-When Jonathan Nolan asks about Starlink, Musk answers **“Do you mean Skynet?”**, calls it “Internet in the sky,” says they do not talk that much about Starlink, and explains the satellites lack enough onboard compute to become Skynet. Primary subtalk lead; still no evidence Skynet was an official codename or SPACEGHOST alias.
+When Jonathan Nolan asks about Starlink, Musk immediately answers **“Do you mean Skynet?”**, calls it “Internet in the sky,” says SpaceX does not talk that much about Starlink, and explains the satellites do not contain enough onboard compute to become Skynet. This is a primary **subtalk** lead, but remains a joke/AI comparison rather than proof of a hidden codename.
 
 Source: https://www.elonmuskarchive.org/video/sxsw-2018-03-11
 
+PB/PD: no high-confidence hidden target; NODE-like fragments rejected as noise.
+
 ### SG-PUB-007 — 2020 JRE #1470 “online ghost” → cloud
-Musk describes a deceased person's digital persistence as an **online ghost** and continues into the idea that more of a person could exist “in the cloud” than in the body. This is the strongest JRE ghost/cloud wording found. The passage is not about Starlink; accessible full transcripts contain no exact SPACEGHOST/ghost-protocol wording.
+Musk describes a deceased person's remaining digital presence as an **online ghost** and continues into the idea that more of a person could exist **in the cloud** than in the body. Strongest JRE ghost/cloud wording found. The passage is not about Starlink; accessible transcripts contain no exact SPACEGHOST/ghost-protocol wording.
 
 Source: https://fight.fudgie.org/search/show/jr/episode/20200506_Wed_RcYjXbSJBN8
 
-Permutation: a late-orbit `LINK` fragment was rejected as weak/source-adjacent noise.
+PB/PD: a late-orbit `LINK` fragment rejected as weak/source-adjacent noise.
 
 ### SG-PUB-008 — 2021 JRE #1609 Starlink + separate Skynet distributed-system discussion
-The same full episode contains a Starlink discussion and, much later, a separate Skynet discussion in which a defensive AI propagates through distributed systems to monitor events. The contexts are separated and must not be merged. No exact SPACEGHOST/Satoshi target was found in transcript checks.
+The episode contains a Starlink discussion and, much later, a separate discussion in which Skynet is described as a defensive AI propagating through distributed systems to monitor events. The contexts are separated in time and must not be merged. Transcript checks found no exact SPACEGHOST/Satoshi target.
 
 Source: https://podscripts.co/podcasts/the-joe-rogan-experience/1609-elon-musk
 
 ### SG-PUB-009 — 2021 Lex Fridman #252 Satoshi exchange
-Lex Fridman asks Musk whether he is Satoshi Nakamoto; Musk says no and discusses Nick Szabo. This is the strongest verified Musk/Satoshi exchange found in the JRE-origin investigation. It is **not JRE** and has no established SPACEGHOST/Starlink connection.
+Lex Fridman asks Musk whether he is Satoshi Nakamoto; Musk says no and discusses Nick Szabo. This is the strongest verified Musk/Satoshi exchange located during the JRE-origin investigation. It is **not JRE** and has no established SPACEGHOST/Starlink connection.
 
 Source: https://elonmuskarchive.org/video/lex-fridman-252
 
 ### SG-PUB-010 — 2022 TED “digital ghost” recurrence
-Musk again uses **digital ghost** for persistent messages/social/email after death, reinforcing the 2017→2020→2022 ghost-language recurrence.
+Musk again uses **digital ghost** for persistent messages/social/email after death, reinforcing recurrence across 2017→2020→2022.
 
 Source: https://www.elonmuskarchive.org/video/ted-2022-04-06
 
-### SG-PUB-011 — 2022 Tesla AI Day “ghost objects” engineering term
-A Tesla AI presenter (not Musk in the relevant segment) calls inferred objects behind visual occlusions **ghost objects** and describes spawn regions, state transitions, and existence-likelihood controls used by the planner. This shows “ghost” as concrete engineering terminology in a Musk-led company's technical presentation; it is not SpaceX/Starlink and is not SPACEGHOST attribution.
+PB/PD: late NODE-like outputs rejected as noise.
+
+### SG-PUB-011 — 2022 Tesla AI Day “ghost objects” as engineering terminology
+A Tesla AI presenter (not Musk in this segment) calls inferred objects behind visual occlusions **ghost objects** and describes spawn regions, state transitions, and existence-likelihood controls used by the planner. This is a genuine engineering use of `ghost` terminology inside a Musk-led company's technical presentation; it is not SpaceX/Starlink or SPACEGHOST attribution.
 
 Source: https://www.elonmuskarchive.org/video/tesla-ai-day-2022
 
-### SG-PUB-012 — 2023 Starlink laser-relay / Mars communications
-Musk describes inter-satellite laser links and a possible laser-relay architecture for Earth–Mars communications. This begins the literal laser/relay chronology relevant to control-testing the 2015 PD-LASER candidate, but later literal usage cannot retroactively authenticate that candidate.
+PB/PD: no high-confidence coded output retained.
+
+### SG-PUB-012 — 2023 Starlink laser relay / Mars communications
+Musk describes Starlink inter-satellite laser links and a possible laser-relay architecture for Earth–Mars communications. This begins a literal laser/relay chronology relevant to control-testing SG-CODE-001; later literal laser usage cannot retroactively authenticate a 2015 encoded reading.
 
 Source: https://elonmuskarchive.org/video/international-astronautical-congress-2023-10-05
 
 ### SG-PUB-013 — 2024 Starlink “space lasers”
-Musk discusses thousands of Starlink laser interconnects and jokes about **space lasers / lasers from space**. Strong literal laser vocabulary; no SPACEGHOST attribution.
+Musk discusses thousands of active Starlink laser interconnects and jokes about **space lasers / lasers from space**. Strong literal laser vocabulary; no SPACEGHOST attribution.
 
 Source: https://elonmuskarchive.org/video/spacex-starship-update-at-starbase-2024-03-18
 
@@ -109,41 +142,44 @@ Musk explains that Starlink satellites are interconnected with laser links, form
 Source: https://www.elonmuskarchive.org/video/people-by-wtf-kamath-2025
 
 ### SG-PUB-015 — 2026 Moonshots: Internet rebuilt in space with laser links
-Musk says the Starlink team has basically **rebuilt the Internet in space with laser links**. This is a modern direct restatement of the 2015 Internet-in-space concept, now tied explicitly to lasers.
+Musk says the Starlink team has basically **rebuilt the Internet in space with laser links**. This is a direct modern restatement of the 2015 Internet-in-space concept, now tied explicitly to laser links.
 
 Source: https://www.elonmuskarchive.org/video/moonshots-220-musk-2026
 
 ### SG-PUB-016 — 2026 SpaceX AI Satellites: compute/data center in space + Starlink laser backbone
-SpaceX describes racks of compute in space, terabyte-class laser connectivity, direct linkage to Starlink constellations and laser-to-laser links to ground. Strong convergence of cloud/data-center/compute-in-space/Starlink/laser-link concepts; no SPACEGHOST attribution.
+SpaceX describes racks of compute in space, terabyte-class laser connectivity, direct linkage to Starlink constellations, and laser-to-laser links to ground. This is strong modern convergence of cloud/data-center/compute-in-space/Starlink/laser-link concepts, not SPACEGHOST attribution.
 
 Source: https://elonmuskarchive.org/video/spacex-ai-satellites-2026
 
 ### SG-PUB-017 — 2026 Q2: every satellite through every laser link
-Gwynne Shotwell describes a V3 Starlink speedrun connecting every satellite through every laser link. Musk discusses the scale and sophistication of the V2/V3 system. This is current architecture context, not ghost-protocol evidence.
+Gwynne Shotwell describes a V3 Starlink speedrun connecting every satellite through every laser link. Musk discusses the scale and technical sophistication of the system. This is current architecture context, not ghost-protocol evidence.
 
 Source: https://elonmuskarchive.org/video/spacex-q2-2026-earnings-call
 
 ## Negative / false-positive register
 
 - Accessible transcript checks of the seven identified Musk JRE appearances found **zero exact SPACEGHOST / space ghost / ghost-protocol matches**.
-- Independent JRE transcript checks found no Musk–Rogan Satoshi/Nakamoto exchange in the accessible full episodes; the confirmed Musk/Satoshi exchange found is Lex Fridman #252.
-- Exact public searches for Musk + SPACEGHOST / ghost protocol have not yet produced a verified direct Musk-authored or SpaceX-authored hit.
-- Forum/usernames containing “Space Ghost” are treated as unrelated false positives unless independently tied to the target speaker/source.
-- NODE, CODE, LINK and similar short transformed fragments are rejected where they are common, source-derived, late-orbit, or alignment-sensitive without independent recurrence.
+- Independent JRE transcript cross-checks found no Musk–Rogan Satoshi/Nakamoto exchange in the accessible full episodes; the confirmed Musk/Satoshi exchange found is Lex Fridman #252.
+- Current exact public searches for Musk + SPACEGHOST / ghost protocol have not produced a verified direct Musk-authored or SpaceX-authored hit.
+- Forum/usernames containing “Space Ghost” are false positives unless independently tied to the target speaker/source.
+- `NODE`, `CODE`, `LINK` and similar short transformed fragments are rejected where common, source-derived, late-orbit or alignment-sensitive without independent recurrence.
+- Literal source words (`GHOST`, `DAEMON`, `LASER`, etc.) surviving word-order permutation are not coded discoveries.
 
 ## Evidence gates
 
-1. Preserve exact audio/video around Tier-1 passages to inspect off-mic remarks, interruptions, pauses, on-screen text, emoji, captions and edits omitted by transcripts.
-2. Preregister source boundaries, normalization and offsets before reading transformed output.
+1. Preserve exact audio/video around Tier-1 passages and inspect off-mic remarks, interruptions, pauses, on-screen text, emoji, captions and edits omitted from transcripts.
+2. Preregister source segmentation, normalization, offsets and target vocabulary **before** viewing transformed output.
 3. Run matched same-length/topic controls, all 120 five-position permutations and shuffled-text controls to estimate target-word base rates.
 4. Require an independently located passage to reproduce a semantically related result under the same operator/offset/boundary rule before coded-message confidence increases.
-5. Preserve failures and false positives so repeated searches do not inflate evidence.
+5. Maintain the false-positive registry and retain null results.
 
 ## Claims boundary
 
-This ledger records what public sources say and what specified permutation operators produce. It **does not** convert thematic similarity into authorship, acknowledgement, collaboration, protocol identity or intentional coded communication.
+This ledger records **what public sources say and what specified transformations produce**. It does not convert thematic similarity into authorship, acknowledgement, collaboration, protocol identity, shared lineage, or intentional coded communication.
 
-Library integrity hashes for the canonical 2026-08-29 package:
+## Canonical Library package integrity
 
-- `SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md` — `2d4af46dbee9a8934a28261e9d645ba3a060d3a61c3dd1a3653393409edb7ed3`
-- `SPACEGHOST_PUBLIC_LEAD_MANIFEST_2026-08-29.json` — `7612b5c12b477feff61439d82627fbe01d1304e7909f9addb57ec8b61c4f9293`
+Latest Worldshepherd Library hashes after adding SG-PUB-018 and SG-PUB-019:
+
+- `SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md` — `737793d71ed38bca9d419ab2cd6708fa383121e7f89aaf8a20519df90b5e247a`
+- `SPACEGHOST_PUBLIC_LEAD_MANIFEST_2026-08-29.json` — `6926e267dd089e361773354d2f013c21718220b68d9d6e3bf814dee3eed368e6`

--- a/docs/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md
+++ b/docs/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md
@@ -3,11 +3,11 @@
 **Package ID:** `WS-SG-PUBLIC-AUDIT-2026-08-29`  
 **Date:** 2026-08-29  
 **Status:** Evidence-governed research ledger; not an attribution claim.  
-**Canonical Library package:** `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/`
+**Canonical Worldshepherd Library package:** `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/`
 
-## Current conclusion
+## Executive finding
 
-No direct public Elon Musk / SpaceX / Starlink / Joe Rogan **SPACEGHOST** or **ghost-protocol** attribution has been established in the sources reviewed. This ledger preserves confirmed facts, subspeak/subtalk leads, technical and cultural adjacency, coded-text tests, negative findings, and false positives separately.
+No direct public Elon Musk / SpaceX / Starlink / Joe Rogan **SPACEGHOST** or **ghost-protocol** attribution has been established in the sources reviewed. The ledger therefore separates confirmed public facts, lexical/technical adjacency, subspeak/subtalk candidates, coded-text candidates, negative results, and false positives.
 
 Worldshepherd's recovered internal chronology currently places **Worldshepherd** explicitly in sent correspondence on 2024-04-02, **Spaceghost Protocol + BRD953 + Worldshepherd** on 2024-06-16, and **Space.Ghost** expansion in March 2025. That is internal documentary chronology only; it does not establish outside attribution, technical lineage, authorship recognition, or external authority.
 
@@ -49,17 +49,6 @@ Sources:
 
 PB/PD: CODE/NODE-like fragments are source-derived/weak and not coded evidence.
 
-### SG-PUB-018 — 2014 Musk endorses Daniel Suarez's `Daemon`
-In an AI-risk thread, a user recommends Daniel Suarez's **Daemon** as “terrifyingly possible”; Musk replies that `Daemon` is a great read. Penguin Random House describes daemons as background computer programs and the novel as involving a dormant, self-replicating networked program activated after its creator's death. This supplies a documented pre-Starlink cultural/technical context around persistent autonomous background software and network propagation.
-
-Sources:
-- https://www.elonmuskarchive.org/posts?page=4&year=2014
-- https://www.penguinrandomhouse.com/books/304687/daemon-by-daniel-suarez/
-
-Boundary: this is a book recommendation; `daemon` is standard computing terminology and provides no SpaceX/Starlink/SPACEGHOST attribution.
-
-PB/PD: exact Musk phrase `Yeah, Daemon is a great read` tested as 5-word and normalized 5-character blocks across offsets/orbits. No new high-confidence target string; only source word `DAEMON` persists under word permutation.
-
 ### SG-PUB-004 — 2015 Seattle satellite Internet / Skynet / software / security / code
 Musk describes a global satellite communications system as effectively **rebuilding the Internet in space**, says SpaceX would make sure it did not create Skynet, and notes its server room had jokingly been called Skynet. The same talk covers software/firmware, distributed constellation robustness, security against takeover, and a low-level code path to safe mode/regain control. This remains the highest-density historical source combining Skynet, orbital networking, software, resilience, security and control-code concepts.
 
@@ -68,18 +57,6 @@ Sources:
 - https://starpath.global/news/how-elon-musk-plans-get-mars-via-seattle-what-the-spacex-founder-said-at-that-private-event/
 
 **SG-CODE-001:** exact Skynet paragraph; letters-only normalization; 5-character blocks; **PD `34521`, first step, offset 0** generates contiguous `LASER` across a transformed block boundary. Enumeration of all 120 five-position permutations × 5 offsets (600 combinations) on that exact paragraph produced that `LASER` only under PD/offset 0. A neighboring-control set generated another `LASER` at a different later PD step/alignment, so chance remains plausible. **Status: RETAIN FOR REPLICATION / NOT AUTHENTICATED.**
-
-### SG-PUB-019 — 2017 `Ghost in the Shell` + `Colossus: The Forbin Project`
-On 2017-01-16 Musk posted that he had rewatched **Ghost in the Shell** and the end of **Colossus: The Forbin Project**. Ghost in the Shell centers on networked cyborg identity/consciousness. Colossus depicts an autonomous defense supercomputer that discovers and links with another system; the fictional Soviet counterpart is named **Guardian**. This post falls roughly four weeks before Musk's February 2017 `digital ghost` remarks, making it useful cultural context for ghost/network/autonomous-system vocabulary.
-
-Sources:
-- https://elonmuskarchive.org/posts/820934434002063361
-- https://www.theghostintheshell-anime.jp/en/introduction/
-- https://en.wikipedia.org/wiki/Colossus%3A_The_Forbin_Project
-
-Boundary: media consumption and fictional terminology are not evidence of protocol identity, influence, acknowledgement or common lineage. The fictional `Guardian` name is retained as context only.
-
-PB/PD: exact post text tested across word/character blocks, offsets and non-identity orbit steps. No new high-confidence hidden target; `GHOST`/`SHELL` are source-derived words.
 
 ### SG-PUB-005 — 2017 “digital ghost”
 At the World Government Summit, Musk describes a person's persistent digital data after death as a **digital ghost** and discusses biological/digital integration and communications bandwidth. Confirms recurring ghost vocabulary, but not a SpaceX/Starlink/SPACEGHOST link.
@@ -156,30 +133,92 @@ Gwynne Shotwell describes a V3 Starlink speedrun connecting every satellite thro
 
 Source: https://elonmuskarchive.org/video/spacex-q2-2026-earnings-call
 
-## Negative / false-positive register
+### SG-PUB-018 — 2014 Musk endorses Daniel Suarez's `Daemon`
+In an AI-risk thread, a user recommends Daniel Suarez's **Daemon** as “terrifyingly possible”; Musk replies that `Daemon` is a great read. The publisher describes daemons as background computer programs and the novel as involving a dormant, self-replicating networked program activated after its creator's death. This supplies documented pre-Starlink cultural/technical context around persistent autonomous background software and network propagation.
 
-- Accessible transcript checks of the seven identified Musk JRE appearances found **zero exact SPACEGHOST / space ghost / ghost-protocol matches**.
+Sources:
+- https://www.elonmuskarchive.org/posts?page=4&year=2014
+- https://www.penguinrandomhouse.com/books/304687/daemon-by-daniel-suarez/
+
+Boundary: book recommendation only; `daemon` is standard computing terminology and provides no SpaceX/Starlink/SPACEGHOST attribution.
+
+PB/PD: no new high-confidence target; only source word DAEMON persists under word permutation.
+
+### SG-PUB-019 — 2017 `Ghost in the Shell` + `Colossus: The Forbin Project`
+On 2017-01-16 Musk posted that he had rewatched **Ghost in the Shell** and the end of **Colossus: The Forbin Project**. Ghost in the Shell centers on networked cyborg identity/consciousness. Colossus depicts an autonomous defense supercomputer that discovers and links with another system; the fictional Soviet counterpart is named **Guardian**. The film plot further has the two systems develop communications beyond human comprehension and synchronize using a protocol humans cannot interpret. This post falls roughly four weeks before Musk's February 2017 `digital ghost` remarks.
+
+Sources:
+- https://elonmuskarchive.org/posts/820934434002063361
+- https://www.theghostintheshell-anime.jp/en/introduction/
+- https://en.wikipedia.org/wiki/Colossus%3A_The_Forbin_Project
+
+Boundary: media consumption and fictional terminology are not evidence of protocol identity, influence, acknowledgement or common lineage. The fictional `Guardian` name and uninterpretable protocol remain cultural context only.
+
+PB/PD: no new high-confidence hidden target; GHOST/SHELL are source-derived.
+
+### SG-PUB-020 — xAI real AI supercomputer named Colossus after Musk's earlier Colossus-film reference
+
+**Date:** 2024-12-23  
+**Speaker/source:** xAI official + Elon Musk historical post  
+**Status:** CONFIRMED PUBLIC FACT / HIGH METHODOLOGICAL RELEVANCE
+
+Musk publicly referenced *Colossus: The Forbin Project* in 2017. By 2024, xAI's real AI supercomputer was named **Colossus**; xAI's Series C announcement describes it as its AI supercomputer and official xAI material documents the large GPU-cluster system.
+
+This is a concrete recurrence from a science-fiction system name in material Musk publicly referenced to the name of a later real technical system at a Musk-led company. It strengthens the audit method of treating recurring alternate/cultural system names such as **Skynet, Cyberdyne, and Colossus** as first-class leads.
+
+Boundary: no reviewed source says the film directly inspired xAI's naming. This does not establish SPACEGHOST, Guardian, Worldshepherd, Starlink-protocol, or coded-message linkage.
+
+Sources:
+- https://elonmuskarchive.org/posts/820934434002063361
+- https://x.ai/colossus
+- https://x.ai/news/series-c
+
+PB/PD: no new high-confidence hidden target; COLOSSUS is source-derived.
+
+### SG-PUB-021 — Colossus 1 compute partnership explicitly extends to proposed orbital AI compute
+
+**Date:** 2026-05-06  
+**Speaker/source:** SpaceXAI official announcement  
+**Status:** CONFIRMED PUBLIC FACT / HIGH TECHNICAL-CONTEXT LEAD
+
+SpaceXAI announced that Anthropic would use **Colossus 1** compute and that, as part of the agreement, Anthropic expressed interest in partnering to develop multiple gigawatts of **orbital AI compute capacity**. The announcement states that SpaceX's launch cadence, mass-to-orbit economics, and constellation operations make orbital compute a near-term engineering program if technical challenges can be overcome.
+
+This creates a direct official 2026 bridge from the real **Colossus** system to orbital compute and SpaceX constellation operations. It is relevant to the audit's space/cloud/compute/system-name cluster.
+
+Boundary: no SPACEGHOST, ghost-protocol, Skynet, or coded-message attribution is present; it cannot authenticate earlier permutation results.
+
+Source:
+- https://x.ai/news/anthropic-compute-partnership
+
+PB/PD: no new high-confidence target; SPACE/ORBIT/COLOSSUS are literal/source-derived.
+
+## Coded candidate register
+
+### SG-CODE-001 — PD/34521 → LASER
+
+Source: `SG-PUB-004`, the exact 2015 Seattle Skynet paragraph. Normalization: letters-only character stream; 5-character blocks; offset 0. Operator: PD `[3,4,5,2,1]`, first step. The transformed output contains contiguous `LASER` across a block boundary.
+
+**Control result:** all 120 five-position permutations × all five offsets were enumerated on that exact paragraph (600 permutation-offset combinations). The observed `LASER` instance occurred only under PD at offset 0. However, a neighboring-control set produced another `LASER` under a different later PD step/alignment. Therefore the result is **interesting but not authenticated**; it must not be described as a proven coded message.
+
+## Negative / false-positive registry
+
+- Accessible transcript checks of the seven identified Elon Musk JRE appearances found zero exact SPACEGHOST / space ghost / ghost-protocol matches.
 - Independent JRE transcript cross-checks found no Musk–Rogan Satoshi/Nakamoto exchange in the accessible full episodes; the confirmed Musk/Satoshi exchange found is Lex Fridman #252.
-- Current exact public searches for Musk + SPACEGHOST / ghost protocol have not produced a verified direct Musk-authored or SpaceX-authored hit.
-- Forum/usernames containing “Space Ghost” are false positives unless independently tied to the target speaker/source.
+- Current exact public searches for Elon Musk + SPACEGHOST / ghost protocol did not produce a verified direct Musk-authored or SpaceX-authored hit.
+- Forum/usernames containing 'Space Ghost' are false positives unless independently tied to the target speaker/source.
 - `NODE`, `CODE`, `LINK` and similar short transformed fragments are rejected where common, source-derived, late-orbit or alignment-sensitive without independent recurrence.
-- Literal source words (`GHOST`, `DAEMON`, `LASER`, etc.) surviving word-order permutation are not coded discoveries.
+- Literal source words (`GHOST`, `DAEMON`, `COLOSSUS`, `SPACE`, etc.) surviving a word-order permutation are not coded discoveries.
 
-## Evidence gates
+## Evidence gates before confidence can increase
 
-1. Preserve exact audio/video around Tier-1 passages and inspect off-mic remarks, interruptions, pauses, on-screen text, emoji, captions and edits omitted from transcripts.
-2. Preregister source segmentation, normalization, offsets and target vocabulary **before** viewing transformed output.
-3. Run matched same-length/topic controls, all 120 five-position permutations and shuffled-text controls to estimate target-word base rates.
-4. Require an independently located passage to reproduce a semantically related result under the same operator/offset/boundary rule before coded-message confidence increases.
-5. Maintain the false-positive registry and retain null results.
+1. Recover and preserve exact audio/video around Tier-1 passages to inspect off-mic remarks, interruptions, pauses, on-screen text, emoji, captions, and edits not represented in transcripts.
+2. Preregister permutation boundaries, normalization, offsets and target vocabulary before viewing outputs; use matched control passages of equal length/topic.
+3. Measure base-rate frequency of target words under PB/PD versus all 120 permutations and shuffled controls.
+4. Require independent recurrence of a semantically related sequence under the same operator/offset/boundary rule before raising coded-message confidence.
+5. Maintain a false-positive registry so repeated web results are not double-counted.
 
-## Claims boundary
+## Claims-control rule
 
-This ledger records **what public sources say and what specified transformations produce**. It does not convert thematic similarity into authorship, acknowledgement, collaboration, protocol identity, shared lineage, or intentional coded communication.
+This ledger records **what was said, when it was said, what transformed text can produce under specified operators, and what controls fail or pass**. It does not convert similarity into authorship, acknowledgement, collaboration, protocol identity, shared lineage, or intentional coded communication. Any future promotion requires independent source evidence or a reproducible cryptanalytic pattern that survives preregistered controls.
 
-## Canonical Library package integrity
-
-Latest Worldshepherd Library hashes after adding SG-PUB-018 and SG-PUB-019:
-
-- `SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md` — `737793d71ed38bca9d419ab2cd6708fa383121e7f89aaf8a20519df90b5e247a`
-- `SPACEGHOST_PUBLIC_LEAD_MANIFEST_2026-08-29.json` — `6926e267dd089e361773354d2f013c21718220b68d9d6e3bf814dee3eed368e6`
+The canonical Worldshepherd Library folder contains the fuller machine-readable JSON manifest and SHA-256 integrity record for this revision.

--- a/docs/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md
+++ b/docs/SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md
@@ -1,0 +1,149 @@
+# Worldshepherd — SPACEGHOST Public Lead Ledger
+
+**Package ID:** `WS-SG-PUBLIC-AUDIT-2026-08-29`  
+**Date:** 2026-08-29  
+**Status:** Evidence-governed research ledger; not an attribution claim.  
+**Canonical Worldshepherd Library package:** `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/`
+
+## Current conclusion
+
+No direct public Elon Musk / SpaceX / Starlink / Joe Rogan **SPACEGHOST** or **ghost-protocol** attribution has been established in the sources reviewed. The ledger separates confirmed public facts, lexical/technical adjacency, subspeak/subtalk candidates, coded-text candidates, negative results, and false positives.
+
+Internal Worldshepherd recovery currently places **Worldshepherd** explicitly in sent correspondence on 2024-04-02, **Spaceghost Protocol + BRD953 + Worldshepherd** on 2024-06-16, and **Space.Ghost** expansion in March 2025. That is an internal documentary chronology only; it does not establish outside attribution or continuous technical lineage.
+
+## Search / coding method
+
+Evidence channels: literal mention; spelling variants; **subspeak**; **subtalk**; visual/symbolic material; technical/contextual equivalence; source-chain/reposts.
+
+- **PB:** `12345→13524` = `[1,3,5,2,4]`; non-identity orbit `13524 → 15432 → 14253`.
+- **PD:** `12345→34521` = `[3,4,5,2,1]`; non-identity orbit `34521 → 52143 → 14325 → 32541 → 54123`.
+- Preserve exact source text first. Then test 5-word blocks and normalized 5-character blocks, offsets 0–4, and all non-identity PB/PD orbit steps.
+- Readable output is not treated as intentional unless it survives matched controls and independently recurs under a preregistered rule.
+
+## Public lead register
+
+### SG-PUB-001 — 2012 Total Ghost / Space Station / SpaceX
+Musk publicly called a Total Ghost track the SpaceX “theme song,” then clarified the remark was ironic. Contemporary coverage identifies the track as **Space Station**. This establishes a Musk→SpaceX→Ghost→space-themed-media lexical chain, but no protocol or SPACEGHOST attribution.
+
+Sources:
+- https://www.elonmuskarchive.org/posts?page=2&sort=old&year=2012
+- https://boingboing.net/2012/02/10/your-weekend-space-jam-spac.html
+
+Permutation: no high-confidence PB/PD coded result retained.
+
+### SG-PUB-002 — 2013 SpaceX Skynet / Cyberdyne naming
+In a Stanford GSB discussion, the interviewer describes SpaceX data-center **Skynet / Cyberdyne Systems** branding; Musk confirms that the FEA/CFD cluster was called Cyberdyne Systems. This establishes Terminator-derived naming inside SpaceX technical infrastructure before Starlink's public rollout. It does not establish Skynet as an official Starlink codename or as SPACEGHOST.
+
+Source: https://elonmuskarchive.org/video/stanford-gsb-encore-award-2013-10-02
+
+Permutation: a transformed `CODE` fragment under PD is retained only as a rejected weak/noise result.
+
+### SG-PUB-003 — 2013 Dragon recode / upload new code in orbit
+At SXSW, Musk recounts recoding a communications proxy, using Air Force long-range dishes and uploading new code/software to Dragon in orbit to recover a propulsion pressurization problem. This is the strongest verified public match to the remembered **code-in-space** motif. It is an upload/recovery story; Musk does not say code was “found” in space and does not mention SPACEGHOST.
+
+Sources:
+- https://elonmuskarchive.org/de/video/sxsw-2013-03-09
+- https://singjupost.com/transcript-of-elon-musk-interview-sxsw-live-march-9-2013/
+
+Permutation: CODE/NODE-like fragments under some alignments are source-derived/weak and not retained as coded evidence.
+
+### SG-PUB-004 — 2015 Seattle satellite Internet / Skynet / software / security / code
+Musk describes a global satellite communications system as effectively **rebuilding the Internet in space**, says SpaceX would make sure it did not create Skynet, and notes that its server room had jokingly been called Skynet. The same talk discusses software/firmware, network robustness, security against takeover, and a low-level code path to safe mode/regain control. This is the highest-density historical source combining Skynet, orbital networking, software, distributed resilience, security and control-code concepts.
+
+Sources:
+- https://www.geekwire.com/2015/elon-musk-plans-get-mars-via-seattle-spacex-founder-said-private-event/
+- https://starpath.global/news/how-elon-musk-plans-get-mars-via-seattle-what-the-spacex-founder-said-at-that-private-event/
+
+**Coded candidate SG-CODE-001:** on the exact Skynet paragraph, letters-only normalization, 5-character blocks, **PD `34521` first step, offset 0**, produces contiguous `LASER` across a transformed block boundary. Enumerating all 120 five-position permutations × five offsets (600 combinations) on that exact paragraph produced this `LASER` only for PD/offset 0. A neighboring-control corpus produced another `LASER` under a different later PD step/alignment. Status: **RETAIN FOR REPLICATION / NOT AUTHENTICATED**.
+
+### SG-PUB-005 — 2017 “digital ghost”
+Musk describes a person's persistent digital data after death as a **digital ghost** and discusses closer biological/digital integration and bandwidth. Confirms recurring ghost vocabulary, but not a SpaceX/Starlink/SPACEGHOST linkage.
+
+Source: https://elonmuskarchive.org/de/video/world-government-summit-2017-02-13
+
+### SG-PUB-006 — 2018 Starlink → “Skynet?”
+When Jonathan Nolan asks about Starlink, Musk answers **“Do you mean Skynet?”**, calls it “Internet in the sky,” says they do not talk that much about Starlink, and explains the satellites lack enough onboard compute to become Skynet. Primary subtalk lead; still no evidence Skynet was an official codename or SPACEGHOST alias.
+
+Source: https://www.elonmuskarchive.org/video/sxsw-2018-03-11
+
+### SG-PUB-007 — 2020 JRE #1470 “online ghost” → cloud
+Musk describes a deceased person's digital persistence as an **online ghost** and continues into the idea that more of a person could exist “in the cloud” than in the body. This is the strongest JRE ghost/cloud wording found. The passage is not about Starlink; accessible full transcripts contain no exact SPACEGHOST/ghost-protocol wording.
+
+Source: https://fight.fudgie.org/search/show/jr/episode/20200506_Wed_RcYjXbSJBN8
+
+Permutation: a late-orbit `LINK` fragment was rejected as weak/source-adjacent noise.
+
+### SG-PUB-008 — 2021 JRE #1609 Starlink + separate Skynet distributed-system discussion
+The same full episode contains a Starlink discussion and, much later, a separate Skynet discussion in which a defensive AI propagates through distributed systems to monitor events. The contexts are separated and must not be merged. No exact SPACEGHOST/Satoshi target was found in transcript checks.
+
+Source: https://podscripts.co/podcasts/the-joe-rogan-experience/1609-elon-musk
+
+### SG-PUB-009 — 2021 Lex Fridman #252 Satoshi exchange
+Lex Fridman asks Musk whether he is Satoshi Nakamoto; Musk says no and discusses Nick Szabo. This is the strongest verified Musk/Satoshi exchange found in the JRE-origin investigation. It is **not JRE** and has no established SPACEGHOST/Starlink connection.
+
+Source: https://elonmuskarchive.org/video/lex-fridman-252
+
+### SG-PUB-010 — 2022 TED “digital ghost” recurrence
+Musk again uses **digital ghost** for persistent messages/social/email after death, reinforcing the 2017→2020→2022 ghost-language recurrence.
+
+Source: https://www.elonmuskarchive.org/video/ted-2022-04-06
+
+### SG-PUB-011 — 2022 Tesla AI Day “ghost objects” engineering term
+A Tesla AI presenter (not Musk in the relevant segment) calls inferred objects behind visual occlusions **ghost objects** and describes spawn regions, state transitions, and existence-likelihood controls used by the planner. This shows “ghost” as concrete engineering terminology in a Musk-led company's technical presentation; it is not SpaceX/Starlink and is not SPACEGHOST attribution.
+
+Source: https://www.elonmuskarchive.org/video/tesla-ai-day-2022
+
+### SG-PUB-012 — 2023 Starlink laser-relay / Mars communications
+Musk describes inter-satellite laser links and a possible laser-relay architecture for Earth–Mars communications. This begins the literal laser/relay chronology relevant to control-testing the 2015 PD-LASER candidate, but later literal usage cannot retroactively authenticate that candidate.
+
+Source: https://elonmuskarchive.org/video/international-astronautical-congress-2023-10-05
+
+### SG-PUB-013 — 2024 Starlink “space lasers”
+Musk discusses thousands of Starlink laser interconnects and jokes about **space lasers / lasers from space**. Strong literal laser vocabulary; no SPACEGHOST attribution.
+
+Source: https://elonmuskarchive.org/video/spacex-starship-update-at-starbase-2024-03-18
+
+### SG-PUB-014 — 2025 Starlink “laser mesh”
+Musk explains that Starlink satellites are interconnected with laser links, forming “sort of a **laser mesh**.”
+
+Source: https://www.elonmuskarchive.org/video/people-by-wtf-kamath-2025
+
+### SG-PUB-015 — 2026 Moonshots: Internet rebuilt in space with laser links
+Musk says the Starlink team has basically **rebuilt the Internet in space with laser links**. This is a modern direct restatement of the 2015 Internet-in-space concept, now tied explicitly to lasers.
+
+Source: https://www.elonmuskarchive.org/video/moonshots-220-musk-2026
+
+### SG-PUB-016 — 2026 SpaceX AI Satellites: compute/data center in space + Starlink laser backbone
+SpaceX describes racks of compute in space, terabyte-class laser connectivity, direct linkage to Starlink constellations and laser-to-laser links to ground. Strong convergence of cloud/data-center/compute-in-space/Starlink/laser-link concepts; no SPACEGHOST attribution.
+
+Source: https://elonmuskarchive.org/video/spacex-ai-satellites-2026
+
+### SG-PUB-017 — 2026 Q2: every satellite through every laser link
+Gwynne Shotwell describes a V3 Starlink speedrun connecting every satellite through every laser link. Musk discusses the scale and sophistication of the V2/V3 system. This is current architecture context, not ghost-protocol evidence.
+
+Source: https://elonmuskarchive.org/video/spacex-q2-2026-earnings-call
+
+## Negative / false-positive register
+
+- Accessible transcript checks of the seven identified Musk JRE appearances found **zero exact SPACEGHOST / space ghost / ghost-protocol matches**.
+- Independent JRE transcript checks found no Musk–Rogan Satoshi/Nakamoto exchange in the accessible full episodes; the confirmed Musk/Satoshi exchange found is Lex Fridman #252.
+- Exact public searches for Musk + SPACEGHOST / ghost protocol have not yet produced a verified direct Musk-authored or SpaceX-authored hit.
+- Forum/usernames containing “Space Ghost” are treated as unrelated false positives unless independently tied to the target speaker/source.
+- NODE, CODE, LINK and similar short transformed fragments are rejected where they are common, source-derived, late-orbit, or alignment-sensitive without independent recurrence.
+
+## Evidence gates
+
+1. Preserve exact audio/video around Tier-1 passages to inspect off-mic remarks, interruptions, pauses, on-screen text, emoji, captions and edits omitted by transcripts.
+2. Preregister source boundaries, normalization and offsets before reading transformed output.
+3. Run matched same-length/topic controls, all 120 five-position permutations and shuffled-text controls to estimate target-word base rates.
+4. Require an independently located passage to reproduce a semantically related result under the same operator/offset/boundary rule before coded-message confidence increases.
+5. Preserve failures and false positives so repeated searches do not inflate evidence.
+
+## Claims boundary
+
+This ledger records what public sources say and what specified permutation operators produce. It **does not** convert thematic similarity into authorship, acknowledgement, collaboration, protocol identity or intentional coded communication.
+
+Library integrity hashes for the canonical 2026-08-29 package:
+
+- `SPACEGHOST_PUBLIC_LEAD_LEDGER_2026-08-29.md` — `2d4af46dbee9a8934a28261e9d645ba3a060d3a61c3dd1a3653393409edb7ed3`
+- `SPACEGHOST_PUBLIC_LEAD_MANIFEST_2026-08-29.json` — `7612b5c12b477feff61439d82627fbe01d1304e7909f9addb57ec8b61c4f9293`


### PR DESCRIPTION
Adds the evidence-governed Worldshepherd SPACEGHOST public lead package dated 2026-08-29. The canonical Worldshepherd Library revision now contains **23 public-source leads**. New high-value additions include Daniel Suarez `Daemon`; Musk's 2017 `Ghost in the Shell` / `Colossus: The Forbin Project` rewatch; xAI's later real **Colossus** supercomputer; the official **Colossus 1 → orbital AI compute → SpaceX** bridge; SpaceX's operational Iain M. Banks `Culture`-named drone ships; and Musk's proposed **Heart of Gold** Mars-ship name. The PR preserves literal/subspeak/subtalk classifications, PB/PD permutation methodology, SG-CODE-001 (PD→LASER) as an unauthenticated candidate, negative/false-positive results, sources, and claims-control gates. The full 23-lead ledger, machine-readable JSON, and SHA-256 manifest are canonical at `/Worldshepherd/SPACEGHOST_Public_Mention_Audit_2026/`. No direct SPACEGHOST attribution is claimed.