### PR TITLE
Integrate WS-GEO-PROV PRE/BAE readiness package

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_geo_provenance.py
+++ b/deployments/sara_verified_local_v1/tests/test_geo_provenance.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from worldshepherd_sara.geo_provenance import (
+    BAEGeoEvidenceOverlay,
+    ChangeDetectionEvidence,
+    EnvironmentalSourceRecord,
+    GeoReviewState,
+    build_geo_prov_bundle,
+)
+
+
+def test_geo_prov_bundle_preserves_claims_boundary_and_bae_gap_map():
+    bundle = build_geo_prov_bundle(
+        software_commit="test-commit",
+        executed_utc="2026-09-01T15:00:00Z",
+        operator="pytest",
+    )
+
+    assert bundle["requirement"]["requirement_delta_id"] == "PRE-RD-2026-0020"
+    assert bundle["requirement"]["demand_class"] == "EMERGING_DEMAND"
+    assert bundle["evidence"][0]["capability_status"] == "SIMULATED_ONLY"
+    assert bundle["evidence"][0]["physical_validation_performed"] is False
+    assert bundle["geo_provenance"]["change_event"]["null_control_passed"] is True
+    assert bundle["bae_evidence_overlay"]["bae_signal_id"] == "PRE-BAE-GEOSPATIAL-PROVENANCE-019"
+    assert "independent replay" in bundle["bae_evidence_overlay"]["missing_validation"]
+    assert any("No BAE interest" in item for item in bundle["claims_boundary"])
+    assert bundle["bundle_digest"].startswith("sha256:")
+
+
+def test_environmental_source_requires_sha256_retrieval_hash():
+    with pytest.raises(ValidationError):
+        EnvironmentalSourceRecord(
+            source_id="bad-source",
+            provider="provider",
+            dataset_name="dataset",
+            dataset_type="raster",
+            dataset_version="v1",
+            spatial_resolution="30m",
+            temporal_resolution="annual",
+            coverage_area="demo",
+            license_terms="public",
+            retrieval_time_utc="2026-09-01T15:00:00Z",
+            retrieval_hash="not-a-hash",
+        )
+
+
+def test_change_detection_requires_hashes_and_human_review_rationale():
+    with pytest.raises(ValidationError):
+        ChangeDetectionEvidence(
+            event_id="event",
+            source_id="source",
+            baseline_period="t0",
+            comparison_period="t1",
+            target_geometry="polygon",
+            change_type="land-cover",
+            area_estimate="1 km2",
+            severity_score=0.5,
+            confidence_score=0.8,
+            uncertainty_reason="bounded uncertainty",
+            method="fixture",
+            configuration_hash="sha256:abc",
+            result_hash="sha256:def",
+            null_control_passed=True,
+            review_state=GeoReviewState.HUMAN_REVIEW_COMPLETED,
+        )
+
+
+def test_bae_overlay_blocks_false_validation_language():
+    with pytest.raises(ValidationError):
+        BAEGeoEvidenceOverlay(
+            bae_signal_id="bad-overlay",
+            maturity_label="BAE_VALIDATED",
+            proposed_demo="demo",
+            likely_bae_value="value",
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/geo_provenance.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/geo_provenance.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import (
+    CapabilityStatus,
+    DemandClass,
+    EvidenceGraph,
+    EvidenceGraphEdge,
+    EvidenceGraphNode,
+    EvidenceScope,
+    ForecastHorizon,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    SourceRecord,
+    SourceStatus,
+    canonical_digest,
+    compile_qualification_bundle,
+)
+
+
+class GeoReviewState(str, Enum):
+    UNREVIEWED = "UNREVIEWED"
+    HUMAN_REVIEW_REQUIRED = "HUMAN_REVIEW_REQUIRED"
+    HUMAN_REVIEW_COMPLETED = "HUMAN_REVIEW_COMPLETED"
+
+
+class EnvironmentalSourceRecord(BaseModel):
+    source_id: str = Field(min_length=1)
+    provider: str = Field(min_length=1)
+    dataset_name: str = Field(min_length=1)
+    dataset_type: str = Field(min_length=1)
+    dataset_version: str = Field(min_length=1)
+    spatial_resolution: str = Field(min_length=1)
+    temporal_resolution: str = Field(min_length=1)
+    coverage_area: str = Field(min_length=1)
+    license_terms: str = Field(min_length=1)
+    retrieval_time_utc: str = Field(min_length=1)
+    retrieval_hash: str = Field(min_length=1)
+    confidence_notes: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_hashed_retrieval(self) -> "EnvironmentalSourceRecord":
+        if not self.retrieval_hash.startswith("sha256:"):
+            raise ValueError("environmental source retrieval_hash must be sha256-prefixed")
+        return self
+
+
+class ChangeDetectionEvidence(BaseModel):
+    event_id: str = Field(min_length=1)
+    source_id: str = Field(min_length=1)
+    baseline_period: str = Field(min_length=1)
+    comparison_period: str = Field(min_length=1)
+    target_geometry: str = Field(min_length=1)
+    change_type: str = Field(min_length=1)
+    area_estimate: str = Field(min_length=1)
+    severity_score: float = Field(ge=0.0, le=1.0)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    uncertainty_reason: str = Field(min_length=1)
+    method: str = Field(min_length=1)
+    configuration_hash: str = Field(min_length=1)
+    result_hash: str = Field(min_length=1)
+    null_control_passed: bool
+    review_state: GeoReviewState = GeoReviewState.UNREVIEWED
+    human_review_rationale: str | None = None
+
+    @model_validator(mode="after")
+    def enforce_uncertainty_and_hashes(self) -> "ChangeDetectionEvidence":
+        for field_name in ("configuration_hash", "result_hash"):
+            if not getattr(self, field_name).startswith("sha256:"):
+                raise ValueError(f"{field_name} must be sha256-prefixed")
+        if self.confidence_score < 0.95 and not self.uncertainty_reason.strip():
+            raise ValueError("non-perfect confidence requires an uncertainty reason")
+        if self.review_state == GeoReviewState.HUMAN_REVIEW_COMPLETED and not self.human_review_rationale:
+            raise ValueError("completed human review requires a rationale")
+        return self
+
+
+class BAEGeoEvidenceOverlay(BaseModel):
+    bae_signal_id: str = Field(min_length=1)
+    bae_lane: list[str] = Field(default_factory=list)
+    worldshepherd_asset: list[str] = Field(default_factory=list)
+    maturity_label: str = Field(min_length=1)
+    missing_validation: list[str] = Field(default_factory=list)
+    proposed_demo: str = Field(min_length=1)
+    likely_bae_value: str = Field(min_length=1)
+    strongest_bae_pathway: list[str] = Field(default_factory=list)
+    supplier_readiness_dependency: list[str] = Field(default_factory=list)
+    claim_boundary: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def block_false_partner_claims(self) -> "BAEGeoEvidenceOverlay":
+        prohibited = ("BAE_VALIDATED", "BAE_CERTIFIED", "BAE_APPROVED", "CMMC_CERTIFIED")
+        text = " ".join(
+            [self.maturity_label, self.proposed_demo, self.likely_bae_value]
+            + self.claim_boundary
+        ).upper()
+        if any(term in text for term in prohibited):
+            raise ValueError("BAE overlay cannot assert validation, approval, certification, or adoption")
+        return self
+
+
+def build_environmental_baseline_requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id="PRE-RD-2026-0020",
+        demand_class=DemandClass.EMERGING_DEMAND,
+        source=SourceRecord(
+            title="Environmental baseline and geospatial provenance readiness",
+            agency="Worldshepherd PRE",
+            url="internal://pre/environmental-baseline-018",
+            solicitation_or_topic="WS-GEO-PROV-001",
+            source_status=SourceStatus.PRIMARY_TECHNICAL_SOURCE,
+            retrieved_utc="2026-09-01T15:00:00Z",
+        ),
+        statement=(
+            "Environmental, infrastructure, and mission-context systems need auditable "
+            "geospatial baselines, repeatable change detection, uncertainty handling, "
+            "null controls, and human-reviewed response decisions."
+        ),
+        recurrence=(
+            "Recurring across wildfire, drought, land restoration, water security, "
+            "environmental compliance, infrastructure resilience, distributed sensing, and mission planning."
+        ),
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=[
+            "SARA evidence orchestration",
+            "ECHO SENTINEL LINK provenance",
+            "PRIME SENTINEL authorization",
+            "OVERWATCH geospatial COP",
+            "autonomous sensing/control",
+            "distributed sensing",
+            "BAE mission engineering readiness",
+        ],
+        existing_capability=[
+            "bounded internal software evidence for audit/provenance workflows",
+            "claims-control separation between prediction, simulation, and validation",
+        ],
+        capability_status=[
+            CapabilityStatus.IMPLEMENTED_IN_SOFTWARE,
+            CapabilityStatus.SIMULATED_ONLY,
+            CapabilityStatus.REQUIRES_PARTNER_VALIDATION,
+        ],
+        missing_capability=[
+            "field-calibrated geospatial pipeline",
+            "independent replay by an external reviewer",
+            "signed evidence bundle",
+            "ground-truth linkage and measurement-uncertainty evidence",
+        ],
+        experiment_or_demonstration_needed=[
+            "WS-GEO-PROV-001A public-dataset replay with null control and degraded-data case"
+        ],
+        partner_needed=[
+            "geospatial analyst",
+            "environmental scientist or field-data partner",
+            "independent reviewer/lab for external replay",
+        ],
+        evidence_target=[
+            "dataset version and retrieval hash",
+            "processing configuration hash",
+            "change-detection result hash",
+            "null-control result",
+            "uncertainty reason",
+            "human review decision",
+            "SARA audit chain",
+            "sanitized BAE overlay",
+        ],
+        likely_future_programs=[
+            "DOE and national-lab environmental sensing",
+            "critical infrastructure resilience",
+            "distributed sensing and mission engineering",
+            "BAE RIVETS/ADAPT/ADAMS-style screening",
+        ],
+        claims_boundary=[
+            "Prediction schedules preparation only and never upgrades capability maturity.",
+            "This record does not establish land-restoration performance, emergency-response authority, BAE validation, DOE validation, CMMC/NIST conformity, or hardware field performance.",
+            "Internal software evidence remains INTERNAL_UNSIGNED unless a later record documents external signing or independent reproduction.",
+        ],
+    )
+
+
+def build_geo_prov_bundle(
+    *, software_commit: str, executed_utc: str, operator: str
+) -> dict[str, Any]:
+    requirement = build_environmental_baseline_requirement()
+    source = EnvironmentalSourceRecord(
+        source_id="ENV-SRC-WS-GEO-PROV-001A",
+        provider="public geospatial dataset placeholder",
+        dataset_name="bounded land/water/fire change fixture",
+        dataset_type="raster/vector/time_series",
+        dataset_version="synthetic-fixture-v1",
+        spatial_resolution="scenario-defined",
+        temporal_resolution="scenario-defined",
+        coverage_area="bounded public demonstration region",
+        license_terms="public/non-sensitive fixture for internal replay",
+        retrieval_time_utc=executed_utc,
+        retrieval_hash=canonical_digest({"fixture": "WS-GEO-PROV-001A", "version": "synthetic-fixture-v1"}),
+        confidence_notes=[
+            "Synthetic fixture proves evidence handling only.",
+            "No physical environmental performance is inferred.",
+        ],
+    )
+    change = ChangeDetectionEvidence(
+        event_id="ENV-CHANGE-WS-GEO-PROV-001A",
+        source_id=source.source_id,
+        baseline_period="baseline-window-synthetic",
+        comparison_period="comparison-window-synthetic",
+        target_geometry="POLYGON_PLACEHOLDER_PUBLIC_REGION",
+        change_type="land_water_fire_context_change",
+        area_estimate="scenario-defined",
+        severity_score=0.5,
+        confidence_score=0.82,
+        uncertainty_reason="Synthetic replay includes degraded-data and source-disagreement controls.",
+        method="deterministic fixture evaluation with null-control and human-review gate",
+        configuration_hash=canonical_digest({"method": "WS-GEO-PROV-001A", "null_control": True}),
+        result_hash=canonical_digest({"event": "ENV-CHANGE-WS-GEO-PROV-001A", "result": "PASS"}),
+        null_control_passed=True,
+        review_state=GeoReviewState.HUMAN_REVIEW_COMPLETED,
+        human_review_rationale="Accepted for internal evidence-chain demonstration only.",
+    )
+    bae_overlay = BAEGeoEvidenceOverlay(
+        bae_signal_id="PRE-BAE-GEOSPATIAL-PROVENANCE-019",
+        bae_lane=[
+            "C5ISR",
+            "distributed sensing",
+            "mission engineering",
+            "digital engineering",
+            "resilient infrastructure",
+        ],
+        worldshepherd_asset=["SARA", "ECHO SENTINEL LINK", "PRIME SENTINEL", "OVERWATCH"],
+        maturity_label="INTERNAL SOFTWARE EVIDENCE / DESIGN-SPEC READY / REQUIRES EXTERNAL VALIDATION",
+        missing_validation=[
+            "independent replay",
+            "signed evidence bundle",
+            "field-calibrated data",
+            "BAE-specific integration test",
+            "CMMC/NIST/DFARS control evidence",
+        ],
+        proposed_demo=(
+            "Mission-context environmental disruption scenario with degraded data, source disagreement, "
+            "human review, replay manifest, and sanitized evidence bundle."
+        ),
+        likely_bae_value=(
+            "Demonstrates provenance discipline for heterogeneous sensing and uncertain mission-state evidence "
+            "without claiming BAE adoption or operational validation."
+        ),
+        strongest_bae_pathway=["RIVETS", "ADAPT/ADAMS", "Virtual Proving Ground-style plugfest", "Mission Advantage screening"],
+        supplier_readiness_dependency=[
+            "SBOM/build provenance",
+            "threat model",
+            "CUI/CDI boundary statement",
+            "NIST SP 800-171/CMMC/DFARS gap map",
+            "data-rights/IP markings",
+        ],
+        claim_boundary=[
+            "No BAE interest, adoption, endorsement, certification, classified access, or partnership is inferred.",
+            "No supplier cybersecurity conformity is claimed without documentary evidence.",
+        ],
+    )
+    evidence = QualificationEvidenceRecord(
+        qualification_id="WS-QE-2026-0020",
+        requirement_id=requirement.requirement_delta_id,
+        test_id="WS-GEO-PROV-001A",
+        evidence_scope=EvidenceScope.SIMULATION,
+        capability_status=CapabilityStatus.SIMULATED_ONLY,
+        environment_digest=canonical_digest({"execution_context": "geo_provenance_bundle", "operator": operator}),
+        configuration_digest=change.configuration_hash,
+        inputs=[source.model_dump(mode="json")],
+        outputs=[change.model_dump(mode="json"), bae_overlay.model_dump(mode="json")],
+        metrics=[
+            {"name": "null_control_passed", "value": change.null_control_passed},
+            {"name": "confidence_score", "value": change.confidence_score},
+        ],
+        uncertainty=[{"reason": change.uncertainty_reason, "scope": "synthetic_replay"}],
+        result=ResultStatus.PASS,
+        rationale="Synthetic replay record satisfies schema/provenance gates only.",
+        negative_evidence=[
+            {"case": "field_validation", "result": "NOT_PERFORMED"},
+            {"case": "external_reproduction", "result": "NOT_PERFORMED"},
+            {"case": "BAE_validation", "result": "NOT_PERFORMED"},
+        ],
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+        physical_validation_performed=False,
+    )
+    graph = EvidenceGraph(
+        graph_id="WS-GEO-PROV-001A-GRAPH",
+        nodes=[
+            EvidenceGraphNode(node_id="source", node_type="dataset", label=source.dataset_name, confidence=0.82),
+            EvidenceGraphNode(node_id="change", node_type="change_event", label=change.change_type, confidence=0.82),
+            EvidenceGraphNode(node_id="review", node_type="human_review", label=change.review_state.value, confidence=1.0),
+            EvidenceGraphNode(node_id="bae", node_type="partner_readiness_overlay", label=bae_overlay.bae_signal_id, confidence=0.6),
+        ],
+        edges=[
+            EvidenceGraphEdge(edge_id="e1", source_node_id="source", target_node_id="change", relation="feeds"),
+            EvidenceGraphEdge(edge_id="e2", source_node_id="change", target_node_id="review", relation="requires_human_review"),
+            EvidenceGraphEdge(edge_id="e3", source_node_id="review", target_node_id="bae", relation="sanitized_for_screening_overlay"),
+        ],
+    )
+    bundle = compile_qualification_bundle(requirement, [evidence], graph)
+    bundle["geo_provenance"] = {
+        "environmental_source": source.model_dump(mode="json"),
+        "change_event": change.model_dump(mode="json"),
+    }
+    bundle["bae_evidence_overlay"] = bae_overlay.model_dump(mode="json")
+    bundle["claims_boundary"].extend(bae_overlay.claim_boundary)
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle

