### PR TITLE
Normalize partner screening claim boundaries

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_partner_screening_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_partner_screening_cli.py
@@ -65,6 +65,20 @@ def test_partner_screening_exports_generic_prime_without_bae_overlay(tmp_path):
     assert overlay["requirement_delta_id"] == "PRE-RD-2026-0020"
 
 
+def test_partner_screening_accepts_no_claim_boundary_language(tmp_path):
+    bundle = _bundle()
+    bundle["claims_boundary"] = [
+        "No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim"
+    ]
+
+    manifest = export_partner_screening_package(bundle, tmp_path, partner="BAE_SYSTEMS")
+
+    assert manifest["partner_id"] == "BAE_SYSTEMS"
+    summary = json.loads((tmp_path / "qualification-summary.json").read_text())
+    assert summary["claim_boundary"] == bundle["claims_boundary"]
+    assert "No physical APNT" in (tmp_path / "claims-boundary.md").read_text()
+
+
 def test_partner_screening_rejects_missing_claim_boundary(tmp_path):
     bundle = _bundle()
     bundle["claims_boundary"] = []

--- a/deployments/sara_verified_local_v1/tests/test_partner_screening_matrix.py
+++ b/deployments/sara_verified_local_v1/tests/test_partner_screening_matrix.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import json
 from pathlib import Path
 
@@ -49,20 +48,6 @@ LANE_MATRIX = {
 }
 
 
-def _screening_ready_copy(bundle: dict) -> dict:
-    """Preserve source boundaries while adding one explicit matrix boundary.
-
-    Some early PRE bundles use short "No ... claim" wording. The generic exporter
-    already preserves those source lines, and this fixture adds a uniform explicit
-    non-claim sentence so the matrix focuses on cross-lane package compatibility.
-    """
-    value = copy.deepcopy(bundle)
-    value.setdefault("claims_boundary", []).append(
-        "Matrix screening export does not establish partner validation, supplier approval, certification, field performance, hardware performance, or operational authority."
-    )
-    return value
-
-
 def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
     bloom_dir = tmp_path / "bloom"
     index = build_bloom(
@@ -81,10 +66,11 @@ def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
         assert expected["required_lane"] in bundle["requirement"]["affected_lanes"]
         assert bundle["bundle_digest"] == index["bundle_digests"][lane]
         assert bundle["evidence"][0]["result"] == "PASS"
+        assert bundle["claims_boundary"]
 
         for partner in ("BAE_SYSTEMS", "GENERIC_PRIME"):
             out = tmp_path / "screening" / lane / partner.lower()
-            manifest = export_partner_screening_package(_screening_ready_copy(bundle), out, partner=partner)
+            manifest = export_partner_screening_package(bundle, out, partner=partner)
 
             assert manifest["schema"] == "WS-PARTNER-SCREENING-MANIFEST-V1"
             assert manifest["partner_id"] == partner
@@ -97,7 +83,7 @@ def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
             assert summary["evidence_scope"] == bundle["evidence"][0]["evidence_scope"]
             assert summary["capability_status"] == bundle["evidence"][0]["capability_status"]
             assert summary["result"] == "PASS"
-            assert "Matrix screening export does not establish" in "\n".join(summary["claim_boundary"])
+            assert summary["claim_boundary"] == bundle["claims_boundary"]
 
             overlay = json.loads((out / "partner-evidence-overlay.json").read_text())
             assert overlay["partner_id"] == partner

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/partner_screening_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/partner_screening_cli.py
@@ -108,6 +108,16 @@ PROHIBITED_ASSERTIONS = (
     "FIELD_VALIDATED",
 )
 
+_NON_CLAIM_MARKERS = (
+    "does not",
+    "do not",
+    "not",
+    "no",
+    "without",
+    "unless",
+    "never",
+)
+
 
 def _json_text(value: dict[str, Any]) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
@@ -123,6 +133,15 @@ def _write_text(path: Path, value: str) -> None:
 
 def _file_digest(path: Path) -> str:
     return canonical_digest({"path": path.name, "content": path.read_text(encoding="utf-8")})
+
+
+def _normalized_words(text: str) -> str:
+    return " " + " ".join(text.lower().replace("-", " ").replace("/", " ").split()) + " "
+
+
+def _has_explicit_non_claim_language(text: str) -> bool:
+    words = _normalized_words(text)
+    return any(f" {marker} " in words for marker in _NON_CLAIM_MARKERS)
 
 
 def _assert_sanitized_text(text: str) -> None:
@@ -144,9 +163,7 @@ def _require_claim_boundary(bundle: dict[str, Any]) -> list[str]:
     if not isinstance(boundary, list) or not boundary:
         raise ValueError("qualification bundle missing claims_boundary")
     text = "\n".join(str(item) for item in boundary)
-    required = ["does not", "not"]
-    lowered = text.lower()
-    if not any(fragment in lowered for fragment in required):
+    if not _has_explicit_non_claim_language(text):
         raise ValueError("claims_boundary must include explicit non-claim language")
     return [str(item) for item in boundary]
 

--- a/docs/WS_CLAIMS_BOUNDARY_NORMALIZATION_2026-09-01.md
+++ b/docs/WS_CLAIMS_BOUNDARY_NORMALIZATION_2026-09-01.md
@@ -1,0 +1,43 @@
+# WS Claims Boundary Normalization — 2026-09-01
+
+## Purpose
+
+Normalize partner-screening claim-boundary acceptance so PRE qualification bundles can be exported directly when they already include explicit non-claim language.
+
+## Change
+
+The `ws-partner-screening` exporter now accepts explicit non-claim markers such as:
+
+- `does not`
+- `do not`
+- `not`
+- `no`
+- `without`
+- `unless`
+- `never`
+
+This covers early PRE bundle wording such as `No physical APNT, shipboard, sensor-accuracy, or Navy operator-performance claim` without requiring a synthetic matrix-only sentence.
+
+## Verification
+
+The matrix test now exports native PRE full-bloom bundles directly for:
+
+- APNT
+- DDIL campaign
+- mission replay
+- sensor fusion
+- RF discrepancy
+- CBM+ / digital twin
+- manufacturing lineage
+- edge benchmark
+- DDIL partition / rejoin
+
+The focused unit test pins acceptance of `No ... claim` language.
+
+## Preserved restrictions
+
+This normalization does not weaken the screening boundary. The exporter still rejects prohibited assertions including partner validation, BAE validation, supplier approval, CMMC certification, NIST conformity, DFARS satisfaction, classified access, DOE validation, field validation, and similar false-readiness claims.
+
+Current maturity remains:
+
+`INTERNAL SOFTWARE EVIDENCE / SCREENING PACKAGE EXPORT / REQUIRES EXTERNAL VALIDATION`


### PR DESCRIPTION
## Summary

Normalizes claim-boundary acceptance in the generic partner-screening exporter so existing PRE bundle language such as `No ... claim` is accepted directly.

## Added/changed

- Adds normalized non-claim detection for claim-boundary text.
- Accepts explicit markers such as `does not`, `do not`, `not`, `no`, `without`, `unless`, and `never`.
- Removes the temporary matrix fixture sentence that made non-GEO bundles screening-ready.
- Updates the matrix test to export native PRE full-bloom bundles directly.
- Adds a focused unit test pinning `No ... claim` acceptance.
- Adds documentation for the normalization rule.

## Claims boundary

This PR does **not** claim partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / SCREENING PACKAGE EXPORT / REQUIRES EXTERNAL VALIDATION`