### PR TITLE
Upload partner screening batch evidence in CI

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -39,7 +39,11 @@ jobs:
           python -m pip check
           python -m pip freeze --all | sort > dependency-freeze.txt
           command -v ws-pre-bloom
+          command -v ws-partner-screening
+          command -v ws-partner-screening-batch
           ws-pre-bloom --help >/dev/null
+          ws-partner-screening --help >/dev/null
+          ws-partner-screening-batch --help >/dev/null
 
       - name: Upload dependency resolution evidence
         uses: actions/upload-artifact@v4
@@ -74,11 +78,49 @@ jobs:
           test -s qualification_evidence_ci/software_provenance.json
           test -d qualification_evidence_ci/echo_store
 
+      - name: Export partner-screening package evidence
+        run: |
+          rm -rf partner_screening_ci
+          ws-partner-screening-batch \
+            --bundle-dir qualification_evidence_ci \
+            --out partner_screening_ci \
+            --partner BAE_SYSTEMS \
+            --partner GENERIC_PRIME
+          test -s partner_screening_ci/batch-manifest.json
+          python - <<'PY'
+          import json
+          import pathlib
+
+          root = pathlib.Path('partner_screening_ci')
+          manifest = json.loads((root / 'batch-manifest.json').read_text())
+          assert manifest['schema'] == 'WS-PARTNER-SCREENING-BATCH-MANIFEST-V1'
+          assert set(manifest['partners']) == {'BAE_SYSTEMS', 'GENERIC_PRIME'}
+          assert manifest['source_bundle_count'] > 0
+          assert manifest['package_count'] == manifest['source_bundle_count'] * len(manifest['partners'])
+          assert manifest['batch_digest'].startswith('sha256:')
+          for record in manifest['exports']:
+              package_dir = pathlib.Path(record['output_dir'])
+              assert package_dir.is_dir()
+              assert (package_dir / 'manifest.json').is_file()
+              assert (package_dir / 'qualification-summary.json').is_file()
+              assert (package_dir / 'claims-boundary.md').is_file()
+          text = '\n'.join(path.read_text() for path in root.rglob('*') if path.is_file())
+          for forbidden in ('PARTNER_VALIDATED', 'SUPPLIER_APPROVED', 'FIELD_VALIDATED', 'CMMC_CERTIFIED'):
+              assert forbidden not in text
+          PY
+
       - name: Upload PRE qualification evidence
         uses: actions/upload-artifact@v4
         with:
           name: pre-full-bloom-qualification-evidence
           path: deployments/sara_verified_local_v1/qualification_evidence_ci
+          if-no-files-found: error
+
+      - name: Upload partner-screening package evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: partner-screening-batch-evidence
+          path: deployments/sara_verified_local_v1/partner_screening_ci
           if-no-files-found: error
 
       - name: Create ephemeral CI environment

--- a/docs/WS_CI_PARTNER_SCREENING_ARTIFACT_2026-09-01.md
+++ b/docs/WS_CI_PARTNER_SCREENING_ARTIFACT_2026-09-01.md
@@ -1,0 +1,56 @@
+# WS CI Partner-Screening Artifact Upload — 2026-09-01
+
+## Purpose
+
+This record documents the SARA Verified Local v1 Gate update that turns the generated PRE full-bloom qualification evidence into a CI-uploaded partner-screening evidence artifact.
+
+The workflow now performs the following sequence:
+
+```text
+ws-pre-bloom
+→ qualification_evidence_ci/
+→ ws-partner-screening-batch
+→ partner_screening_ci/
+→ upload-artifact: partner-screening-batch-evidence
+```
+
+## Added CI checks
+
+The workflow verifies the installed console scripts:
+
+```text
+ws-pre-bloom
+ws-partner-screening
+ws-partner-screening-batch
+```
+
+It then validates the batch output before upload:
+
+- `partner_screening_ci/batch-manifest.json` exists and is non-empty.
+- Manifest schema is `WS-PARTNER-SCREENING-BATCH-MANIFEST-V1`.
+- Default partners are `BAE_SYSTEMS` and `GENERIC_PRIME`.
+- Source bundle count is greater than zero.
+- Package count equals source bundle count multiplied by partner count.
+- Batch digest is present and SHA-256 shaped.
+- Every export record has a package directory with `manifest.json`, `qualification-summary.json`, and `claims-boundary.md`.
+- Prohibited false-readiness assertions remain absent from the generated package tree.
+
+## Artifact
+
+The new uploaded artifact is:
+
+```text
+partner-screening-batch-evidence
+```
+
+It contains the generated partner/lane screening package tree created from the same PRE full-bloom bundle set used in the gate.
+
+## Claims boundary
+
+This artifact is a CI-generated screening evidence package only. It does **not** establish partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.
+
+Current maturity remains:
+
+```text
+INTERNAL SOFTWARE EVIDENCE / CI-GENERATED SCREENING PACKAGE / REQUIRES EXTERNAL VALIDATION
+```


### PR DESCRIPTION
## Summary

Adds CI generation and upload of the cross-lane partner-screening batch package produced from PRE full-bloom qualification evidence.

## Added/changed

- Verifies `ws-partner-screening` and `ws-partner-screening-batch` are installed and expose `--help`.
- Runs `ws-partner-screening-batch` after `ws-pre-bloom` generates `qualification_evidence_ci`.
- Validates `partner_screening_ci/batch-manifest.json` before upload.
- Checks expected partner presets, package count, batch digest, required per-package files, and prohibited false-readiness assertions.
- Uploads the generated package tree as `partner-screening-batch-evidence`.
- Adds a documentation record for the CI artifact gate.

## Claims boundary

This PR does **not** claim partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / CI-GENERATED SCREENING PACKAGE / REQUIRES EXTERNAL VALIDATION`