--- a/docs/WS_GEO_PROV_BAE_SCREENING_BUNDLE_INDEX_2026-09-01.md
+++ b/docs/WS_GEO_PROV_BAE_SCREENING_BUNDLE_INDEX_2026-09-01.md
@@ -1,0 +1,75 @@
+# WS-GEO-PROV / BAE Screening Bundle Index — 2026-09-01
+
+Status: `BUNDLE DESIGN / NOT BAE VALIDATED / NOT EXTERNALLY REPRODUCED`
+
+## Bundle purpose
+
+Create a non-confidential, partner-screening-safe package for the `WS-GEO-PROV-001A` geospatial provenance demonstrator.
+
+The bundle frames environmental/geospatial data as a mission-context evidence problem:
+
+```text
+source dataset -> source hash -> baseline -> comparison -> change event -> uncertainty -> null control -> human review -> audit chain -> replay -> BAE overlay
+```
+
+## Required bundle files
+
+```text
+WS-BAE-GEO-PROV-BUNDLE-001/
+├── README.md
+├── claims-boundary.md
+├── executive-summary-nonconfidential.md
+├── manifest.json
+├── dataset-register.json
+├── run-config.json
+├── evidence-index.json
+├── audit-chain.jsonl
+├── null-control-report.md
+├── uncertainty-report.md
+├── replay-instructions.md
+├── interface-control-description.md
+├── overwatch-layer-mockup.md
+├── threat-model.md
+├── sbom-or-sbom-placeholder.json
+├── build-provenance.md
+├── nist-cmmc-dfars-gap-map.md
+├── data-rights-and-ip-markings.md
+└── external-validation-route.md
+```
+
+## Supplier/compliance gap map
+
+This bundle must retain the following gates as gaps unless documentary evidence exists:
+
+| Gate | Current status |
+|---|---|
+| SAM/CAGE status | Not asserted by this module |
+| Small-business status | Not asserted by this module |
+| CUI/CDI boundary | Must state no CUI/classified data used unless explicitly authorized |
+| DFARS 252.204-7012 | Potential flowdown only; no compliance claim |
+| CMMC 2.0 | Not certified by this module |
+| NIST SP 800-171 | Not conformant by this module |
+| SBOM/dependency provenance | Required before screening-ready bundle |
+| Secure build/release evidence | Required before screening-ready bundle |
+| Incident response | Required organizational artifact, not provided here |
+| Secrets management | Required organizational artifact, not provided here |
+| Data rights/IP markings | Required for all non-confidential external sharing |
+| Export-control screening | Required before external technical transfer |
+| Quality program | Required for hardware/platform claims; not established here |
+| Facility/personnel clearance | Not asserted |
+
+## BAE pathway alignment
+
+| BAE pathway | Relevance |
+|---|---|
+| Mission Advantage | C5ISR, AI/ML, cyber, digital engineering, modeling/simulation, radar/mission-system screening angle |
+| FAST Labs Technology Scouting | Relevant only if novel autonomy, AI/ML, EO/IR/RF, microelectronics, or multimodal sensing is added |
+| RIVETS | Best fit for third-party software/sensor/subsystem integration evidence |
+| Combat Mission Systems Virtual Proving Ground / plugfest | Synthetic interoperability and scenario replay target |
+| ADAPT / ADAMS | MBSE, configuration custody, traceability, synthetic environments, and digital baseline discipline |
+| Platforms & Services | Infrastructure resilience and platform environmental-context evidence |
+| Space & Mission Systems | Possible remote-sensing provenance angle; speculative until a specific opportunity appears |
+
+## Release condition
+
+The bundle cannot be represented as externally validated until an independent reviewer can reproduce the same manifest, audit chain, outputs, failure cases, and claims boundary from the provided materials.

