### PR TITLE
Add CI release evidence index artifact

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -42,10 +42,12 @@ jobs:
           command -v ws-partner-screening
           command -v ws-partner-screening-batch
           command -v ws-partner-screening-verify
+          command -v ws-release-index
           ws-pre-bloom --help >/dev/null
           ws-partner-screening --help >/dev/null
           ws-partner-screening-batch --help >/dev/null
           ws-partner-screening-verify --help >/dev/null
+          ws-release-index --help >/dev/null
           bash scripts/verify_partner_screening_artifact.sh --help >/dev/null
 
       - name: Upload dependency resolution evidence
@@ -115,6 +117,7 @@ jobs:
           bash scripts/verify_partner_screening_artifact.sh partner_screening_ci >/dev/null
 
       - name: Upload PRE qualification evidence
+        id: upload_pre_qualification_evidence
         uses: actions/upload-artifact@v4
         with:
           name: pre-full-bloom-qualification-evidence
@@ -122,6 +125,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload partner-screening package evidence
+        id: upload_partner_screening_evidence
         uses: actions/upload-artifact@v4
         with:
           name: partner-screening-batch-evidence
@@ -160,6 +164,7 @@ jobs:
           PY
 
       - name: Upload recovery evidence
+        id: upload_recovery_evidence
         uses: actions/upload-artifact@v4
         with:
           name: sara-recovery-exercise-evidence
@@ -167,10 +172,72 @@ jobs:
           if-no-files-found: error
 
       - name: Upload operational snapshot evidence
+        id: upload_operational_snapshot_evidence
         uses: actions/upload-artifact@v4
         with:
           name: sara-operational-snapshot-evidence
           path: deployments/sara_verified_local_v1/operations_evidence
+          if-no-files-found: error
+
+      - name: Build release evidence index
+        env:
+          PRE_ARTIFACT_ID: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-id }}
+          PRE_ARTIFACT_DIGEST: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-digest }}
+          PRE_ARTIFACT_URL: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-url }}
+          PARTNER_ARTIFACT_ID: ${{ steps.upload_partner_screening_evidence.outputs.artifact-id }}
+          PARTNER_ARTIFACT_DIGEST: ${{ steps.upload_partner_screening_evidence.outputs.artifact-digest }}
+          PARTNER_ARTIFACT_URL: ${{ steps.upload_partner_screening_evidence.outputs.artifact-url }}
+        run: |
+          rm -rf release_index_ci
+          PR_NUMBER=""
+          MERGE_STATE="POST_MERGE_OR_MANUAL_RUN"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            PR_NUMBER=$(python - <<'PY'
+          import json, os
+          event=json.load(open(os.environ['GITHUB_EVENT_PATH'], encoding='utf-8'))
+          print(event.get('number') or event.get('pull_request', {}).get('number') or '')
+          PY
+          )
+            MERGE_STATE="PR_CANDIDATE_UNMERGED"
+          fi
+          ws-release-index \
+            --out release_index_ci/release-index.json \
+            --pre-dir qualification_evidence_ci \
+            --partner-dir partner_screening_ci \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit-sha "$GITHUB_SHA" \
+            --workflow-name "$GITHUB_WORKFLOW" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-number "$GITHUB_RUN_NUMBER" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --ref "$GITHUB_REF" \
+            --pr-number "$PR_NUMBER" \
+            --merge-state "$MERGE_STATE" \
+            --pre-artifact-id "$PRE_ARTIFACT_ID" \
+            --pre-artifact-digest "$PRE_ARTIFACT_DIGEST" \
+            --pre-artifact-url "$PRE_ARTIFACT_URL" \
+            --partner-artifact-id "$PARTNER_ARTIFACT_ID" \
+            --partner-artifact-digest "$PARTNER_ARTIFACT_DIGEST" \
+            --partner-artifact-url "$PARTNER_ARTIFACT_URL" \
+            --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >/dev/null
+          test -s release_index_ci/release-index.json
+          python -m json.tool release_index_ci/release-index.json >/dev/null
+          python - <<'PY'
+          import json
+          record=json.load(open('release_index_ci/release-index.json', encoding='utf-8'))
+          assert record['schema'] == 'WS-SARA-RELEASE-EVIDENCE-INDEX-V1'
+          assert record['artifacts']['pre_full_bloom_qualification_evidence']['artifact_digest'].startswith('sha256:')
+          assert record['artifacts']['partner_screening_batch_evidence']['artifact_digest'].startswith('sha256:')
+          assert record['release_index_digest'].startswith('sha256:')
+          assert 'does not establish partner validation' in record['claims_boundary']
+          PY
+
+      - name: Upload release evidence index
+        id: upload_release_evidence_index
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-release-evidence-index
+          path: deployments/sara_verified_local_v1/release_index_ci
           if-no-files-found: error
 
       - name: Capture container logs on failure

