### PR TITLE
Emit WS-GEO-PROV from PRE full-bloom compiler

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_pre_bloom_cli.py
@@ -19,7 +19,7 @@ def test_full_bloom_compiler_emits_cross_domain_evidence_readiness_horizons_and_
     )
     expected_bundles = {
         "apnt", "mbse", "ietm", "ade", "mission", "fusion", "rf", "cbm",
-        "manufacturing", "ddil", "edge", "ddil_rejoin",
+        "manufacturing", "ddil", "edge", "ddil_rejoin", "geo_prov",
     }
     assert expected_bundles.issubset(index["bundle_digests"])
     assert all(not failures for failures in index["failures"].values())
@@ -27,6 +27,18 @@ def test_full_bloom_compiler_emits_cross_domain_evidence_readiness_horizons_and_
     assert (out / "capability_readiness_ledger.json").is_file()
     assert (out / "capability_horizons.json").is_file()
     assert (out / "software_provenance.json").is_file()
+    assert (out / "geo_prov_qualification_bundle.json").is_file()
+
+    geo = json.loads((out / "geo_prov_qualification_bundle.json").read_text())
+    assert geo["requirement"]["requirement_delta_id"] == "PRE-RD-2026-0020"
+    assert geo["evidence"][0]["test_id"] == "WS-GEO-PROV-001A"
+    assert geo["evidence"][0]["evidence_scope"] == "SIMULATION"
+    assert geo["evidence"][0]["capability_status"] == "SIMULATED_ONLY"
+    assert geo["geo_provenance"]["change_event"]["null_control_passed"] is True
+    assert "BAE_validation" in geo["evidence"][0]["negative_evidence"][2]["case"]
+    assert any("No BAE interest" in item for item in geo["claims_boundary"])
+    assert "geo_prov" in index["bundle_digests"]
+    assert "geo_provenance_replay_bundle" in index["bloom_extensions"]
 
     provenance = json.loads((out / "software_provenance.json").read_text())
     assert provenance["attestation_state"] == "INTERNAL_UNSIGNED"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
@@ -12,6 +12,7 @@ from typing import Any
 from .ddil_rejoin_qualification import qualify_partition_rejoin
 from .edge_qualification import qualify_host_callable
 from .evidence_store import EvidenceStore
