### PR TITLE
Verify post-merge release index state

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           rm -rf release_index_ci
           PR_NUMBER=""
-          MERGE_STATE="POST_MERGE_OR_MANUAL_RUN"
+          MERGE_STATE="MANUAL_OR_NON_MAIN_RUN"
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             PR_NUMBER=$(python - <<'PY'
           import json, os
@@ -199,6 +199,8 @@ jobs:
           PY
           )
             MERGE_STATE="PR_CANDIDATE_UNMERGED"
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            MERGE_STATE="MERGED_MAIN_PUSH"
           fi
           ws-release-index \
             --out release_index_ci/release-index.json \
@@ -223,13 +225,24 @@ jobs:
           test -s release_index_ci/release-index.json
           python -m json.tool release_index_ci/release-index.json >/dev/null
           python - <<'PY'
-          import json
+          import json, os
           record=json.load(open('release_index_ci/release-index.json', encoding='utf-8'))
           assert record['schema'] == 'WS-SARA-RELEASE-EVIDENCE-INDEX-V1'
           assert record['artifacts']['pre_full_bloom_qualification_evidence']['artifact_digest'].startswith('sha256:')
           assert record['artifacts']['partner_screening_batch_evidence']['artifact_digest'].startswith('sha256:')
           assert record['release_index_digest'].startswith('sha256:')
           assert 'does not establish partner validation' in record['claims_boundary']
+          merge_state = record['workflow']['merge_state']
+          event_name = record['workflow']['event_name']
+          ref = record['workflow']['ref']
+          if event_name == 'pull_request':
+              assert merge_state == 'PR_CANDIDATE_UNMERGED'
+              assert record['workflow']['pull_request_number']
+          elif event_name == 'push' and ref == 'refs/heads/main':
+              assert merge_state == 'MERGED_MAIN_PUSH'
+              assert record['workflow']['pull_request_number'] is None
+          else:
+              assert merge_state == 'MANUAL_OR_NON_MAIN_RUN'
           PY
 
       - name: Upload release evidence index

--- a/deployments/sara_verified_local_v1/docs/WS_POST_MERGE_RELEASE_INDEX_VERIFY_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_POST_MERGE_RELEASE_INDEX_VERIFY_2026-09-01.md
@@ -1,0 +1,104 @@
+# WS Post-Merge Release Index Verification — 2026-09-01
+
+## Purpose
+
+This record documents the post-merge release-index verification patch for the Worldshepherd/SARA Verified Local v1 evidence path.
+
+The prior release-index path generated a machine-readable `release-index.json` in PR runs and non-PR runs, but non-PR runs used a broad merge-state label:
+
+```text
+POST_MERGE_OR_MANUAL_RUN
+```
+
+That was useful, but not precise enough to distinguish a merged `main` push from a manual or non-main run.
+
+This patch adds explicit release-state separation so the post-merge `main` run can be verified independently.
+
+## Added release states
+
+```text
+PR_CANDIDATE_UNMERGED
+MERGED_MAIN_PUSH
+MANUAL_OR_NON_MAIN_RUN
+```
+
+## Derivation rule
+
+```text
+if GITHUB_EVENT_NAME == pull_request:
+    merge_state = PR_CANDIDATE_UNMERGED
+elif GITHUB_EVENT_NAME == push and GITHUB_REF == refs/heads/main:
+    merge_state = MERGED_MAIN_PUSH
+else:
+    merge_state = MANUAL_OR_NON_MAIN_RUN
+```
+
+## Validation rule
+
+The release-index builder rejects mismatches between the supplied merge-state label and the event/ref context.
+
+Examples:
+
+```text
+pull_request + refs/pull/<n>/merge => PR_CANDIDATE_UNMERGED
+push + refs/heads/main            => MERGED_MAIN_PUSH
+workflow_dispatch                 => MANUAL_OR_NON_MAIN_RUN
+push + non-main branch            => MANUAL_OR_NON_MAIN_RUN
+```
+
+## CI effect
+
+The SARA Verified Local v1 Gate now validates the generated `release-index.json` after the hard evidence gates:
+
+1. PRE full-bloom generation.
+2. Partner-screening batch export.
+3. Partner-screening manifest verification.
+4. Deployment verification.
+5. Destructive backup/restore.
+6. Operational snapshot.
+7. Observable release identity.
+8. Release-index build.
+9. Release-index event/ref/merge-state assertion.
+10. Release-index artifact upload.
+
+## Post-merge verification target
+
+After this PR merges, the push-triggered run on `main` must produce a `sara-release-evidence-index` artifact whose `release-index.json` contains:
+
+```json
+{
+  "workflow": {
+    "event_name": "push",
+    "ref": "refs/heads/main",
+    "pull_request_number": null,
+    "merge_state": "MERGED_MAIN_PUSH"
+  }
+}
+```
+
+That confirms the merged commit itself, not only the PR-candidate merge ref, generated a release-index artifact.
+
+## Claims boundary
+
+This patch verifies CI evidence custody and event/ref labeling only.
+
+It does not claim:
+
+- BAE interest;
+- partner validation;
+- supplier approval;
+- certification;
+- CMMC, NIST SP 800-171, or DFARS conformity;
+- classified access;
+- DOE validation;
+- field performance;
+- hardware performance;
+- external reproduction;
+- export-control clearance;
+- operational authority.
+
+## Current maturity label
+
+```text
+INTERNAL SOFTWARE EVIDENCE / PR-CANDIDATE AND POST-MERGE CI INDEXING / REQUIRES EXTERNAL VALIDATION
+```