--- a/deployments/sara_verified_local_v1/docs/WS_RELEASE_EVIDENCE_INDEX_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_RELEASE_EVIDENCE_INDEX_2026-09-01.md
@@ -1,0 +1,137 @@
+# WS Release Evidence Index — 2026-09-01
+
+## Purpose
+
+Add a machine-readable release evidence index to the SARA Verified Local v1 Gate.
+
+The index ties one CI run to the evidence artifacts it produced so the Worldshepherd review path has a single custody record for:
+
+- repository;
+- commit SHA;
+- workflow name;
+- workflow run ID;
+- workflow run number;
+- event name;
+- ref;
+- pull request number where available;
+- merge-state label;
+- PRE full-bloom artifact ID, URL, and SHA-256 artifact digest;
+- partner-screening batch artifact ID, URL, and SHA-256 artifact digest;
+- local qualification-index digest;
+- local partner batch-manifest digest;
+- partner package count;
+- partner presets;
+- partner lanes;
+- release-index digest.
+
+## New command
+
+```bash
+ws-release-index \
+  --out release_index_ci/release-index.json \
+  --pre-dir qualification_evidence_ci \
+  --partner-dir partner_screening_ci \
+  --repository "$GITHUB_REPOSITORY" \
+  --commit-sha "$GITHUB_SHA" \
+  --workflow-name "$GITHUB_WORKFLOW" \
+  --workflow-run-id "$GITHUB_RUN_ID" \
+  --workflow-run-number "$GITHUB_RUN_NUMBER" \
+  --event-name "$GITHUB_EVENT_NAME" \
+  --ref "$GITHUB_REF" \
+  --pr-number "$PR_NUMBER" \
+  --merge-state "$MERGE_STATE" \
+  --pre-artifact-id "$PRE_ARTIFACT_ID" \
+  --pre-artifact-digest "$PRE_ARTIFACT_DIGEST" \
+  --pre-artifact-url "$PRE_ARTIFACT_URL" \
+  --partner-artifact-id "$PARTNER_ARTIFACT_ID" \
+  --partner-artifact-digest "$PARTNER_ARTIFACT_DIGEST" \
+  --partner-artifact-url "$PARTNER_ARTIFACT_URL"
+```
+
+## CI artifact
+
+The workflow now uploads:
+
+```text
+sara-release-evidence-index
+```
+
+The artifact contains:
+
+```text
+release-index.json
+```
+
+## Schema
+
+```text
+WS-SARA-RELEASE-EVIDENCE-INDEX-V1
+```
+
+Core fields:
+
+```json
+{
+  "schema": "WS-SARA-RELEASE-EVIDENCE-INDEX-V1",
+  "repository": "Bdavis1390/Sara_pro",
+  "commit_sha": "<GITHUB_SHA>",
+  "workflow": {
+    "name": "SARA Verified Local v1 Gate",
+    "run_id": "<GITHUB_RUN_ID>",
+    "run_number": "<GITHUB_RUN_NUMBER>",
+    "event_name": "pull_request|push|workflow_dispatch",
+    "ref": "<GITHUB_REF>",
+    "pull_request_number": "<PR number or null>",
+    "merge_state": "PR_CANDIDATE_UNMERGED|POST_MERGE_OR_MANUAL_RUN"
+  },
+  "artifacts": {
+    "pre_full_bloom_qualification_evidence": {
+      "artifact_id": "<upload-artifact id>",
+      "artifact_digest": "sha256:<digest>",
+      "artifact_url": "<upload-artifact url>"
+    },
+    "partner_screening_batch_evidence": {
+      "artifact_id": "<upload-artifact id>",
+      "artifact_digest": "sha256:<digest>",
+      "artifact_url": "<upload-artifact url>"
+    }
+  },
+  "local_evidence": {
+    "qualification_index_sha256": "sha256:<digest>",
+    "partner_batch_manifest_sha256": "sha256:<digest>",
+    "partner_batch_digest": "sha256:<canonical batch digest>",
+    "partner_package_count": 0,
+    "partner_source_bundle_count": 0,
+    "partner_presets": [],
+    "partner_lanes": []
+  },
+  "release_index_digest": "sha256:<canonical index digest>"
+}
+```
+
+## Claims boundary
+
+This artifact records CI evidence custody only.
+
+It does **not** establish partner interest, partner validation, BAE validation, supplier approval, certification, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, external reproduction, field performance, hardware performance, export-control clearance, or operational authority.
+
+## Worldshepherd readiness effect
+
+This closes the release-index gap between generated evidence artifacts and review/disclosure discipline.
+
+The resulting path becomes:
+
+```text
+PRE full-bloom evidence
+→ partner-screening batch evidence
+→ manifest/file verification
+→ downloaded-artifact verification
+→ release evidence index
+→ reviewer can map run ⇄ commit ⇄ artifacts ⇄ digests ⇄ PR state
+```
+
+Current maturity remains:
+
+```text
+INTERNAL SOFTWARE EVIDENCE / CI-GENERATED RELEASE INDEX / REQUIRES EXTERNAL VALIDATION
+```

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -26,6 +26,7 @@ ws-bae-geo-screening = "worldshepherd_sara.bae_geo_screening_cli:main"
 ws-partner-screening = "worldshepherd_sara.partner_screening_cli:main"
 ws-partner-screening-batch = "worldshepherd_sara.partner_screening_cli:batch_main"
 ws-partner-screening-verify = "worldshepherd_sara.partner_screening_verify_cli:main"
+ws-release-index = "worldshepherd_sara.release_index_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldshepherd_sara.release_index_cli import RELEASE_INDEX_SCHEMA, build_release_evidence_index, main
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _make_evidence_dirs(tmp_path):
+    pre_dir = tmp_path / "qualification_evidence_ci"
+    partner_dir = tmp_path / "partner_screening_ci"
+    _write_json(
+        pre_dir / "qualification_index.json",
+        {
+            "schema": "WS-PRE-FULL-BLOOM-QUALIFICATION-INDEX-V1",
+            "bundle_digests": {"apnt": "sha256:" + "1" * 64},
+            "claims_boundary": ["No external reproduction or partner validation claim."],
+        },
+    )
+    _write_json(
+        partner_dir / "batch-manifest.json",
+        {
+            "schema": "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1",
+            "partners": ["BAE_SYSTEMS", "GENERIC_PRIME"],
+            "lanes": ["apnt", "geo_prov"],
+            "source_bundle_count": 2,
+            "package_count": 4,
+            "batch_digest": "sha256:" + "2" * 64,
+            "claims_boundary": "Batch screening export only; no partner validation claim.",
+        },
+    )
+    return pre_dir, partner_dir
+
+
+def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> None:
+    pre_dir, partner_dir = _make_evidence_dirs(tmp_path)
+
+    index = build_release_evidence_index(
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        workflow_name="SARA Verified Local v1 Gate",
+        workflow_run_id="33500000000",
+        workflow_run_number="653",
+        event_name="pull_request",
+        ref="refs/pull/44/merge",
+        pr_number="44",
+        merge_state="PR_CANDIDATE_UNMERGED",
+        pre_dir=pre_dir,
+        partner_dir=partner_dir,
+        pre_artifact_id="111",
+        pre_artifact_digest="sha256:" + "a" * 64,
+        pre_artifact_url="https://github.example/pre",
+        partner_artifact_id="222",
+        partner_artifact_digest="b" * 64,
+        partner_artifact_url="https://github.example/partner",
+        executed_utc="2026-09-01T17:10:00Z",
+    )
+
+    assert index["schema"] == RELEASE_INDEX_SCHEMA
+    assert index["commit_sha"] == "abc123"
+    assert index["workflow"]["pull_request_number"] == "44"
+    assert index["workflow"]["merge_state"] == "PR_CANDIDATE_UNMERGED"
+    assert index["artifacts"]["pre_full_bloom_qualification_evidence"]["artifact_digest"] == "sha256:" + "a" * 64
+    assert index["artifacts"]["partner_screening_batch_evidence"]["artifact_digest"] == "sha256:" + "b" * 64
+    assert index["local_evidence"]["partner_batch_digest"] == "sha256:" + "2" * 64
+    assert index["local_evidence"]["partner_package_count"] == 4
+    assert index["local_evidence"]["partner_presets"] == ["BAE_SYSTEMS", "GENERIC_PRIME"]
+    assert index["release_index_digest"].startswith("sha256:")
+    assert "does not establish partner validation" in index["claims_boundary"]
+
+
+def test_release_index_cli_writes_index_file(tmp_path) -> None:
+    pre_dir, partner_dir = _make_evidence_dirs(tmp_path)
+    out_path = tmp_path / "release_index_ci" / "release-index.json"
+
+    exit_code = main(
+        [
+            "--out",
+            str(out_path),
+            "--pre-dir",
+            str(pre_dir),
+            "--partner-dir",
+            str(partner_dir),
+            "--repository",
+            "Bdavis1390/Sara_pro",
+            "--commit-sha",
+            "abc123",
+            "--workflow-name",
+            "SARA Verified Local v1 Gate",
+            "--workflow-run-id",
+            "33500000001",
+            "--workflow-run-number",
+            "654",
+            "--event-name",
+            "push",
+            "--ref",
+            "refs/heads/main",
+            "--merge-state",
+            "POST_MERGE_OR_MANUAL_RUN",
+            "--pre-artifact-id",
+            "111",
+            "--pre-artifact-digest",
+            "sha256:" + "c" * 64,
+            "--partner-artifact-id",
+            "222",
+            "--partner-artifact-digest",
+            "sha256:" + "d" * 64,
+            "--executed-utc",
+            "2026-09-01T17:11:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    written = json.loads(out_path.read_text(encoding="utf-8"))
+    assert written["schema"] == RELEASE_INDEX_SCHEMA
+    assert written["workflow"]["event_name"] == "push"
+    assert written["workflow"]["merge_state"] == "POST_MERGE_OR_MANUAL_RUN"
+
+
+def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
+    pre_dir, partner_dir = _make_evidence_dirs(tmp_path)
+
+    with pytest.raises(ValueError, match="must be a SHA-256 digest"):
+        build_release_evidence_index(
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            workflow_name="SARA Verified Local v1 Gate",
+            workflow_run_id="33500000002",
+            workflow_run_number="655",
+            event_name="pull_request",
+            ref="refs/pull/44/merge",
+            pr_number="44",
+            merge_state="PR_CANDIDATE_UNMERGED",
+            pre_dir=pre_dir,
+            partner_dir=partner_dir,
+            pre_artifact_id="111",
+            pre_artifact_digest="not-a-digest",
+            pre_artifact_url=None,
+            partner_artifact_id="222",
+            partner_artifact_digest="sha256:" + "e" * 64,
+            partner_artifact_url=None,
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .qualification import canonical_digest
+
+RELEASE_INDEX_SCHEMA = "WS-SARA-RELEASE-EVIDENCE-INDEX-V1"
+
+CLAIMS_BOUNDARY = (
+    "Release index records CI evidence custody only. It does not establish partner validation, "
+    "supplier approval, certification, CMMC/NIST/DFARS conformity, classified access, DOE validation, "
+    "external reproduction, field performance, hardware performance, export-control clearance, or operational authority."
+)
+
+
+def _json_text(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_text(value), encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"required JSON file missing: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"required file missing for digest: {path}")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _normalize_digest(value: str | None, *, field: str, required: bool = True) -> str | None:
+    if value is None or value == "":
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    raw = str(value).strip()
+    if raw.startswith("sha256:"):
+        hex_value = raw[len("sha256:") :]
+    else:
+        hex_value = raw
+    if len(hex_value) != 64 or any(ch not in "0123456789abcdefABCDEF" for ch in hex_value):
+        raise ValueError(f"{field} must be a SHA-256 digest")
+    return f"sha256:{hex_value.lower()}"
+
+
+def _artifact_record(*, name: str, artifact_id: str | None, digest: str | None, url: str | None, required: bool = True) -> dict[str, Any]:
+    normalized = _normalize_digest(digest, field=f"{name}.digest", required=required)
+    return {
+        "name": name,
+        "artifact_id": artifact_id or None,
+        "artifact_digest": normalized,
+        "artifact_url": url or None,
+    }
+
+
+def build_release_evidence_index(
+    *,
+    repository: str,
+    commit_sha: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    workflow_run_number: str,
+    event_name: str,
+    ref: str,
+    pr_number: str | None,
+    merge_state: str,
+    pre_dir: Path,
+    partner_dir: Path,
+    pre_artifact_id: str | None,
+    pre_artifact_digest: str | None,
+    pre_artifact_url: str | None,
+    partner_artifact_id: str | None,
+    partner_artifact_digest: str | None,
+    partner_artifact_url: str | None,
+    executed_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build a machine-readable release evidence index for one SARA CI run."""
+    if not commit_sha:
+        raise ValueError("commit_sha is required")
+    pre_root = Path(pre_dir)
+    partner_root = Path(partner_dir)
+    qualification_index = _load_json(pre_root / "qualification_index.json")
+    partner_batch_manifest = _load_json(partner_root / "batch-manifest.json")
+
+    if partner_batch_manifest.get("schema") != "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1":
+        raise ValueError("unexpected partner batch manifest schema")
+    if qualification_index.get("schema") is None:
+        raise ValueError("qualification index missing schema")
+
+    generated_at = executed_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    pre_artifact = _artifact_record(
+        name="pre-full-bloom-qualification-evidence",
+        artifact_id=pre_artifact_id,
+        digest=pre_artifact_digest,
+        url=pre_artifact_url,
+    )
+    partner_artifact = _artifact_record(
+        name="partner-screening-batch-evidence",
+        artifact_id=partner_artifact_id,
+        digest=partner_artifact_digest,
+        url=partner_artifact_url,
+    )
+
+    index: dict[str, Any] = {
+        "schema": RELEASE_INDEX_SCHEMA,
+        "generated_utc": generated_at,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "workflow": {
+            "name": workflow_name,
+            "run_id": workflow_run_id,
+            "run_number": workflow_run_number,
+            "event_name": event_name,
+            "ref": ref,
+            "pull_request_number": pr_number or None,
+            "merge_state": merge_state,
+        },
+        "artifacts": {
+            "pre_full_bloom_qualification_evidence": pre_artifact,
+            "partner_screening_batch_evidence": partner_artifact,
+        },
+        "local_evidence": {
+            "qualification_index_path": str(pre_root / "qualification_index.json"),
+            "qualification_index_sha256": _sha256_file(pre_root / "qualification_index.json"),
+            "partner_batch_manifest_path": str(partner_root / "batch-manifest.json"),
+            "partner_batch_manifest_sha256": _sha256_file(partner_root / "batch-manifest.json"),
+            "partner_batch_digest": partner_batch_manifest.get("batch_digest"),
+            "partner_package_count": partner_batch_manifest.get("package_count"),
+            "partner_source_bundle_count": partner_batch_manifest.get("source_bundle_count"),
+            "partner_presets": partner_batch_manifest.get("partners", []),
+            "partner_lanes": partner_batch_manifest.get("lanes", []),
+        },
+        "claims_boundary": CLAIMS_BOUNDARY,
+    }
+    index["release_index_digest"] = canonical_digest(index)
+    return index
+
+
+def _pr_number_from_event(path: str | None) -> str | None:
+    if not path:
+        return None
+    event_path = Path(path)
+    if not event_path.is_file():
+        return None
+    event = _load_json(event_path)
+    number = event.get("number") or event.get("pull_request", {}).get("number")
+    return str(number) if number else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build SARA release evidence index JSON for a CI run.")
+    parser.add_argument("--out", type=Path, required=True, help="Output release-index.json path.")
+    parser.add_argument("--pre-dir", type=Path, required=True, help="Directory containing PRE full-bloom evidence.")
+    parser.add_argument("--partner-dir", type=Path, required=True, help="Directory containing partner-screening batch evidence.")
+    parser.add_argument("--repository", default=os.getenv("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--commit-sha", default=os.getenv("GITHUB_SHA", ""))
+    parser.add_argument("--workflow-name", default=os.getenv("GITHUB_WORKFLOW", ""))
+    parser.add_argument("--workflow-run-id", default=os.getenv("GITHUB_RUN_ID", ""))
+    parser.add_argument("--workflow-run-number", default=os.getenv("GITHUB_RUN_NUMBER", ""))
+    parser.add_argument("--event-name", default=os.getenv("GITHUB_EVENT_NAME", ""))
+    parser.add_argument("--ref", default=os.getenv("GITHUB_REF", ""))
+    parser.add_argument("--pr-number", default=None)
+    parser.add_argument("--merge-state", default=None)
+    parser.add_argument("--pre-artifact-id", default=None)
+    parser.add_argument("--pre-artifact-digest", default=None)
+    parser.add_argument("--pre-artifact-url", default=None)
+    parser.add_argument("--partner-artifact-id", default=None)
+    parser.add_argument("--partner-artifact-digest", default=None)
+    parser.add_argument("--partner-artifact-url", default=None)
+    parser.add_argument("--executed-utc", default=None)
+    args = parser.parse_args(argv)
+
+    pr_number = args.pr_number or _pr_number_from_event(os.getenv("GITHUB_EVENT_PATH"))
+    merge_state = args.merge_state
+    if merge_state is None:
+        merge_state = "PR_CANDIDATE_UNMERGED" if args.event_name == "pull_request" else "POST_MERGE_OR_MANUAL_RUN"
+
+    index = build_release_evidence_index(
+        repository=args.repository,
+        commit_sha=args.commit_sha,
+        workflow_name=args.workflow_name,
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_number=args.workflow_run_number,
+        event_name=args.event_name,
+        ref=args.ref,
+        pr_number=pr_number,
+        merge_state=merge_state,
+        pre_dir=args.pre_dir,
+        partner_dir=args.partner_dir,
+        pre_artifact_id=args.pre_artifact_id,
+        pre_artifact_digest=args.pre_artifact_digest,
+        pre_artifact_url=args.pre_artifact_url,
+        partner_artifact_id=args.partner_artifact_id,
+        partner_artifact_digest=args.partner_artifact_digest,
+        partner_artifact_url=args.partner_artifact_url,
+        executed_utc=args.executed_utc,
+    )
+    _write_json(args.out, index)
+    print(_json_text(index), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a machine-readable release evidence index artifact to the SARA Verified Local v1 Gate.

## Added/changed

- Adds `release_index_cli.py`.
- Exposes `ws-release-index` as a console script.
- Records repository, commit SHA, workflow name, run ID, run number, event, ref, PR number, and merge-state label.
- Records PRE full-bloom artifact ID, URL, and SHA-256 artifact digest.
- Records partner-screening batch artifact ID, URL, and SHA-256 artifact digest.
- Records local qualification-index and partner batch-manifest SHA-256 digests.
- Records partner batch digest, package count, source-bundle count, partner presets, and lanes.
- Adds tests for release-index generation, CLI output, digest normalization, and bad-digest rejection.
- Updates CI to generate and upload `sara-release-evidence-index` after the existing evidence uploads and hard verification gates.
- Adds a documentation record for the release evidence index.

## Claims boundary

This PR records CI evidence custody only. It does **not** claim BAE interest, partner validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / CI-GENERATED RELEASE INDEX / REQUIRES EXTERNAL VALIDATION`