+from .geo_provenance import build_geo_prov_bundle
 from .pre_cli import build_all
 from .pre_portfolio import build_horizon_portfolio, build_readiness_ledger
 from .qualification import (
@@ -166,9 +167,14 @@ def build_bloom(
         executed_utc=executed_utc,
         operator=operator,
     )
+    geo_prov = build_geo_prov_bundle(
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
 
     store = EvidenceStore(out / "echo_store")
-    for name, bundle in {"edge": edge, "ddil_rejoin": rejoin}.items():
+    for name, bundle in {"edge": edge, "ddil_rejoin": rejoin, "geo_prov": geo_prov}.items():
         _write(out / f"{name}_qualification_bundle.json", bundle)
         index["bundle_digests"][name] = bundle["bundle_digest"]
         index["custody_digests"][name] = store.put_bundle(bundle)
@@ -225,6 +231,7 @@ def build_bloom(
     index["bloom_extensions"] = [
         "edge_host_benchmark",
         "ddil_partition_rejoin",
+        "geo_provenance_replay_bundle",
         "capability_readiness_ledger",
         "0-90D_3-12M_12-24M_PLUS_horizons",
         "internal_unsigned_software_provenance",
@@ -234,6 +241,7 @@ def build_bloom(
         [
             "Edge benchmark metrics are host/runtime specific and do not establish target-device performance.",
             "DDIL rejoin evidence validates a synthetic conflict policy, not distributed consensus or operational network resilience.",
+            "Geo provenance evidence validates a synthetic replay/evidence-chain workflow only; it does not establish land-restoration performance, emergency-response authority, BAE validation, DOE validation, CMMC/NIST conformity, or hardware field performance.",
             "Capability horizons schedule preparation only and never upgrade readiness claims.",
             "Software provenance is INTERNAL_UNSIGNED unless a later attestation explicitly records signing/verification evidence.",
             "Pinned versions and base-image digests improve repeatability but do not constitute a hermetic or independently verified software supply chain.",

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_bloom_cli.py
@@ -175,6 +175,8 @@ def build_bloom(
 
     store = EvidenceStore(out / "echo_store")
     for name, bundle in {"edge": edge, "ddil_rejoin": rejoin, "geo_prov": geo_prov}.items():
+        bundle.pop("bundle_digest", None)
+        bundle["bundle_digest"] = canonical_digest(bundle)
         _write(out / f"{name}_qualification_bundle.json", bundle)
         index["bundle_digests"][name] = bundle["bundle_digest"]
         index["custody_digests"][name] = store.put_bundle(bundle)

--- a/docs/WS_GEO_PROV_FULL_BLOOM_OUTPUT_2026-09-01.md
+++ b/docs/WS_GEO_PROV_FULL_BLOOM_OUTPUT_2026-09-01.md
@@ -1,0 +1,84 @@
+# WS-GEO-PROV full-bloom output gate — 2026-09-01
+
+Status: `INTEGRATION_TARGET / CI_REQUIRED`
+
+This document records the second integration step for the Worldshepherd environmental/geospatial provenance lane. The prior PR made `worldshepherd_sara.geo_provenance` code-addressable. This step wires that module into the PRE full-bloom evidence compiler so the CI evidence build emits a concrete qualification bundle.
+
+## Output artifact
+
+`ws-pre-bloom` now emits:
+
+```text
+geo_prov_qualification_bundle.json
+```
+
+The bundle is added to:
+
+- `qualification_index.json` under `bundle_digests.geo_prov`
+- ECHO evidence custody storage
+- custody verification
+- the capability readiness ledger input set
+- `bloom_extensions` as `geo_provenance_replay_bundle`
+
+## Claims boundary
+
+This output remains bounded to:
+
+```text
+INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION
+```
+
+It does not claim:
+
+- land-restoration performance
+- emergency-response authority
+- BAE validation, approval, endorsement, certification, or adoption
+- DOE validation
+- CMMC/NIST conformity
+- hardware/platform performance
+- external reproduction
+- classified access or supplier approval
+
+## PRE record
+
+Primary generated requirement:
+
+```text
+PRE-RD-2026-0020 — environmental baseline and geospatial provenance readiness
+```
+
+Generated test:
+
+```text
+WS-GEO-PROV-001A
+```
+
+Generated evidence status:
+
+```text
+Evidence scope: SIMULATION
+Capability status: SIMULATED_ONLY
+Negative evidence retained: field validation / external reproduction / BAE validation NOT_PERFORMED
+```
+
+## BAE readiness value
+
+The output supports a BAE-screening-safe proposition only:
+
+> Worldshepherd can package heterogeneous geospatial/environmental evidence as a replayable, claims-controlled mission-context provenance bundle.
+
+The strongest BAE pathway remains RIVETS / ADAPT-ADAMS / Virtual Proving Ground-style plugfest / Mission Advantage screening, subject to independent validation and supplier-readiness work.
+
+## CI verification target
+
+The full gate must pass before this step is treated as merged evidence infrastructure:
+
+- pinned dependency installation
+- operations policy validation
+- package compile
+- unit/API tests
+- PRE full-bloom evidence compilation
+- deployment verifier
+- destructive backup/restore
+- operational snapshot
+- observable release identity


### PR DESCRIPTION
## Summary

Supersedes PR #34 after CI correctly caught a digest-finalization problem. This corrected PR wires `worldshepherd_sara.geo_provenance` into the PRE full-bloom compiler and finalizes all bundle digests immediately before file output and ECHO custody storage.

## Added/changed

- Imports `build_geo_prov_bundle` into `pre_bloom_cli.py`.
- Emits `geo_prov_qualification_bundle.json` during `ws-pre-bloom` generation.
- Adds the geo bundle digest to `qualification_index.json` and ECHO custody verification.
- Adds `geo_provenance_replay_bundle` to `bloom_extensions`.
- Recomputes each full-bloom bundle digest from the final payload immediately before writing and `EvidenceStore.put_bundle()`.
- Extends full-bloom pytest coverage to verify:
  - `PRE-RD-2026-0020`
  - `WS-GEO-PROV-001A`
  - `SIMULATION` evidence scope
  - `SIMULATED_ONLY` capability status
  - null-control preservation
  - BAE validation retained as negative evidence
  - no false BAE validation claim
- Adds a project doc recording the full-bloom output gate.

## Failure corrected

Run 605 failed because the geo bundle was mutated after its original digest was computed. The correction is intentionally fail-closed: stale digests are stripped and recomputed only from the final bundle payload before storage.

## Claims boundary

This PR does **not** claim land-restoration performance, emergency-response authority, BAE validation, DOE validation, CMMC/NIST conformity, external reproduction, hardware/platform performance, classified access, supplier approval, or partner adoption.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION`