### PR TITLE
Add partner screening matrix coverage

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_partner_screening_matrix.py
+++ b/deployments/sara_verified_local_v1/tests/test_partner_screening_matrix.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from worldshepherd_sara.partner_screening_cli import REQUIRED_OUTPUTS, export_partner_screening_package
+from worldshepherd_sara.pre_bloom_cli import build_bloom
+
+ROOT = Path(__file__).resolve().parents[1]
+
+LANE_MATRIX = {
+    "apnt": {
+        "requirement_id": "PRE-RD-2026-0001",
+        "required_lane": "APNT",
+    },
+    "ddil": {
+        "requirement_id": "PRE-RD-2026-0001",
+        "required_lane": "DDIL",
+    },
+    "mission": {
+        "requirement_id": "PRE-RD-2026-0013",
+        "required_lane": "mission replay",
+    },
+    "fusion": {
+        "requirement_id": "PRE-RD-2026-0014",
+        "required_lane": "distributed sensing",
+    },
+    "rf": {
+        "requirement_id": "PRE-RD-2026-0015",
+        "required_lane": "RF",
+    },
+    "cbm": {
+        "requirement_id": "PRE-RD-2026-0016",
+        "required_lane": "CBM+",
+    },
+    "manufacturing": {
+        "requirement_id": "PRE-RD-2026-0017",
+        "required_lane": "DED",
+    },
+    "edge": {
+        "requirement_id": "PRE-RD-2026-0018",
+        "required_lane": "edge AI",
+    },
+    "ddil_rejoin": {
+        "requirement_id": "PRE-RD-2026-0019",
+        "required_lane": "DDIL",
+    },
+}
+
+
+def _screening_ready_copy(bundle: dict) -> dict:
+    """Preserve source boundaries while adding one explicit matrix boundary.
+
+    Some early PRE bundles use short "No ... claim" wording. The generic exporter
+    already preserves those source lines, and this fixture adds a uniform explicit
+    non-claim sentence so the matrix focuses on cross-lane package compatibility.
+    """
+    value = copy.deepcopy(bundle)
+    value.setdefault("claims_boundary", []).append(
+        "Matrix screening export does not establish partner validation, supplier approval, certification, field performance, hardware performance, or operational authority."
+    )
+    return value
+
+
+def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
+    bloom_dir = tmp_path / "bloom"
+    index = build_bloom(
+        fixtures=ROOT / "fixtures",
+        out=bloom_dir,
+        software_commit="test-commit",
+        executed_utc="2026-09-01T16:10:00Z",
+        operator="pytest-partner-screening-matrix",
+    )
+
+    for lane, expected in LANE_MATRIX.items():
+        bundle_path = bloom_dir / f"{lane}_qualification_bundle.json"
+        assert bundle_path.is_file(), lane
+        bundle = json.loads(bundle_path.read_text())
+        assert bundle["requirement"]["requirement_delta_id"] == expected["requirement_id"]
+        assert expected["required_lane"] in bundle["requirement"]["affected_lanes"]
+        assert bundle["bundle_digest"] == index["bundle_digests"][lane]
+        assert bundle["evidence"][0]["result"] == "PASS"
+
+        for partner in ("BAE_SYSTEMS", "GENERIC_PRIME"):
+            out = tmp_path / "screening" / lane / partner.lower()
+            manifest = export_partner_screening_package(_screening_ready_copy(bundle), out, partner=partner)
+
+            assert manifest["schema"] == "WS-PARTNER-SCREENING-MANIFEST-V1"
+            assert manifest["partner_id"] == partner
+            assert set(manifest["artifact_digests"]) == REQUIRED_OUTPUTS
+            assert all(value.startswith("sha256:") for value in manifest["artifact_digests"].values())
+
+            summary = json.loads((out / "qualification-summary.json").read_text())
+            assert summary["requirement_delta_id"] == expected["requirement_id"]
+            assert summary["test_id"] == bundle["evidence"][0]["test_id"]
+            assert summary["evidence_scope"] == bundle["evidence"][0]["evidence_scope"]
+            assert summary["capability_status"] == bundle["evidence"][0]["capability_status"]
+            assert summary["result"] == "PASS"
+            assert "Matrix screening export does not establish" in "\n".join(summary["claim_boundary"])
+
+            overlay = json.loads((out / "partner-evidence-overlay.json").read_text())
+            assert overlay["partner_id"] == partner
+            assert overlay["requirement_delta_id"] == expected["requirement_id"]
+            assert overlay["test_id"] == bundle["evidence"][0]["test_id"]
+            assert overlay["claim_boundary_note"].startswith("The overlay is a screening map only")
+
+            package_text = "\n".join(path.read_text() for path in out.iterdir() if path.is_file())
+            assert "does not establish partner interest" in package_text
+            assert "SUPPLIER_APPROVED" not in package_text
+            assert "FIELD_VALIDATED" not in package_text
+            assert "PARTNER_VALIDATED" not in package_text