--- a/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
@@ -4,7 +4,15 @@ import json
 
 import pytest
 
-from worldshepherd_sara.release_index_cli import RELEASE_INDEX_SCHEMA, build_release_evidence_index, main
+from worldshepherd_sara.release_index_cli import (
+    MERGE_STATE_MAIN_PUSH,
+    MERGE_STATE_MANUAL_OR_NON_MAIN,
+    MERGE_STATE_PR_CANDIDATE,
+    RELEASE_INDEX_SCHEMA,
+    build_release_evidence_index,
+    derive_merge_state,
+    main,
+)
 
 
 def _write_json(path, value):
@@ -50,7 +58,7 @@ def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> Non
         event_name="pull_request",
         ref="refs/pull/44/merge",
         pr_number="44",
-        merge_state="PR_CANDIDATE_UNMERGED",
+        merge_state=MERGE_STATE_PR_CANDIDATE,
         pre_dir=pre_dir,
         partner_dir=partner_dir,
         pre_artifact_id="111",
@@ -65,7 +73,7 @@ def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> Non
     assert index["schema"] == RELEASE_INDEX_SCHEMA
     assert index["commit_sha"] == "abc123"
     assert index["workflow"]["pull_request_number"] == "44"
-    assert index["workflow"]["merge_state"] == "PR_CANDIDATE_UNMERGED"
+    assert index["workflow"]["merge_state"] == MERGE_STATE_PR_CANDIDATE
     assert index["artifacts"]["pre_full_bloom_qualification_evidence"]["artifact_digest"] == "sha256:" + "a" * 64
     assert index["artifacts"]["partner_screening_batch_evidence"]["artifact_digest"] == "sha256:" + "b" * 64
     assert index["local_evidence"]["partner_batch_digest"] == "sha256:" + "2" * 64
@@ -75,7 +83,7 @@ def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> Non
     assert "does not establish partner validation" in index["claims_boundary"]
 
 
-def test_release_index_cli_writes_index_file(tmp_path) -> None:
+def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
     pre_dir, partner_dir = _make_evidence_dirs(tmp_path)
     out_path = tmp_path / "release_index_ci" / "release-index.json"
 
@@ -101,8 +109,6 @@ def test_release_index_cli_writes_index_file(tmp_path) -> None:
             "push",
             "--ref",
             "refs/heads/main",
-            "--merge-state",
-            "POST_MERGE_OR_MANUAL_RUN",
             "--pre-artifact-id",
             "111",
             "--pre-artifact-digest",
@@ -120,7 +126,14 @@ def test_release_index_cli_writes_index_file(tmp_path) -> None:
     written = json.loads(out_path.read_text(encoding="utf-8"))
     assert written["schema"] == RELEASE_INDEX_SCHEMA
     assert written["workflow"]["event_name"] == "push"
-    assert written["workflow"]["merge_state"] == "POST_MERGE_OR_MANUAL_RUN"
+    assert written["workflow"]["ref"] == "refs/heads/main"
+    assert written["workflow"]["pull_request_number"] is None
+    assert written["workflow"]["merge_state"] == MERGE_STATE_MAIN_PUSH
+
+
+def test_release_index_derives_manual_or_non_main_state() -> None:
+    assert derive_merge_state(event_name="workflow_dispatch", ref="refs/heads/main") == MERGE_STATE_MANUAL_OR_NON_MAIN
+    assert derive_merge_state(event_name="push", ref="refs/heads/feature") == MERGE_STATE_MANUAL_OR_NON_MAIN
 
 
 def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
@@ -136,11 +149,36 @@ def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
             event_name="pull_request",
             ref="refs/pull/44/merge",
             pr_number="44",
-            merge_state="PR_CANDIDATE_UNMERGED",
+            merge_state=MERGE_STATE_PR_CANDIDATE,
             pre_dir=pre_dir,
             partner_dir=partner_dir,
             pre_artifact_id="111",
             pre_artifact_digest="not-a-digest",
+            pre_artifact_url=None,
+            partner_artifact_id="222",
+            partner_artifact_digest="sha256:" + "e" * 64,
+            partner_artifact_url=None,
+        )
+
+
+def test_release_index_rejects_merge_state_mismatch(tmp_path) -> None:
+    pre_dir, partner_dir = _make_evidence_dirs(tmp_path)
+
+    with pytest.raises(ValueError, match="does not match event/ref context"):
+        build_release_evidence_index(
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            workflow_name="SARA Verified Local v1 Gate",
+            workflow_run_id="33500000003",
+            workflow_run_number="656",
+            event_name="push",
+            ref="refs/heads/main",
+            pr_number=None,
+            merge_state=MERGE_STATE_PR_CANDIDATE,
+            pre_dir=pre_dir,
+            partner_dir=partner_dir,
+            pre_artifact_id="111",
+            pre_artifact_digest="sha256:" + "f" * 64,
             pre_artifact_url=None,
             partner_artifact_id="222",
             partner_artifact_digest="sha256:" + "e" * 64,

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
@@ -196,6 +196,14 @@ def _pr_number_from_event(path: str | None) -> str | None:
     return str(number) if number else None
 
 
+def _resolve_pr_number(*, cli_value: str | None, event_name: str) -> str | None:
+    if cli_value is not None:
+        return cli_value or None
+    if event_name == "pull_request":
+        return _pr_number_from_event(os.getenv("GITHUB_EVENT_PATH"))
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build SARA release evidence index JSON for a CI run.")
     parser.add_argument("--out", type=Path, required=True, help="Output release-index.json path.")
@@ -219,7 +227,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--executed-utc", default=None)
     args = parser.parse_args(argv)
 
-    pr_number = args.pr_number or _pr_number_from_event(os.getenv("GITHUB_EVENT_PATH"))
+    pr_number = _resolve_pr_number(cli_value=args.pr_number, event_name=args.event_name)
     merge_state = args.merge_state or derive_merge_state(event_name=args.event_name, ref=args.ref)
 
     index = build_release_evidence_index(

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
@@ -11,6 +11,14 @@ from typing import Any
 from .qualification import canonical_digest
 
 RELEASE_INDEX_SCHEMA = "WS-SARA-RELEASE-EVIDENCE-INDEX-V1"
+MERGE_STATE_PR_CANDIDATE = "PR_CANDIDATE_UNMERGED"
+MERGE_STATE_MAIN_PUSH = "MERGED_MAIN_PUSH"
+MERGE_STATE_MANUAL_OR_NON_MAIN = "MANUAL_OR_NON_MAIN_RUN"
+ALLOWED_MERGE_STATES = {
+    MERGE_STATE_PR_CANDIDATE,
+    MERGE_STATE_MAIN_PUSH,
+    MERGE_STATE_MANUAL_OR_NON_MAIN,
+}
 
 CLAIMS_BOUNDARY = (
     "Release index records CI evidence custody only. It does not establish partner validation, "
@@ -69,6 +77,30 @@ def _artifact_record(*, name: str, artifact_id: str | None, digest: str | None, 
     }
 
 
+def derive_merge_state(*, event_name: str, ref: str) -> str:
+    """Derive the release-index merge-state label from GitHub event context."""
+    if event_name == "pull_request":
+        return MERGE_STATE_PR_CANDIDATE
+    if event_name == "push" and ref == "refs/heads/main":
+        return MERGE_STATE_MAIN_PUSH
+    return MERGE_STATE_MANUAL_OR_NON_MAIN
+
+
+def _validate_release_context(*, event_name: str, ref: str, pr_number: str | None, merge_state: str) -> None:
+    if merge_state not in ALLOWED_MERGE_STATES:
+        raise ValueError(f"merge_state must be one of {sorted(ALLOWED_MERGE_STATES)}")
+    expected = derive_merge_state(event_name=event_name, ref=ref)
+    if merge_state != expected:
+        raise ValueError(
+            f"merge_state {merge_state!r} does not match event/ref context; expected {expected!r} "
+            f"for event_name={event_name!r}, ref={ref!r}"
+        )
+    if merge_state == MERGE_STATE_PR_CANDIDATE and not pr_number:
+        raise ValueError("pull_request release indexes must include a PR number")
+    if merge_state == MERGE_STATE_MAIN_PUSH and pr_number:
+        raise ValueError("main push release indexes must not include a PR number")
+
+
 def build_release_evidence_index(
     *,
     repository: str,
@@ -93,6 +125,7 @@ def build_release_evidence_index(
     """Build a machine-readable release evidence index for one SARA CI run."""
     if not commit_sha:
         raise ValueError("commit_sha is required")
+    _validate_release_context(event_name=event_name, ref=ref, pr_number=pr_number, merge_state=merge_state)
     pre_root = Path(pre_dir)
     partner_root = Path(partner_dir)
     qualification_index = _load_json(pre_root / "qualification_index.json")
@@ -187,9 +220,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     pr_number = args.pr_number or _pr_number_from_event(os.getenv("GITHUB_EVENT_PATH"))
-    merge_state = args.merge_state
-    if merge_state is None:
-        merge_state = "PR_CANDIDATE_UNMERGED" if args.event_name == "pull_request" else "POST_MERGE_OR_MANUAL_RUN"
+    merge_state = args.merge_state or derive_merge_state(event_name=args.event_name, ref=args.ref)
 
     index = build_release_evidence_index(
         repository=args.repository,


### PR DESCRIPTION
## Summary

Adds explicit post-merge release-index verification so PR-candidate runs and merged `main` push runs are no longer conflated.

## Added/changed

- Adds explicit release-index merge states:
  - `PR_CANDIDATE_UNMERGED`
  - `MERGED_MAIN_PUSH`
  - `MANUAL_OR_NON_MAIN_RUN`
- Adds event/ref-derived merge-state validation in `release_index_cli.py`.
- Rejects mismatches such as `push` to `refs/heads/main` being labeled as a PR candidate.
- Requires pull-request release indexes to include a PR number.
- Requires merged-main push release indexes to have no PR number.
- Updates release-index tests for main-push derivation, manual/non-main derivation, and mismatch rejection.
- Updates the SARA Verified Local v1 Gate to assert release-index state based on `GITHUB_EVENT_NAME` and `GITHUB_REF`.
- Adds a documentation record for the post-merge verification target.

## Post-merge target

After this PR merges, the push-triggered run on `main` must produce `sara-release-evidence-index` with:

```json
{
  "workflow": {
    "event_name": "push",
    "ref": "refs/heads/main",
    "pull_request_number": null,
    "merge_state": "MERGED_MAIN_PUSH"
  }
}
```

## Claims boundary

This PR verifies CI evidence custody and event/ref labeling only. It does **not** claim BAE interest, partner validation, supplier approval, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, classified access, DOE validation, field performance, hardware performance, external reproduction, export-control clearance, or operational authority.

Current maturity remains:

`INTERNAL SOFTWARE EVIDENCE / PR-CANDIDATE AND POST-MERGE CI INDEXING / REQUIRES EXTERNAL VALIDATION`