### PR TITLE
Add partner screening manifest verifier

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -41,9 +41,11 @@ jobs:
           command -v ws-pre-bloom
           command -v ws-partner-screening
           command -v ws-partner-screening-batch
+          command -v ws-partner-screening-verify
           ws-pre-bloom --help >/dev/null
           ws-partner-screening --help >/dev/null
           ws-partner-screening-batch --help >/dev/null
+          ws-partner-screening-verify --help >/dev/null
 
       - name: Upload dependency resolution evidence
         uses: actions/upload-artifact@v4
@@ -108,6 +110,7 @@ jobs:
           for forbidden in ('PARTNER_VALIDATED', 'SUPPLIER_APPROVED', 'FIELD_VALIDATED', 'CMMC_CERTIFIED'):
               assert forbidden not in text
           PY
+          ws-partner-screening-verify --batch partner_screening_ci >/dev/null
 
       - name: Upload PRE qualification evidence
         uses: actions/upload-artifact@v4

--- a/deployments/sara_verified_local_v1/docs/WS_PARTNER_SCREENING_MANIFEST_VERIFIER_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_PARTNER_SCREENING_MANIFEST_VERIFIER_2026-09-01.md
@@ -1,0 +1,64 @@
+# WS Partner-Screening Manifest Verifier — 2026-09-01
+
+## Purpose
+
+Add a read-only verifier for partner-screening package artifacts generated from PRE full-bloom evidence.
+
+The verifier is intended to support the BAE Systems and generic-prime screening workflow by ensuring that a generated package has not been altered before review or archival.
+
+## New CLI
+
+```bash
+ws-partner-screening-verify --package <partner-package-dir>
+ws-partner-screening-verify --batch <partner-screening-batch-dir>
+```
+
+## Verification scope
+
+For a single partner-screening package, the verifier checks:
+
+- `manifest.json` exists;
+- manifest schema is `WS-PARTNER-SCREENING-MANIFEST-V1`;
+- every declared output file exists;
+- every declared output file digest matches;
+- the manifest bootstrap self-digest matches;
+- required package files are present;
+- prohibited false-readiness assertions are absent.
+
+For a batch export, the verifier checks:
+
+- `batch-manifest.json` exists;
+- batch schema is `WS-PARTNER-SCREENING-BATCH-MANIFEST-V1`;
+- `source_bundle_count`, `package_count`, lanes and partners are internally consistent;
+- `batch_digest` matches the manifest bootstrap form;
+- every export record resolves to a package directory;
+- every package manifest and file digest verifies;
+- every package manifest digest matches the batch export record.
+
+## CI integration
+
+The SARA Verified Local v1 Gate now checks:
+
+```bash
+command -v ws-partner-screening-verify
+ws-partner-screening-verify --help >/dev/null
+ws-partner-screening-verify --batch partner_screening_ci >/dev/null
+```
+
+This means the uploaded `partner-screening-batch-evidence` artifact is generated and verified before upload.
+
+## Claims boundary
+
+This verifier confirms package integrity only.
+
+It does not establish partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.
+
+Current maturity remains:
+
+`INTERNAL SOFTWARE EVIDENCE / CI-GENERATED AND DIGEST-VERIFIED SCREENING PACKAGE / REQUIRES EXTERNAL VALIDATION`
+
+## BAE readiness effect
+
+This is a partner-readiness improvement because it gives Worldshepherd a reproducible way to prove that a BAE-style screening package still matches its generated manifests and file digests before external review.
+
+It is not a BAE endorsement or acceptance signal.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -25,6 +25,7 @@ ws-pre-bloom = "worldshepherd_sara.pre_bloom_cli:main"
 ws-bae-geo-screening = "worldshepherd_sara.bae_geo_screening_cli:main"
 ws-partner-screening = "worldshepherd_sara.partner_screening_cli:main"
 ws-partner-screening-batch = "worldshepherd_sara.partner_screening_cli:batch_main"
+ws-partner-screening-verify = "worldshepherd_sara.partner_screening_verify_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_partner_screening_verify_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_partner_screening_verify_cli.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from worldshepherd_sara.geo_provenance import build_geo_prov_bundle
+from worldshepherd_sara.partner_screening_cli import export_partner_screening_batch, export_partner_screening_package
+from worldshepherd_sara.partner_screening_verify_cli import (
+    main as verify_main,
+    verify_partner_screening_batch,
+    verify_partner_screening_package,
+)
+
+
+def _geo_bundle():
+    return build_geo_prov_bundle(
+        software_commit="test-manifest-verifier",
+        executed_utc="2026-09-01T16:40:00Z",
+        operator="pytest",
+    )
+
+
+def _write_bundle(path, bundle):
+    path.write_text(json.dumps(bundle, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def test_verify_partner_screening_package_accepts_exported_package(tmp_path):
+    out = tmp_path / "package"
+    manifest = export_partner_screening_package(_geo_bundle(), out, partner="BAE_SYSTEMS")
+
+    report = verify_partner_screening_package(out)
+
+    assert report["schema"] == "WS-PARTNER-SCREENING-VERIFY-V1"
+    assert report["status"] == "PASS"
+    assert report["verification_scope"] == "partner_screening_package"
+    assert report["partner_id"] == "BAE_SYSTEMS"
+    assert report["manifest_bootstrap_digest"] == manifest["artifact_digests"]["manifest.json"]
+    assert "manifest.json" in report["checked_files"]
+    assert "qualification-summary.json" in report["checked_files"]
+    assert "claims-boundary.md" in report["checked_files"]
+
+
+def test_verify_partner_screening_package_rejects_tampered_file(tmp_path):
+    out = tmp_path / "package"
+    export_partner_screening_package(_geo_bundle(), out, partner="BAE_SYSTEMS")
+    (out / "claims-boundary.md").write_text("tampered\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        verify_partner_screening_package(out)
+
+
+def test_verify_partner_screening_batch_accepts_exported_batch(tmp_path):
+    bundle_dir = tmp_path / "bundles"
+    bundle_dir.mkdir()
+    _write_bundle(bundle_dir / "geo_prov_qualification_bundle.json", _geo_bundle())
+    out = tmp_path / "batch-screening"
+
+    manifest = export_partner_screening_batch(bundle_dir, out, partners=("BAE_SYSTEMS", "GENERIC_PRIME"))
+    report = verify_partner_screening_batch(out)
+
+    assert report["schema"] == "WS-PARTNER-SCREENING-VERIFY-V1"
+    assert report["status"] == "PASS"
+    assert report["verification_scope"] == "partner_screening_batch"
+    assert set(report["partners"]) == {"BAE_SYSTEMS", "GENERIC_PRIME"}
+    assert report["source_bundle_count"] == 1
+    assert report["package_count"] == 2
+    assert report["verified_package_count"] == 2
+    assert report["batch_digest"] == manifest["batch_digest"]
+
+
+def test_verify_partner_screening_batch_rejects_tampered_batch_manifest(tmp_path):
+    bundle_dir = tmp_path / "bundles"
+    bundle_dir.mkdir()
+    _write_bundle(bundle_dir / "geo_prov_qualification_bundle.json", _geo_bundle())
+    out = tmp_path / "batch-screening"
+    export_partner_screening_batch(bundle_dir, out, partners=("BAE_SYSTEMS", "GENERIC_PRIME"))
+
+    manifest_path = out / "batch-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["package_count"] = 999
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="package_count"):
+        verify_partner_screening_batch(out)
+
+
+def test_verify_cli_returns_nonzero_on_tamper(tmp_path, capsys):
+    out = tmp_path / "package"
+    export_partner_screening_package(_geo_bundle(), out, partner="BAE_SYSTEMS")
+    (out / "claims-boundary.md").write_text("tampered\n", encoding="utf-8")
+
+    rc = verify_main(["--package", str(out)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert '"status": "FAIL"' in captured.err
+    assert "digest mismatch" in captured.err

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/partner_screening_verify_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/partner_screening_verify_cli.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .partner_screening_cli import REQUIRED_OUTPUTS, _assert_sanitized_text, _file_digest, _json_text
+from .qualification import canonical_digest
+
+VERIFY_SCHEMA = "WS-PARTNER-SCREENING-VERIFY-V1"
+PACKAGE_MANIFEST_SCHEMA = "WS-PARTNER-SCREENING-MANIFEST-V1"
+BATCH_MANIFEST_SCHEMA = "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"required manifest file missing: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"manifest must be a JSON object: {path}")
+    return value
+
+
+def _require_string_list(value: Any, *, field: str) -> list[str]:
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{field} must be a non-empty list of strings")
+    return list(value)
+
+
+def _require_string_dict(value: Any, *, field: str) -> dict[str, str]:
+    if not isinstance(value, dict) or not value or not all(isinstance(k, str) and isinstance(v, str) for k, v in value.items()):
+        raise ValueError(f"{field} must be a non-empty string map")
+    return dict(value)
+
+
+def _verify_manifest_bootstrap_digest(manifest_path: Path, manifest: dict[str, Any], artifact_digests: dict[str, str]) -> str | None:
+    """Verify the manifest's recorded self-digest against its bootstrap form.
+
+    `export_partner_screening_package()` first writes the manifest without a
+    manifest self-entry, hashes that bootstrap manifest, then records the hash
+    under `artifact_digests["manifest.json"]`. A verifier must therefore remove
+    the self-entry before recomputing the digest.
+    """
+    recorded = artifact_digests.get("manifest.json")
+    if recorded is None:
+        return None
+    bootstrap = dict(manifest)
+    bootstrap_digests = dict(artifact_digests)
+    bootstrap_digests.pop("manifest.json", None)
+    bootstrap["artifact_digests"] = bootstrap_digests
+    actual = canonical_digest({"path": "manifest.json", "content": _json_text(bootstrap)})
+    if actual != recorded:
+        raise ValueError(f"digest mismatch for {manifest_path}: expected {recorded}, got {actual}")
+    return actual
+
+
+def _verify_batch_digest(batch_manifest: dict[str, Any]) -> str:
+    recorded = batch_manifest.get("batch_digest")
+    if not isinstance(recorded, str) or not recorded.startswith("sha256:"):
+        raise ValueError("batch manifest missing batch_digest")
+    bootstrap = dict(batch_manifest)
+    bootstrap.pop("batch_digest", None)
+    actual = canonical_digest(bootstrap)
+    if actual != recorded:
+        raise ValueError(f"batch digest mismatch: expected {recorded}, got {actual}")
+    return actual
+
+
+def _read_all_text(root: Path) -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in sorted(root.rglob("*")) if path.is_file())
+
+
+def verify_partner_screening_package(package_dir: Path) -> dict[str, Any]:
+    """Verify one exported partner-screening package without mutating it."""
+    root = Path(package_dir)
+    if not root.is_dir():
+        raise ValueError(f"partner-screening package directory does not exist: {root}")
+
+    manifest_path = root / "manifest.json"
+    manifest = _load_json(manifest_path)
+    if manifest.get("schema") != PACKAGE_MANIFEST_SCHEMA:
+        raise ValueError(f"unexpected package manifest schema: {manifest.get('schema')}")
+
+    output_files = _require_string_list(manifest.get("output_files"), field="manifest.output_files")
+    artifact_digests = _require_string_dict(manifest.get("artifact_digests"), field="manifest.artifact_digests")
+
+    missing_required = sorted((REQUIRED_OUTPUTS - {"manifest.json"}) - set(output_files))
+    if missing_required:
+        raise ValueError(f"package manifest missing required output files: {missing_required}")
+
+    checked: dict[str, str] = {}
+    for filename in sorted(output_files):
+        path = root / filename
+        if not path.is_file():
+            raise ValueError(f"declared package file missing: {path}")
+        expected = artifact_digests.get(filename)
+        if expected is None:
+            raise ValueError(f"artifact digest missing for package file: {filename}")
+        actual = _file_digest(path)
+        if actual != expected:
+            raise ValueError(f"digest mismatch for {path}: expected {expected}, got {actual}")
+        checked[filename] = actual
+
+    manifest_bootstrap_digest = _verify_manifest_bootstrap_digest(manifest_path, manifest, artifact_digests)
+    if manifest_bootstrap_digest:
+        checked["manifest.json"] = manifest_bootstrap_digest
+
+    _assert_sanitized_text(_read_all_text(root))
+
+    return {
+        "schema": VERIFY_SCHEMA,
+        "status": "PASS",
+        "verification_scope": "partner_screening_package",
+        "package_dir": str(root),
+        "partner_id": manifest.get("partner_id"),
+        "package_id": manifest.get("package_id"),
+        "source_bundle_digest": manifest.get("source_bundle_digest"),
+        "checked_file_count": len(checked),
+        "checked_files": sorted(checked),
+        "manifest_bootstrap_digest": manifest_bootstrap_digest,
+        "claims_boundary": "Digest verification only; this does not establish partner validation, supplier approval, certification, compliance conformity, external reproduction, field performance, hardware performance, classified access, or operational authority.",
+    }
+
+
+def _resolve_package_dir(batch_root: Path, record: dict[str, Any]) -> Path:
+    raw = Path(str(record.get("output_dir", "")))
+    partner_id = str(record.get("partner_id", "")).lower()
+    lane = str(record.get("lane", ""))
+    candidates = []
+    if raw:
+        candidates.append(raw)
+        if raw.parts and raw.parts[0] == batch_root.name:
+            candidates.append(batch_root.joinpath(*raw.parts[1:]))
+    if partner_id and lane:
+        candidates.append(batch_root / partner_id / lane)
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    raise ValueError(f"could not resolve package directory for batch export record: {record}")
+
+
+def verify_partner_screening_batch(batch_dir: Path) -> dict[str, Any]:
+    """Verify a batch partner-screening artifact tree without mutating it."""
+    root = Path(batch_dir)
+    if not root.is_dir():
+        raise ValueError(f"partner-screening batch directory does not exist: {root}")
+
+    batch_manifest_path = root / "batch-manifest.json"
+    batch_manifest = _load_json(batch_manifest_path)
+    if batch_manifest.get("schema") != BATCH_MANIFEST_SCHEMA:
+        raise ValueError(f"unexpected batch manifest schema: {batch_manifest.get('schema')}")
+
+    exports = batch_manifest.get("exports")
+    if not isinstance(exports, list) or not exports:
+        raise ValueError("batch manifest must include a non-empty exports list")
+    partners = _require_string_list(batch_manifest.get("partners"), field="batch_manifest.partners")
+    lanes = _require_string_list(batch_manifest.get("lanes"), field="batch_manifest.lanes")
+    if batch_manifest.get("source_bundle_count") != len(set(lanes)):
+        raise ValueError("batch source_bundle_count does not match lanes")
+    if batch_manifest.get("package_count") != len(exports):
+        raise ValueError("batch package_count does not match export records")
+    if batch_manifest.get("package_count") != batch_manifest.get("source_bundle_count") * len(partners):
+        raise ValueError("batch package_count does not match source bundles multiplied by partners")
+
+    batch_digest = _verify_batch_digest(batch_manifest)
+    _assert_sanitized_text(batch_manifest_path.read_text(encoding="utf-8"))
+
+    package_reports = []
+    for record in exports:
+        if not isinstance(record, dict):
+            raise ValueError("batch export records must be JSON objects")
+        package_dir = _resolve_package_dir(root, record)
+        report = verify_partner_screening_package(package_dir)
+        if record.get("source_bundle_digest") != report.get("source_bundle_digest"):
+            raise ValueError(f"source bundle digest mismatch for batch export record: {record}")
+        if record.get("package_manifest_digest") != report.get("manifest_bootstrap_digest"):
+            raise ValueError(f"package manifest digest mismatch for batch export record: {record}")
+        package_reports.append(report)
+
+    return {
+        "schema": VERIFY_SCHEMA,
+        "status": "PASS",
+        "verification_scope": "partner_screening_batch",
+        "batch_dir": str(root),
+        "partners": partners,
+        "lanes": sorted(set(lanes)),
+        "source_bundle_count": batch_manifest.get("source_bundle_count"),
+        "package_count": batch_manifest.get("package_count"),
+        "verified_package_count": len(package_reports),
+        "batch_digest": batch_digest,
+        "claims_boundary": "Batch digest verification only; this does not establish partner validation, supplier approval, certification, compliance conformity, external reproduction, field performance, hardware performance, classified access, or operational authority.",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify partner-screening package manifests and artifact digests.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--package", type=Path, help="Directory containing one partner-screening manifest.json.")
+    group.add_argument("--batch", type=Path, help="Directory containing batch-manifest.json and partner/lane package folders.")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.package is not None:
+            report = verify_partner_screening_package(args.package)
+        else:
+            report = verify_partner_screening_batch(args.batch)
+    except Exception as exc:  # pragma: no cover - exercised through CLI behavior
+        print(_json_text({"schema": VERIFY_SCHEMA, "status": "FAIL", "error": str(exc)}), end="", file=sys.stderr)
+        return 1
+
+    print(_json_text(report), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a read-only manifest verifier for generated partner-screening package artifacts.

## Added/changed

- Adds `partner_screening_verify_cli.py`.
- Exposes `ws-partner-screening-verify` as a console script.
- Verifies single package manifests and batch manifests.
- Checks declared files, artifact digests, manifest bootstrap self-digests, batch digests, package counts, and prohibited false-readiness assertions.
- Adds tamper-rejection tests for package files and batch manifests.
- Updates the SARA Verified Local v1 Gate to run `ws-partner-screening-verify --batch partner_screening_ci` before partner-screening artifact upload.
- Adds a documentation record for the verifier and claims boundary.

## Claims boundary

This PR verifies artifact integrity only. It does **not** claim partner interest, partner validation, BAE validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / CI-GENERATED AND DIGEST-VERIFIED SCREENING PACKAGE / REQUIRES EXTERNAL VALIDATION`