### PR TITLE
Add partner screening batch exporter

### DIFF
--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -24,6 +24,7 @@ test = [
 ws-pre-bloom = "worldshepherd_sara.pre_bloom_cli:main"
 ws-bae-geo-screening = "worldshepherd_sara.bae_geo_screening_cli:main"
 ws-partner-screening = "worldshepherd_sara.partner_screening_cli:main"
+ws-partner-screening-batch = "worldshepherd_sara.partner_screening_cli:batch_main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_partner_screening_matrix.py
+++ b/deployments/sara_verified_local_v1/tests/test_partner_screening_matrix.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from worldshepherd_sara.partner_screening_cli import REQUIRED_OUTPUTS, export_partner_screening_package
+from worldshepherd_sara.partner_screening_cli import (
+    REQUIRED_OUTPUTS,
+    export_partner_screening_batch,
+    export_partner_screening_package,
+)
 from worldshepherd_sara.pre_bloom_cli import build_bloom
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -48,7 +52,7 @@ LANE_MATRIX = {
 }
 
 
-def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
+def _build_full_bloom(tmp_path: Path):
     bloom_dir = tmp_path / "bloom"
     index = build_bloom(
         fixtures=ROOT / "fixtures",
@@ -57,6 +61,11 @@ def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
         executed_utc="2026-09-01T16:10:00Z",
         operator="pytest-partner-screening-matrix",
     )
+    return bloom_dir, index
+
+
+def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
+    bloom_dir, index = _build_full_bloom(tmp_path)
 
     for lane, expected in LANE_MATRIX.items():
         bundle_path = bloom_dir / f"{lane}_qualification_bundle.json"
@@ -96,3 +105,47 @@ def test_partner_screening_matrix_exports_major_non_geo_pre_lanes(tmp_path):
             assert "SUPPLIER_APPROVED" not in package_text
             assert "FIELD_VALIDATED" not in package_text
             assert "PARTNER_VALIDATED" not in package_text
+
+
+def test_partner_screening_batch_exports_every_full_bloom_bundle(tmp_path):
+    bloom_dir, index = _build_full_bloom(tmp_path)
+    out = tmp_path / "batch-screening"
+
+    manifest = export_partner_screening_batch(
+        bloom_dir,
+        out,
+        partners=("BAE_SYSTEMS", "GENERIC_PRIME"),
+    )
+
+    expected_lanes = set(index["bundle_digests"])
+    assert manifest["schema"] == "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1"
+    assert set(manifest["partners"]) == {"BAE_SYSTEMS", "GENERIC_PRIME"}
+    assert set(manifest["lanes"]) == expected_lanes
+    assert manifest["source_bundle_count"] == len(expected_lanes)
+    assert manifest["package_count"] == len(expected_lanes) * 2
+    assert manifest["batch_digest"].startswith("sha256:")
+    assert (out / "batch-manifest.json").is_file()
+
+    for record in manifest["exports"]:
+        lane = record["lane"]
+        partner_id = record["partner_id"]
+        package_dir = out / partner_id.lower() / lane
+        assert package_dir.is_dir()
+        assert record["source_bundle_digest"] == index["bundle_digests"][lane]
+        assert record["package_manifest_digest"].startswith("sha256:")
+        assert record["package_file_count"] == len(REQUIRED_OUTPUTS) - 1
+
+        for filename in REQUIRED_OUTPUTS:
+            assert (package_dir / filename).is_file(), (lane, partner_id, filename)
+
+        summary = json.loads((package_dir / "qualification-summary.json").read_text())
+        assert summary["requirement_delta_id"]
+        assert summary["test_id"]
+        assert summary["result"] == "PASS"
+        assert summary["claim_boundary"]
+
+    package_text = "\n".join(path.read_text() for path in out.rglob("*") if path.is_file())
+    assert "Batch screening export only" in package_text
+    assert "PARTNER_VALIDATED" not in package_text
+    assert "SUPPLIER_APPROVED" not in package_text
+    assert "FIELD_VALIDATED" not in package_text

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/partner_screening_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/partner_screening_cli.py
@@ -118,6 +118,9 @@ _NON_CLAIM_MARKERS = (
     "never",
 )
 
+QUALIFICATION_BUNDLE_SUFFIX = "_qualification_bundle.json"
+DEFAULT_BATCH_PARTNERS = ("BAE_SYSTEMS", "GENERIC_PRIME")
+
 
 def _json_text(value: dict[str, Any]) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
@@ -175,6 +178,22 @@ def _partner_preset(partner: str) -> tuple[str, dict[str, Any]]:
     if key not in PARTNER_PRESETS:
         key = "GENERIC_PRIME"
     return key, PARTNER_PRESETS[key]
+
+
+def _partner_ids(partners: list[str] | tuple[str, ...] | None) -> list[str]:
+    values = list(partners or DEFAULT_BATCH_PARTNERS)
+    normalized: list[str] = []
+    for value in values:
+        for fragment in value.split(","):
+            fragment = fragment.strip()
+            if not fragment:
+                continue
+            partner_id, _preset = _partner_preset(fragment)
+            if partner_id not in normalized:
+                normalized.append(partner_id)
+    if not normalized:
+        raise ValueError("at least one partner preset is required")
+    return normalized
 
 
 def _derive_partner_overlay(bundle: dict[str, Any], partner_id: str, preset: dict[str, Any]) -> dict[str, Any]:
@@ -451,6 +470,67 @@ def export_partner_screening_package(bundle: dict[str, Any], out_dir: Path, *, p
     return manifest
 
 
+def _bundle_lane(path: Path) -> str:
+    if not path.name.endswith(QUALIFICATION_BUNDLE_SUFFIX):
+        raise ValueError(f"not a qualification bundle path: {path}")
+    return path.name[: -len(QUALIFICATION_BUNDLE_SUFFIX)]
+
+
+def discover_qualification_bundles(bundle_dir: Path) -> list[Path]:
+    if not bundle_dir.is_dir():
+        raise ValueError(f"qualification bundle directory does not exist: {bundle_dir}")
+    bundles = sorted(path for path in bundle_dir.glob(f"*{QUALIFICATION_BUNDLE_SUFFIX}") if path.is_file())
+    if not bundles:
+        raise ValueError(f"no qualification bundles found in {bundle_dir}")
+    return bundles
+
+
+def export_partner_screening_batch(bundle_dir: Path, out_dir: Path, *, partners: list[str] | tuple[str, ...] | None = None) -> dict[str, Any]:
+    """Export every PRE qualification bundle in a directory for each partner preset."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    partner_ids = _partner_ids(partners)
+    records: list[dict[str, Any]] = []
+    lanes: list[str] = []
+
+    for bundle_path in discover_qualification_bundles(bundle_dir):
+        lane = _bundle_lane(bundle_path)
+        lanes.append(lane)
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        for partner_id in partner_ids:
+            package_dir = out_dir / partner_id.lower() / lane
+            package_manifest = export_partner_screening_package(bundle, package_dir, partner=partner_id)
+            records.append(
+                {
+                    "lane": lane,
+                    "partner_id": partner_id,
+                    "source_bundle": bundle_path.name,
+                    "source_bundle_digest": bundle.get("bundle_digest"),
+                    "output_dir": str(package_dir),
+                    "package_manifest_digest": package_manifest["artifact_digests"]["manifest.json"],
+                    "package_file_count": len(package_manifest["output_files"]),
+                }
+            )
+
+    batch_manifest = {
+        "schema": "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1",
+        "source_bundle_dir": str(bundle_dir),
+        "output_dir": str(out_dir),
+        "partners": partner_ids,
+        "lanes": sorted(set(lanes)),
+        "source_bundle_count": len(set(lanes)),
+        "package_count": len(records),
+        "exports": records,
+        "claims_boundary": (
+            "Batch screening export only; it does not establish partner interest, validation, supplier approval, "
+            "certification, classified access, compliance conformity, external reproduction, field performance, "
+            "hardware performance, or operational authority."
+        ),
+    }
+    batch_manifest["batch_digest"] = canonical_digest(batch_manifest)
+    _write_json(out_dir / "batch-manifest.json", batch_manifest)
+    return batch_manifest
+
+
 def _load_bundle(path: Path | None) -> dict[str, Any]:
     if path is None:
         return build_geo_prov_bundle(
@@ -469,6 +549,17 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     bundle = _load_bundle(args.bundle)
     manifest = export_partner_screening_package(bundle, args.out, partner=args.partner)
+    print(_json_text(manifest), end="")
+    return 0
+
+
+def batch_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch-export partner-screening packages from PRE full-bloom bundles.")
+    parser.add_argument("--bundle-dir", type=Path, required=True, help="Directory containing *_qualification_bundle.json files.")
+    parser.add_argument("--partner", action="append", default=[], help="Partner preset. May be repeated or comma-separated. Defaults to BAE_SYSTEMS and GENERIC_PRIME.")
+    parser.add_argument("--out", type=Path, required=True, help="Output root for partner/lane screening package directories.")
+    args = parser.parse_args(argv)
+    manifest = export_partner_screening_batch(args.bundle_dir, args.out, partners=args.partner or None)
     print(_json_text(manifest), end="")
     return 0
 

--- a/docs/WS_PARTNER_SCREENING_BATCH_EXPORT_2026-09-01.md
+++ b/docs/WS_PARTNER_SCREENING_BATCH_EXPORT_2026-09-01.md
@@ -1,0 +1,74 @@
+# WS Partner Screening Batch Export — 2026-09-01
+
+## Purpose
+
+Add a batch export path for partner-screening packages so a PRE full-bloom output directory can be converted into structured partner/lane screening folders with one command.
+
+## Command
+
+```bash
+ws-pre-bloom --fixtures deployments/sara_verified_local_v1/fixtures --out build/pre-bloom
+ws-partner-screening-batch --bundle-dir build/pre-bloom --out build/partner-screening
+```
+
+By default, the batch command exports each `*_qualification_bundle.json` for both:
+
+- `BAE_SYSTEMS`
+- `GENERIC_PRIME`
+
+A caller may override the partner set by repeating `--partner`, for example:
+
+```bash
+ws-partner-screening-batch \
+  --bundle-dir build/pre-bloom \
+  --partner BAE_SYSTEMS \
+  --out build/partner-screening/bae-only
+```
+
+## Output layout
+
+```text
+build/partner-screening/
+├── batch-manifest.json
+├── bae_systems/
+│   ├── apnt/
+│   ├── cbm/
+│   ├── ddil/
+│   ├── ddil_rejoin/
+│   ├── edge/
+│   ├── fusion/
+│   ├── geo_prov/
+│   ├── manufacturing/
+│   ├── mission/
+│   └── rf/
+└── generic_prime/
+    └── ...same lane layout...
+```
+
+Each lane/partner folder is generated through the existing single-bundle exporter and therefore retains the same controls:
+
+- required claims boundary;
+- prohibited-assertion rejection;
+- evidence scope preservation;
+- capability-status preservation;
+- negative-evidence preservation;
+- package-level artifact digests;
+- partner-overlay claim boundary.
+
+## Batch manifest
+
+`batch-manifest.json` records:
+
+- source bundle directory;
+- output directory;
+- partner IDs;
+- exported lanes;
+- source bundle count;
+- package count;
+- per-export source bundle digest;
+- per-export package manifest digest;
+- batch digest.
+
+## Claims boundary
+
+This batch export is a packaging/readiness mechanism only. It does not establish partner interest, partner validation, BAE validation, supplier approval, certification, classified access, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, external reproduction, field performance, hardware performance, DOE validation, or operational authority.


### PR DESCRIPTION
## Summary

Adds a batch export path so a PRE full-bloom output directory can be converted into structured partner/lane screening package folders with one command.

## Added/changed

- Adds `export_partner_screening_batch()` inside the existing partner-screening module.
- Adds `ws-partner-screening-batch` console script.
- Discovers every `*_qualification_bundle.json` in a PRE full-bloom output directory.
- Exports each discovered bundle for partner presets, defaulting to both:
  - `BAE_SYSTEMS`
  - `GENERIC_PRIME`
- Writes a `batch-manifest.json` with partner IDs, lanes, package count, source bundle digests, package manifest digests, and batch digest.
- Updates the matrix test to verify every full-bloom bundle exports through the batch path.
- Documents the output layout and claim boundary.

## Claims boundary

This PR does **not** claim partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / SCREENING PACKAGE EXPORT / REQUIRES EXTERNAL VALIDATION`