### PR TITLE
Add BAE GEO screening package CLI

### DIFF
--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -22,6 +22,7 @@ test = [
 
 [project.scripts]
 ws-pre-bloom = "worldshepherd_sara.pre_bloom_cli:main"
+ws-bae-geo-screening = "worldshepherd_sara.bae_geo_screening_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_bae_geo_screening_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_bae_geo_screening_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+from worldshepherd_sara.bae_geo_screening_cli import REQUIRED_OUTPUTS, export_screening_package
+from worldshepherd_sara.geo_provenance import build_geo_prov_bundle
+
+
+def test_bae_geo_screening_export_writes_sanitized_partner_package(tmp_path):
+    bundle = build_geo_prov_bundle(
+        software_commit="test-commit",
+        executed_utc="2026-09-01T16:00:00Z",
+        operator="pytest",
+    )
+    manifest = export_screening_package(bundle, tmp_path)
+
+    for filename in REQUIRED_OUTPUTS:
+        assert (tmp_path / filename).is_file(), filename
+
+    assert manifest["schema"] == "WS-BAE-GEO-SCREENING-MANIFEST-V1"
+    assert manifest["package_id"] == "WS-BAE-GEO-SCREENING-BUNDLE-001"
+    assert manifest["source_bundle_digest"] == bundle["bundle_digest"]
+    assert sorted(manifest["output_files"]) == sorted(REQUIRED_OUTPUTS - {"manifest.json"})
+    assert set(manifest["artifact_digests"]) == REQUIRED_OUTPUTS
+    assert all(value.startswith("sha256:") for value in manifest["artifact_digests"].values())
+
+    summary = json.loads((tmp_path / "qualification-summary.json").read_text())
+    assert summary["requirement_delta_id"] == "PRE-RD-2026-0020"
+    assert summary["test_id"] == "WS-GEO-PROV-001A"
+    assert summary["evidence_scope"] == "SIMULATION"
+    assert summary["capability_status"] == "SIMULATED_ONLY"
+    assert any(item["case"] == "BAE_validation" and item["result"] == "NOT_PERFORMED" for item in summary["negative_evidence_retained"])
+    assert "RIVETS" in summary["strongest_bae_pathway"]
+
+    overlay = json.loads((tmp_path / "bae-evidence-overlay.json").read_text())
+    assert overlay["schema"] == "WS-BAE-GEO-EVIDENCE-OVERLAY-V1"
+    assert "C5ISR" in overlay["overlay"]["bae_lane"]
+    assert "SARA" in overlay["overlay"]["worldshepherd_asset"]
+
+    package_text = "\n".join(path.read_text() for path in tmp_path.iterdir() if path.is_file())
+    assert "Current maturity remains" in package_text
+    assert "does not establish" in package_text
+    assert "BAE Systems interest" in package_text
+    assert "CMMC conformity" in package_text
+    assert "NIST SP 800-171" in package_text
+    assert "FIELD_VALIDATED" not in package_text
+    assert "SUPPLIER_APPROVED" not in package_text
+
+
+def test_bae_geo_screening_export_rejects_missing_claim_boundary(tmp_path):
+    bundle = build_geo_prov_bundle(
+        software_commit="test-commit",
+        executed_utc="2026-09-01T16:00:00Z",
+        operator="pytest",
+    )
+    bundle["claims_boundary"] = []
+
+    try:
+        export_screening_package(bundle, tmp_path)
+    except ValueError as exc:
+        assert "missing required claims-boundary" in str(exc)
+    else:  # pragma: no cover - explicit failure clarity
+        raise AssertionError("expected missing claims-boundary rejection")

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/bae_geo_screening_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/bae_geo_screening_cli.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .geo_provenance import build_geo_prov_bundle
+from .qualification import canonical_digest
+
+REQUIRED_OUTPUTS = {
+    "manifest.json",
+    "qualification-summary.json",
+    "bae-evidence-overlay.json",
+    "claims-boundary.md",
+    "interface-control-description.md",
+    "threat-model.md",
+    "nist-cmmc-dfars-gap-map.md",
+    "data-rights-ip-markings.md",
+    "external-validation-route.md",
+    "replay-instructions.md",
+}
+
+PROHIBITED_ASSERTIONS = (
+    "BAE_VALIDATED",
+    "BAE_CERTIFIED",
+    "BAE_APPROVED",
+    "BAE_ADOPTED",
+    "CMMC_CERTIFIED",
+    "NIST_800_171_CONFORMANT",
+    "SUPPLIER_APPROVED",
+    "CLASSIFIED_ACCESS_GRANTED",
+)
+
+
+def _json_text(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(_json_text(value), encoding="utf-8")
+
+
+def _write_text(path: Path, value: str) -> None:
+    path.write_text(value.rstrip() + "\n", encoding="utf-8")
+
+
+def _file_digest(path: Path) -> str:
+    return canonical_digest({"path": path.name, "content": path.read_text(encoding="utf-8")})
+
+
+def _assert_sanitized_text(text: str) -> None:
+    upper = text.upper()
+    for assertion in PROHIBITED_ASSERTIONS:
+        if assertion in upper:
+            raise ValueError(f"screening package contains prohibited assertion: {assertion}")
+
+
+def _assert_bundle_claims_boundary(bundle: dict[str, Any]) -> None:
+    boundary = "\n".join(str(item) for item in bundle.get("claims_boundary", []))
+    required_fragments = [
+        "No BAE interest",
+        "No supplier cybersecurity conformity",
+    ]
+    for fragment in required_fragments:
+        if fragment not in boundary:
+            raise ValueError(f"missing required claims-boundary fragment: {fragment}")
+
+
+def build_screening_package(bundle: dict[str, Any]) -> dict[str, str | dict[str, Any]]:
+    """Create non-confidential BAE screening package artifacts from a GEO bundle.
+
+    The output is intentionally a screening package, not a proposal, certification,
+    endorsement record, operational validation, or evidence of BAE interest.
+    """
+    _assert_bundle_claims_boundary(bundle)
+    overlay = bundle.get("bae_evidence_overlay")
+    if not isinstance(overlay, dict):
+        raise ValueError("geo qualification bundle missing bae_evidence_overlay")
+    evidence = bundle.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        raise ValueError("geo qualification bundle missing evidence records")
+
+    source_digest = bundle.get("bundle_digest") or canonical_digest(bundle)
+    summary = {
+        "schema": "WS-BAE-GEO-SCREENING-SUMMARY-V1",
+        "source_bundle_digest": source_digest,
+        "requirement_delta_id": bundle["requirement"]["requirement_delta_id"],
+        "test_id": evidence[0]["test_id"],
+        "evidence_scope": evidence[0]["evidence_scope"],
+        "capability_status": evidence[0]["capability_status"],
+        "current_maturity": "INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION",
+        "negative_evidence_retained": evidence[0].get("negative_evidence", []),
+        "bae_lane": overlay.get("bae_lane", []),
+        "worldshepherd_asset": overlay.get("worldshepherd_asset", []),
+        "missing_validation": overlay.get("missing_validation", []),
+        "strongest_bae_pathway": overlay.get("strongest_bae_pathway", []),
+        "claim_boundary": bundle.get("claims_boundary", []),
+    }
+    artifacts: dict[str, str | dict[str, Any]] = {
+        "qualification-summary.json": summary,
+        "bae-evidence-overlay.json": {
+            "schema": "WS-BAE-GEO-EVIDENCE-OVERLAY-V1",
+            "source_bundle_digest": source_digest,
+            "overlay": overlay,
+            "claim_boundary": [
+                "The overlay is a screening/readiness artifact only.",
+                "It does not evidence BAE interest, endorsement, adoption, validation, certification, classified access, supplier approval, or cybersecurity conformity.",
+            ],
+        },
+        "claims-boundary.md": """
+# WS-BAE-GEO Screening Claims Boundary
+
+This package is a non-confidential screening/readiness artifact derived from the `WS-GEO-PROV-001A` simulated qualification bundle.
+
+It may support discussion of a mission-context provenance pattern for heterogeneous environmental/geospatial evidence, degraded data, source disagreement, null controls, and human-reviewed decisions.
+
+It does not establish:
+
+- BAE Systems interest, endorsement, adoption, partnership, certification, approval, supplier approval, or classified access;
+- DOE validation, national-lab validation, independent reproduction, or external acceptance;
+- land-restoration performance, emergency-response authority, field-calibrated sensor performance, or hardware/platform performance;
+- CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, CUI/CDI handling authorization, or export-control clearance.
+
+Current maturity remains: `INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION`.
+""",
+        "interface-control-description.md": """
+# Interface Control Description — WS-BAE-GEO-SCREENING-ICD-001
+
+## Inputs
+
+- `geospatial_dataset`: raster, vector, or time-series evidence with provider, dataset version, timestamp, spatial resolution, license/use terms, and retrieval hash.
+- `local_sensor_or_ground_truth`: optional evidence with collector, time, location, collection method, confidence, and chain-of-custody note.
+
+## Outputs
+
+- `baseline_record`
+- `change_event`
+- `uncertainty_record`
+- `null_control_record`
+- `human_review_record`
+- `audit_event`
+- `bae_evidence_overlay`
+
+## Timing assumptions
+
+Batch replay only. Near-real-time operation is not claimed.
+
+## Security assumptions
+
+No classified data and no CUI/CDI are used in this package. Access control is a design/readiness topic only unless supported by later documentary evidence.
+""",
+        "threat-model.md": """
+# Threat Model — WS-BAE-GEO-SCREENING-THREAT-001
+
+## Primary abuse/failure modes
+
+- treating simulated evidence as field validation;
+- overclaiming BAE/DOE acceptance from thematic fit;
+- ingesting stale, altered, or unlicensed datasets;
+- suppressing null-control failures or negative evidence;
+- omitting uncertainty when source data conflicts;
+- leaking protected IP or sensitive partner data into a screening package;
+- handling CUI/CDI without an authorized boundary;
+- publishing a map layer without source, timestamp, confidence, or review state.
+
+## Controls required before external partner screening
+
+- claims-boundary review;
+- SBOM/build-provenance attachment;
+- source and output digests;
+- role-based access review;
+- data-rights/IP marking review;
+- CUI/CDI exclusion statement;
+- external-validation route.
+""",
+        "nist-cmmc-dfars-gap-map.md": """
+# NIST / CMMC / DFARS Gap Map — Screening Only
+
+This package does not claim CMMC certification, NIST SP 800-171 conformity, DFARS 252.204-7012 satisfaction, or authorized CUI/CDI handling.
+
+## Current internal evidence
+
+- CI and test evidence for software behavior;
+- audit/provenance pattern evidence;
+- simulated bundle generation and ECHO custody verification.
+
+## Missing supplier-readiness evidence
+
+- defined CUI/CDI boundary;
+- system security plan and control implementation evidence;
+- SPRS/NIST assessment evidence where applicable;
+- incident-response procedure and test record;
+- secrets-management evidence;
+- SBOM/dependency provenance and secure release artifacts;
+- DFARS flowdown review;
+- data-rights and IP-marking review;
+- export-control screening;
+- quality-system evidence;
+- facility/personnel clearance determination if a future opportunity requires it.
+""",
+        "data-rights-ip-markings.md": """
+# Data Rights and IP Markings — Screening Package
+
+This package should contain only non-confidential, non-enabling, public/synthetic demonstration content.
+
+## Required markings
+
+- `WORLD-SHEPHERD-INTERNAL-SIMULATED-EVIDENCE`
+- `NON-CONFIDENTIAL-SCREENING-VERSION`
+- `NO-CUI-NO-CLASSIFIED-DATA`
+- `NO-EXTERNAL-VALIDATION-CLAIM`
+
+Any future partner package must be reviewed before transmission for protected IP, export-control sensitivity, proprietary source data, CUI/CDI, and third-party license restrictions.
+""",
+        "external-validation-route.md": """
+# External Validation Route
+
+## Minimum credible next validation
+
+1. Independent replay of the generated package by a technically competent reviewer using only the manifest and public/synthetic inputs.
+2. Review of uncertainty, null-control, negative-evidence, and claims-boundary handling.
+3. Signed or otherwise attributable reproduction report.
+4. Separate security-control review before any supplier-readiness assertion.
+5. Field data, sensor data, or hardware evidence only after a bounded partner-approved test plan exists.
+
+External replay can upgrade reproducibility evidence only for the tested software/artifact scope. It does not validate BAE adoption, supplier approval, field performance, or CMMC/NIST conformity.
+""",
+        "replay-instructions.md": """
+# Replay Instructions — WS-BAE-GEO-SCREENING-BUNDLE-001
+
+## Source
+
+Start from a generated `geo_prov_qualification_bundle.json` emitted by `ws-pre-bloom` or from a freshly generated internal synthetic GEO bundle.
+
+## Expected checks
+
+- requirement delta is `PRE-RD-2026-0020`;
+- test is `WS-GEO-PROV-001A`;
+- evidence scope is `SIMULATION`;
+- capability status is `SIMULATED_ONLY`;
+- null control is preserved;
+- BAE validation remains negative evidence;
+- claims boundary states no BAE interest or supplier cybersecurity conformity.
+
+## Output
+
+The package exports markdown and JSON artifacts for partner-screening discussion only.
+""",
+    }
+    return artifacts
+
+
+def export_screening_package(bundle: dict[str, Any], out: Path) -> dict[str, Any]:
+    out.mkdir(parents=True, exist_ok=True)
+    artifacts = build_screening_package(bundle)
+    for filename, value in artifacts.items():
+        target = out / filename
+        if isinstance(value, dict):
+            _write_json(target, value)
+        else:
+            _assert_sanitized_text(value)
+            _write_text(target, value)
+
+    artifact_digests = {filename: _file_digest(out / filename) for filename in sorted(artifacts)}
+    manifest = {
+        "schema": "WS-BAE-GEO-SCREENING-MANIFEST-V1",
+        "package_id": "WS-BAE-GEO-SCREENING-BUNDLE-001",
+        "source_bundle_digest": bundle.get("bundle_digest") or canonical_digest(bundle),
+        "output_files": sorted(REQUIRED_OUTPUTS - {"manifest.json"}),
+        "artifact_digests": artifact_digests,
+        "claim_boundary": [
+            "Screening package only.",
+            "No partner validation, supplier approval, external reproduction, field performance, or cybersecurity conformity is claimed.",
+        ],
+    }
+    _write_json(out / "manifest.json", manifest)
+    manifest["artifact_digests"]["manifest.json"] = _file_digest(out / "manifest.json")
+    _write_json(out / "manifest.json", manifest)
+    return manifest
+
+
+def _load_bundle(path: Path | None, *, software_commit: str, executed_utc: str, operator: str) -> dict[str, Any]:
+    if path is not None:
+        return json.loads(path.read_text(encoding="utf-8"))
+    return build_geo_prov_bundle(
+        software_commit=software_commit,
+        executed_utc=executed_utc,
+        operator=operator,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export a sanitized BAE GEO screening package")
+    parser.add_argument("--bundle", type=Path, default=None, help="Optional geo_prov_qualification_bundle.json input")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--software-commit", default=os.getenv("GITHUB_SHA", "UNKNOWN"))
+    parser.add_argument("--executed-utc", required=True)
+    parser.add_argument("--operator", default="worldshepherd-bae-geo-screening-cli")
+    args = parser.parse_args()
+    bundle = _load_bundle(
+        args.bundle,
+        software_commit=args.software_commit,
+        executed_utc=args.executed_utc,
+        operator=args.operator,
+    )
+    manifest = export_screening_package(bundle, args.out)
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/WS_BAE_GEO_SCREENING_CLI_2026-09-01.md
+++ b/docs/WS_BAE_GEO_SCREENING_CLI_2026-09-01.md
@@ -1,0 +1,66 @@
+# WS-BAE-GEO Screening CLI — 2026-09-01
+
+## Purpose
+
+`ws-bae-geo-screening` exports a non-confidential BAE screening package from the `WS-GEO-PROV-001A` geospatial provenance qualification bundle.
+
+The package is meant to help translate the generated PRE evidence into a partner-screening discussion artifact. It is not a proposal, certification, validation, supplier approval, operational authority, or evidence of BAE interest.
+
+## Inputs
+
+The CLI can either:
+
+1. read a generated `geo_prov_qualification_bundle.json`; or
+2. build the internal synthetic GEO bundle directly from `worldshepherd_sara.geo_provenance.build_geo_prov_bundle()`.
+
+## Command
+
+```bash
+ws-bae-geo-screening \
+  --bundle path/to/geo_prov_qualification_bundle.json \
+  --out out/ws-bae-geo-screening \
+  --executed-utc 2026-09-01T16:00:00Z \
+  --operator SSPADAWANZZ
+```
+
+If `--bundle` is omitted, the CLI generates the internal synthetic bundle first.
+
+## Output files
+
+- `manifest.json`
+- `qualification-summary.json`
+- `bae-evidence-overlay.json`
+- `claims-boundary.md`
+- `interface-control-description.md`
+- `threat-model.md`
+- `nist-cmmc-dfars-gap-map.md`
+- `data-rights-ip-markings.md`
+- `external-validation-route.md`
+- `replay-instructions.md`
+
+## Controls
+
+The exporter requires the source bundle claims boundary to retain the no-BAE-interest and no-supplier-cybersecurity-conformity statements before package generation.
+
+The exporter also writes a manifest with file digests so the package can be reviewed and compared after transfer.
+
+## Current maturity
+
+`INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION`
+
+## Claims boundary
+
+This package does not claim:
+
+- BAE Systems interest, endorsement, adoption, validation, certification, approval, classified access, supplier approval, or partnership;
+- DOE validation, national-lab validation, independent reproduction, or external acceptance;
+- land-restoration performance, emergency-response authority, field-calibrated sensor performance, or hardware/platform performance;
+- CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, CUI/CDI handling authorization, or export-control clearance.
+
+## BAE readiness value
+
+The value proposition remains narrow and evidence-governed:
+
+> Worldshepherd can package a simulated, replayable mission-context provenance workflow for heterogeneous environmental/geospatial evidence, degraded data, source disagreement, null controls, and human-reviewed decisions.
+
+This can support BAE-oriented screening against RIVETS, ADAPT/ADAMS, Virtual Proving Ground-style interoperability, and Mission Advantage framing, but it does not imply BAE acceptance.


### PR DESCRIPTION
## Summary

Adds `ws-bae-geo-screening`, a CLI that exports a non-confidential BAE screening/readiness package from the generated `WS-GEO-PROV-001A` qualification bundle.

## Added/changed

- Adds `worldshepherd_sara.bae_geo_screening_cli`.
- Exposes console script `ws-bae-geo-screening`.
- Exports the screening package files:
  - `manifest.json`
  - `qualification-summary.json`
  - `bae-evidence-overlay.json`
  - `claims-boundary.md`
  - `interface-control-description.md`
  - `threat-model.md`
  - `nist-cmmc-dfars-gap-map.md`
  - `data-rights-ip-markings.md`
  - `external-validation-route.md`
  - `replay-instructions.md`
- Adds pytest coverage requiring:
  - all package files to be emitted;
  - `PRE-RD-2026-0020` / `WS-GEO-PROV-001A` preservation;
  - `SIMULATION` and `SIMULATED_ONLY` preservation;
  - BAE validation retained as negative evidence;
  - RIVETS/BAE-lane overlay preservation;
  - package rejection when the source claims boundary is missing.
- Adds documentation for the CLI and claims controls.

## Claims boundary

This PR does **not** claim BAE interest, endorsement, adoption, validation, certification, classified access, supplier approval, partnership, DOE validation, field performance, emergency-response authority, land-restoration performance, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, CUI/CDI handling authorization, or export-control clearance.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / SIMULATED REPLAY / REQUIRES EXTERNAL VALIDATION`