### PR TITLE
Add downloaded partner screening artifact verifier

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -46,6 +46,7 @@ jobs:
           ws-partner-screening --help >/dev/null
           ws-partner-screening-batch --help >/dev/null
           ws-partner-screening-verify --help >/dev/null
+          bash scripts/verify_partner_screening_artifact.sh --help >/dev/null
 
       - name: Upload dependency resolution evidence
         uses: actions/upload-artifact@v4
@@ -111,6 +112,7 @@ jobs:
               assert forbidden not in text
           PY
           ws-partner-screening-verify --batch partner_screening_ci >/dev/null
+          bash scripts/verify_partner_screening_artifact.sh partner_screening_ci >/dev/null
 
       - name: Upload PRE qualification evidence
         uses: actions/upload-artifact@v4

--- a/deployments/sara_verified_local_v1/docs/WS_DOWNLOADED_PARTNER_SCREENING_ARTIFACT_VERIFY_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_DOWNLOADED_PARTNER_SCREENING_ARTIFACT_VERIFY_2026-09-01.md
@@ -1,0 +1,139 @@
+# WS Downloaded Partner-Screening Artifact Verification
+
+Date: 2026-09-01  
+Status: CI-integrated verifier support  
+Scope: Worldshepherd/SARA partner-screening evidence custody
+
+## Purpose
+
+This record adds a local verification path for downloaded GitHub Actions artifacts, especially:
+
+```text
+partner-screening-batch-evidence
+```
+
+The goal is to let a reviewer or operator download a GitHub Actions artifact ZIP, compare the downloaded ZIP against the GitHub-displayed artifact digest, extract it safely into a temporary directory, and run the existing partner-screening manifest verifier against the extracted package tree.
+
+## Added script
+
+```bash
+scripts/verify_partner_screening_artifact.sh <artifact.zip|extracted-dir> [expected-artifact-sha256]
+```
+
+Accepted inputs:
+
+- GitHub Actions artifact ZIP;
+- extracted batch directory containing `batch-manifest.json`;
+- extracted single package directory containing `manifest.json`.
+
+The optional digest argument accepts either:
+
+```text
+<hex>
+sha256:<hex>
+```
+
+## Verification sequence
+
+For a downloaded ZIP:
+
+```text
+ZIP exists
+→ optional ZIP SHA-256 matches supplied expected digest
+→ ZIP is extracted into a temporary directory
+→ artifact root is resolved
+→ batch-manifest.json or manifest.json is identified
+→ ws-partner-screening-verify validates manifests and file digests
+→ JSON PASS/FAIL report is emitted
+```
+
+For an extracted directory:
+
+```text
+directory exists
+→ artifact root is resolved
+→ batch-manifest.json or manifest.json is identified
+→ ws-partner-screening-verify validates manifests and file digests
+→ JSON PASS/FAIL report is emitted
+```
+
+## Example use
+
+```bash
+cd deployments/sara_verified_local_v1
+bash scripts/verify_partner_screening_artifact.sh \
+  ~/Downloads/partner-screening-batch-evidence.zip \
+  sha256:<digest-shown-by-github-actions>
+```
+
+Or, after manual extraction:
+
+```bash
+cd deployments/sara_verified_local_v1
+bash scripts/verify_partner_screening_artifact.sh /path/to/extracted/partner_screening_ci
+```
+
+## CI integration
+
+The SARA Verified Local v1 Gate now checks:
+
+```bash
+bash scripts/verify_partner_screening_artifact.sh --help
+```
+
+and, after generating the CI partner-screening batch package:
+
+```bash
+bash scripts/verify_partner_screening_artifact.sh partner_screening_ci
+```
+
+That proves the reviewer-facing script path works on the same generated evidence tree uploaded by CI.
+
+## Test coverage
+
+The test suite verifies:
+
+- extracted batch verification succeeds;
+- artifact ZIP verification succeeds when the expected digest matches;
+- artifact ZIP verification fails when the expected digest is wrong.
+
+## Claims boundary
+
+This verification path checks integrity and manifest consistency only.
+
+It does **not** establish:
+
+- BAE interest;
+- partner validation;
+- supplier approval;
+- CMMC conformity;
+- NIST SP 800-171 implementation;
+- DFARS satisfaction;
+- classified access;
+- DOE validation;
+- field performance;
+- hardware performance;
+- external reproduction;
+- export-control clearance;
+- operational authority.
+
+Current maturity remains:
+
+```text
+INTERNAL SOFTWARE EVIDENCE / CI-GENERATED AND LOCALLY VERIFIABLE SCREENING PACKAGE / REQUIRES EXTERNAL VALIDATION
+```
+
+## BAE readiness effect
+
+This closes the downloaded-artifact custody gap for the BAE screening package path. The chain now supports:
+
+```text
+PRE full-bloom generation
+→ partner-screening batch export
+→ CI manifest verification
+→ Actions artifact upload
+→ downloaded ZIP digest comparison
+→ local manifest/file-digest verification
+```
+
+That improves review discipline without changing Worldshepherd's technical validation status.

--- a/deployments/sara_verified_local_v1/scripts/verify_partner_screening_artifact.sh
+++ b/deployments/sara_verified_local_v1/scripts/verify_partner_screening_artifact.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage:
+  verify_partner_screening_artifact.sh <partner-screening-batch.zip|extracted-package-dir> [expected-artifact-sha256]
+
+Purpose:
+  Verify a downloaded or extracted Worldshepherd partner-screening artifact before review or sharing.
+
+Inputs:
+  <partner-screening-batch.zip|extracted-package-dir>
+      A GitHub Actions artifact ZIP, an extracted batch directory containing batch-manifest.json,
+      or one partner package directory containing manifest.json.
+
+  [expected-artifact-sha256]
+      Optional SHA-256 digest for the ZIP. Accepts either '<hex>' or 'sha256:<hex>'.
+      Use this with the digest shown by GitHub Actions for the downloaded artifact.
+
+Claims boundary:
+  This script verifies file integrity and manifest consistency only. It does not establish partner
+  validation, supplier approval, certification, CMMC/NIST/DFARS conformity, classified access,
+  external reproduction, field performance, hardware performance, or operational authority.
+USAGE
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+INPUT=$1
+EXPECTED_DIGEST=${2:-}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd -P)
+TMP_DIR=""
+
+cleanup() {
+  if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+normalize_digest() {
+  local value=$1
+  value=${value#sha256:}
+  printf '%s' "$value"
+}
+
+resolve_artifact_root() {
+  local root=$1
+
+  if [[ -f "$root/batch-manifest.json" || -f "$root/manifest.json" ]]; then
+    printf '%s' "$root"
+    return 0
+  fi
+
+  if [[ -d "$root/partner_screening_ci" ]]; then
+    if [[ -f "$root/partner_screening_ci/batch-manifest.json" || -f "$root/partner_screening_ci/manifest.json" ]]; then
+      printf '%s' "$root/partner_screening_ci"
+      return 0
+    fi
+  fi
+
+  mapfile -t candidates < <(find "$root" -maxdepth 3 \( -name batch-manifest.json -o -name manifest.json \) -type f | sort)
+  if [[ ${#candidates[@]} -eq 1 ]]; then
+    dirname "${candidates[0]}"
+    return 0
+  fi
+
+  fail "could not resolve a unique partner-screening manifest under $root"
+}
+
+if [[ -f "$INPUT" ]]; then
+  INPUT_ABS=$(cd "$(dirname "$INPUT")" && pwd -P)/$(basename "$INPUT")
+  case "$INPUT_ABS" in
+    *.zip) ;;
+    *) fail "file input must be a .zip artifact: $INPUT_ABS" ;;
+  esac
+
+  if [[ -n "$EXPECTED_DIGEST" ]]; then
+    command -v sha256sum >/dev/null || fail "sha256sum is required to compare the artifact ZIP digest"
+    EXPECTED_HEX=$(normalize_digest "$EXPECTED_DIGEST")
+    ACTUAL_HEX=$(sha256sum "$INPUT_ABS" | awk '{print $1}')
+    if [[ "$ACTUAL_HEX" != "$EXPECTED_HEX" ]]; then
+      fail "artifact ZIP digest mismatch: expected sha256:$EXPECTED_HEX, got sha256:$ACTUAL_HEX"
+    fi
+  fi
+
+  command -v unzip >/dev/null || fail "unzip is required to inspect artifact ZIP files"
+  TMP_DIR=$(mktemp -d)
+  unzip -q "$INPUT_ABS" -d "$TMP_DIR"
+  ARTIFACT_ROOT=$(resolve_artifact_root "$TMP_DIR")
+elif [[ -d "$INPUT" ]]; then
+  ARTIFACT_ROOT=$(cd "$INPUT" && pwd -P)
+  ARTIFACT_ROOT=$(resolve_artifact_root "$ARTIFACT_ROOT")
+else
+  fail "input does not exist: $INPUT"
+fi
+
+if [[ -f "$ARTIFACT_ROOT/batch-manifest.json" ]]; then
+  MODE="--batch"
+elif [[ -f "$ARTIFACT_ROOT/manifest.json" ]]; then
+  MODE="--package"
+else
+  fail "resolved artifact root has neither batch-manifest.json nor manifest.json: $ARTIFACT_ROOT"
+fi
+
+if command -v ws-partner-screening-verify >/dev/null; then
+  ws-partner-screening-verify "$MODE" "$ARTIFACT_ROOT"
+else
+  (cd "$PROJECT_ROOT" && python -m worldshepherd_sara.partner_screening_verify_cli "$MODE" "$ARTIFACT_ROOT")
+fi

--- a/deployments/sara_verified_local_v1/tests/test_verify_partner_screening_artifact_script.py
+++ b/deployments/sara_verified_local_v1/tests/test_verify_partner_screening_artifact_script.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+from worldshepherd_sara.geo_provenance import build_geo_prov_bundle
+from worldshepherd_sara.partner_screening_cli import export_partner_screening_batch
+from worldshepherd_sara.pre_bloom_cli import _write_json
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = PROJECT_ROOT / "scripts" / "verify_partner_screening_artifact.sh"
+
+
+def _make_batch_export(tmp_path: Path) -> Path:
+    bundle_dir = tmp_path / "bundles"
+    bundle_dir.mkdir()
+    bundle = build_geo_prov_bundle(
+        software_commit="downloaded-artifact-script-test",
+        executed_utc="2026-09-01T17:00:00Z",
+        operator="pytest",
+    )
+    _write_json(bundle_dir / "geo_prov_qualification_bundle.json", bundle)
+    out_dir = tmp_path / "partner_screening_ci"
+    export_partner_screening_batch(bundle_dir, out_dir, partners=["BAE_SYSTEMS", "GENERIC_PRIME"])
+    return out_dir
+
+
+def _zip_tree(source_dir: Path, zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(source_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(source_dir).as_posix())
+
+
+def test_downloaded_artifact_script_verifies_extracted_batch(tmp_path: Path) -> None:
+    batch_dir = _make_batch_export(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(batch_dir)],
+        cwd=PROJECT_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    report = json.loads(result.stdout)
+    assert report["status"] == "PASS"
+    assert report["verification_scope"] == "partner_screening_batch"
+    assert report["verified_package_count"] == report["package_count"]
+
+
+def test_downloaded_artifact_script_verifies_zip_and_expected_digest(tmp_path: Path) -> None:
+    if shutil.which("unzip") is None:
+        raise AssertionError("unzip must be available in CI to verify downloaded artifacts")
+
+    batch_dir = _make_batch_export(tmp_path)
+    zip_path = tmp_path / "partner-screening-batch-evidence.zip"
+    _zip_tree(batch_dir, zip_path)
+    digest = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(zip_path), f"sha256:{digest}"],
+        cwd=PROJECT_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    report = json.loads(result.stdout)
+    assert report["status"] == "PASS"
+    assert report["verification_scope"] == "partner_screening_batch"
+
+
+def test_downloaded_artifact_script_rejects_wrong_zip_digest(tmp_path: Path) -> None:
+    if shutil.which("unzip") is None:
+        raise AssertionError("unzip must be available in CI to verify downloaded artifacts")
+
+    batch_dir = _make_batch_export(tmp_path)
+    zip_path = tmp_path / "partner-screening-batch-evidence.zip"
+    _zip_tree(batch_dir, zip_path)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(zip_path), "sha256:" + "0" * 64],
+        cwd=PROJECT_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "artifact ZIP digest mismatch" in result.stderr

--- a/deployments/sara_verified_local_v1/tests/test_verify_partner_screening_artifact_script.py
+++ b/deployments/sara_verified_local_v1/tests/test_verify_partner_screening_artifact_script.py
@@ -6,14 +6,18 @@ import shutil
 import subprocess
 import zipfile
 from pathlib import Path
+from typing import Any
 
 from worldshepherd_sara.geo_provenance import build_geo_prov_bundle
 from worldshepherd_sara.partner_screening_cli import export_partner_screening_batch
-from worldshepherd_sara.pre_bloom_cli import _write_json
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = PROJECT_ROOT / "scripts" / "verify_partner_screening_artifact.sh"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 
 
 def _make_batch_export(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

Adds a reviewer-facing downloaded-artifact verification path for partner-screening batch evidence.

## Added/changed

- Adds `scripts/verify_partner_screening_artifact.sh`.
- Supports verifying either a downloaded GitHub Actions artifact ZIP or an extracted package directory.
- Supports optional comparison against the GitHub-displayed artifact SHA-256 digest.
- Runs `ws-partner-screening-verify` against the resolved batch or package manifest.
- Adds tests for extracted-directory verification, ZIP verification with matching digest, and rejection with wrong digest.
- Updates the SARA Verified Local v1 Gate to exercise the reviewer script after batch export and during install/help validation.
- Adds a documentation record for the downloaded-artifact verification workflow.

## Claims boundary

This PR verifies artifact custody and manifest/file digest integrity only. It does **not** claim BAE interest, partner validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / CI-GENERATED AND LOCALLY VERIFIABLE SCREENING PACKAGE / REQUIRES EXTERNAL VALIDATION`