--- a/docs/WS_PARTNER_SCREENING_MATRIX_2026-09-01.md
+++ b/docs/WS_PARTNER_SCREENING_MATRIX_2026-09-01.md
@@ -1,0 +1,69 @@
+# Worldshepherd Partner Screening Matrix — 2026-09-01
+
+## Purpose
+
+This record extends the generic `ws-partner-screening` export path beyond the initial GEO bundle. It adds CI coverage proving that major PRE full-bloom qualification bundles can be converted into sanitized partner-screening packages under the same evidence and claims-boundary controls.
+
+## Covered PRE lanes
+
+The matrix covers the following generated full-bloom bundles:
+
+- `apnt_qualification_bundle.json`
+- `ddil_qualification_bundle.json`
+- `mission_qualification_bundle.json`
+- `fusion_qualification_bundle.json`
+- `rf_qualification_bundle.json`
+- `cbm_qualification_bundle.json`
+- `manufacturing_qualification_bundle.json`
+- `edge_qualification_bundle.json`
+- `ddil_rejoin_qualification_bundle.json`
+
+Each bundle is exported through both partner presets:
+
+- `BAE_SYSTEMS`
+- `GENERIC_PRIME`
+
+## Required preservation checks
+
+For every lane and partner preset, the matrix requires preservation of:
+
+- source bundle digest linkage;
+- requirement delta ID;
+- test ID;
+- evidence scope;
+- capability status;
+- PASS result;
+- partner evidence overlay;
+- partner-screening claim boundary;
+- artifact digests for every emitted file.
+
+## Claims boundary
+
+This matrix does not upgrade capability maturity. It only verifies that each lane can be transformed into a sanitized partner-screening package.
+
+It does **not** claim:
+
+- partner interest;
+- partner endorsement;
+- partner adoption;
+- BAE validation;
+- supplier approval;
+- CMMC conformity;
+- NIST SP 800-171 implementation;
+- DFARS satisfaction;
+- CUI/CDI handling authorization;
+- classified access;
+- DOE validation;
+- field performance;
+- hardware performance;
+- operational authority.
+
+Current maturity remains:
+
+`INTERNAL SOFTWARE EVIDENCE / SCREENING PACKAGE EXPORT / REQUIRES EXTERNAL VALIDATION`
+
+## BAE campaign relevance
+
+This adds a practical BAE-readiness improvement: the screening package path is no longer a GEO-only prototype. APNT, DDIL, mission replay, sensor fusion, RF discrepancy, CBM+/digital twin, manufacturing lineage and edge benchmark evidence can now be checked against the same package-export controls.
+
+That strengthens screening discipline and partner-readiness packaging. It does not establish any BAE relationship or validation.


### PR DESCRIPTION
## Summary

Adds CI coverage proving that the generic `ws-partner-screening` exporter can handle major non-GEO PRE full-bloom bundles, not only the initial GEO path.

## Added/changed

- Adds `test_partner_screening_matrix.py`.
- Generates a PRE full-bloom output using `build_bloom()`.
- Exports these bundles through both `BAE_SYSTEMS` and `GENERIC_PRIME` presets:
  - APNT
  - DDIL campaign
  - mission replay
  - sensor fusion
  - RF discrepancy
  - CBM+/digital twin
  - manufacturing lineage
  - edge benchmark
  - DDIL partition/rejoin
- Verifies preservation of:
  - source bundle digest linkage;
  - requirement delta ID;
  - test ID;
  - evidence scope;
  - capability status;
  - PASS result;
  - partner evidence overlay;
  - partner-screening claim boundary;
  - artifact digests for every emitted file.
- Adds documentation for the partner-screening matrix.

## Claims boundary

This PR does **not** claim partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / SCREENING PACKAGE EXPORT / REQUIRES EXTERNAL VALIDATION`