--- a/docs/WS_GEO_PROV_PRE_BAE_INTEGRATION_2026-09-01.md
+++ b/docs/WS_GEO_PROV_PRE_BAE_INTEGRATION_2026-09-01.md
@@ -1,0 +1,101 @@
+# Worldshepherd Geospatial Provenance PRE/BAE Integration — 2026-09-01
+
+Status: `INTERNAL DESIGN / SIMULATED SOFTWARE EVIDENCE ONLY / REQUIRES EXTERNAL VALIDATION`
+
+This document binds the environmental-resilience intake/design workstream into the Worldshepherd/SARA project without promoting any unvalidated capability claim.
+
+## Integration target
+
+`WS-GEO-PROV-001A` is a synthetic replay package for environmental/geospatial evidence handling. Its purpose is to demonstrate:
+
+1. dataset registration and hash-based provenance;
+2. baseline/comparison period tracking;
+3. change-detection event representation;
+4. null-control retention;
+5. uncertainty labeling;
+6. human-review gating;
+7. BAE-facing screening overlay with explicit non-validation boundary.
+
+It is not a restoration claim, emergency-response claim, BAE validation claim, DOE validation claim, CMMC/NIST conformity claim, or hardware field-performance claim.
+
+## PRE records
+
+| Record | Class | Purpose |
+|---|---:|---|
+| `PRE-ENVIRONMENTAL-BASELINE-018` | `EMERGING DEMAND` | Prepare for auditable geospatial baselines, uncertainty, null controls, and human-reviewed response decisions. |
+| `PRE-BAE-GEOSPATIAL-PROVENANCE-019` | `WORLDSHEPHERD FORECAST` | Package geospatial/environmental state as mission-context provenance for BAE screening, not as partnership evidence. |
+| `PRE-RD-2026-0020` | `EMERGING_DEMAND` | Code-level Requirement Delta identifier used by `worldshepherd_sara.geo_provenance`. |
+
+`PRE-RD-2026-0020` is intentionally used in code to avoid collision with existing PRE compiler IDs already present in the repository.
+
+## Worldshepherd asset mapping
+
+| Asset | Role |
+|---|---|
+| SARA | Orchestrates intake, evidence records, reviewer disposition, and audit chain. |
+| ECHO SENTINEL LINK | Preserves dataset, sensor, imagery, configuration, and result provenance. |
+| PRIME SENTINEL | Blocks consequential escalation until policy and human-review gates pass. |
+| OVERWATCH | Displays map layers, uncertainty, null controls, source status, and review state. |
+| Autonomous sensing/control | Alerting and monitoring only; no unsupervised field action. |
+| Software/database workflows | Stores source records, change events, evidence graphs, BAE overlays, and replay manifests. |
+| DOE/national-lab pathways | Potential external validation and environmental/resilience research alignment. |
+| BAE campaign | Mission-state provenance angle for distributed sensing, C5ISR, digital engineering, and resilient infrastructure. |
+
+## BAE evidence map
+
+| Field | Value |
+|---|---|
+| BAE lane | C5ISR, distributed sensing, mission engineering, digital engineering, resilient infrastructure |
+| Worldshepherd asset | SARA + ECHO + PRIME + OVERWATCH |
+| Current maturity | Internal software/design evidence; synthetic replay only |
+| Missing validation | Independent replay, signed bundle, field-calibrated data, BAE-specific integration test, supplier-compliance evidence |
+| Proposed demo | Environmental disruption scenario with degraded data, source disagreement, human review, replay manifest, and sanitized evidence bundle |
+| Likely value | Shows evidence discipline for heterogeneous sensing and uncertain mission-state data |
+| Strongest BAE path | RIVETS, ADAPT/ADAMS, Virtual Proving Ground-style plugfest, Mission Advantage screening |
+
+## Acceptance gates
+
+`BAE_SCREENING_READY_DESIGN` requires:
+
+- `claims-boundary.md` or equivalent claims-boundary section;
+- replay manifest or deterministic synthetic fixture;
+- audit/event chain with source/configuration/result hashes;
+- interface assumptions;
+- null-control and uncertainty reporting;
+- threat model;
+- SBOM/build-provenance plan;
+- NIST/CMMC/DFARS gap map;
+- external validation route.
+
+Blocked claims:
+
+- `BAE_VALIDATED`
+- `BAE_INTEREST_CONFIRMED`
+- `CMMC_CERTIFIED`
+- `NIST_800_171_CONFORMANT`
+- `HARDWARE_FIELD_VALIDATED`
+- `DOE_VALIDATED`
+- `FIELD_RESTORATION_PERFORMANCE_PROVEN`
+
+## Code artifact
+
+The module `worldshepherd_sara.geo_provenance` provides:
+
+- `EnvironmentalSourceRecord`
+- `ChangeDetectionEvidence`
+- `BAEGeoEvidenceOverlay`
+- `build_environmental_baseline_requirement()`
+- `build_geo_prov_bundle()`
+
+The pytest file `tests/test_geo_provenance.py` verifies:
+
+- PRE demand class and synthetic capability status;
+- null-control preservation;
+- BAE missing-validation map;
+- SHA-256 provenance requirements;
+- human-review rationale enforcement;
+- rejection of false BAE validation language.
+
+## Claims boundary
+
+The package is designed to strengthen Worldshepherd partner-readiness discipline. It does not establish external reproduction, BAE adoption, government acceptance, operational suitability, classified access, CMMC/NIST conformity, or environmental field performance.


### PR DESCRIPTION
## Summary

Integrates the WS-GEO-PROV environmental/geospatial provenance design into the Worldshepherd/SARA project as a code-addressable and test-covered package.

## Added

- `worldshepherd_sara.geo_provenance` module
  - Environmental source record
  - Change-detection evidence record
  - BAE evidence overlay
  - PRE requirement builder
  - Synthetic `WS-GEO-PROV-001A` qualification bundle builder
- Pytest coverage for:
  - claims-boundary preservation
  - BAE non-validation language guard
  - SHA-256 provenance requirements
  - human-review rationale enforcement
- Project docs:
  - `WS_GEO_PROV_PRE_BAE_INTEGRATION_2026-09-01.md`
  - `WS_GEO_PROV_BAE_SCREENING_BUNDLE_INDEX_2026-09-01.md`

## Claims boundary

This PR does **not** claim land-restoration performance, emergency-response authority, BAE validation, DOE validation, CMMC/NIST conformity, external reproduction, hardware field validation, classified access, or partner adoption.

The package is intended to move the workstream from prose-only design into an auditable, testable, partner-screening-safe Worldshepherd artifact.

## Current maturity

`INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION`