### PR TITLE
Add vulnerability advisory evidence gate

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -40,12 +40,14 @@ jobs:
           python -m pip freeze --all | sort > dependency-freeze.txt
           command -v ws-pre-bloom
           command -v ws-sbom-evidence
+          command -v ws-vulnerability-evidence
           command -v ws-partner-screening
           command -v ws-partner-screening-batch
           command -v ws-partner-screening-verify
           command -v ws-release-index
           ws-pre-bloom --help >/dev/null
           ws-sbom-evidence --help >/dev/null
+          ws-vulnerability-evidence --help >/dev/null
           ws-partner-screening --help >/dev/null
           ws-partner-screening-batch --help >/dev/null
           ws-partner-screening-verify --help >/dev/null
@@ -92,6 +94,40 @@ jobs:
         with:
           name: software-sbom-evidence
           path: deployments/sara_verified_local_v1/sbom_evidence_ci
+          if-no-files-found: error
+
+      - name: Build vulnerability advisory evidence
+        run: |
+          rm -rf vulnerability_evidence_ci
+          ws-vulnerability-evidence \
+            --dependency-freeze dependency-freeze.txt \
+            --sbom sbom_evidence_ci/software-sbom.json \
+            --out vulnerability_evidence_ci \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit-sha "$GITHUB_SHA" \
+            --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --operator "github-actions"
+          test -s vulnerability_evidence_ci/vulnerability-advisory-report.json
+          test -s vulnerability_evidence_ci/vulnerability-evidence-summary.json
+          python -m json.tool vulnerability_evidence_ci/vulnerability-advisory-report.json >/dev/null
+          python -m json.tool vulnerability_evidence_ci/vulnerability-evidence-summary.json >/dev/null
+          python - <<'PY'
+          import json
+          summary=json.load(open('vulnerability_evidence_ci/vulnerability-evidence-summary.json', encoding='utf-8'))
+          assert summary['schema'] == 'WS-VULNERABILITY-ADVISORY-EVIDENCE-V1'
+          assert summary['evidence_status'] == 'INTERNAL_CI_GENERATED_UNSIGNED'
+          assert summary['component_count'] > 0
+          assert summary['advisory_record_count'] >= 0
+          assert summary['vulnerability_report_sha256'].startswith('sha256:')
+          assert 'does not establish absence of vulnerabilities' in summary['claims_boundary']
+          PY
+
+      - name: Upload vulnerability advisory evidence
+        id: upload_vulnerability_evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: vulnerability-advisory-evidence
+          path: deployments/sara_verified_local_v1/vulnerability_evidence_ci
           if-no-files-found: error
 
       - name: Validate operations policy
@@ -221,6 +257,9 @@ jobs:
           SBOM_ARTIFACT_ID: ${{ steps.upload_software_sbom_evidence.outputs.artifact-id }}
           SBOM_ARTIFACT_DIGEST: ${{ steps.upload_software_sbom_evidence.outputs.artifact-digest }}
           SBOM_ARTIFACT_URL: ${{ steps.upload_software_sbom_evidence.outputs.artifact-url }}
+          VULNERABILITY_ARTIFACT_ID: ${{ steps.upload_vulnerability_evidence.outputs.artifact-id }}
+          VULNERABILITY_ARTIFACT_DIGEST: ${{ steps.upload_vulnerability_evidence.outputs.artifact-digest }}
+          VULNERABILITY_ARTIFACT_URL: ${{ steps.upload_vulnerability_evidence.outputs.artifact-url }}
           PRE_ARTIFACT_ID: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-id }}
           PRE_ARTIFACT_DIGEST: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-digest }}
           PRE_ARTIFACT_URL: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-url }}
@@ -247,6 +286,7 @@ jobs:
             --pre-dir qualification_evidence_ci \
             --partner-dir partner_screening_ci \
             --sbom-dir sbom_evidence_ci \
+            --vulnerability-dir vulnerability_evidence_ci \
             --repository "$GITHUB_REPOSITORY" \
             --commit-sha "$GITHUB_SHA" \
             --workflow-name "$GITHUB_WORKFLOW" \
@@ -265,6 +305,9 @@ jobs:
             --sbom-artifact-id "$SBOM_ARTIFACT_ID" \
             --sbom-artifact-digest "$SBOM_ARTIFACT_DIGEST" \
             --sbom-artifact-url "$SBOM_ARTIFACT_URL" \
+            --vulnerability-artifact-id "$VULNERABILITY_ARTIFACT_ID" \
+            --vulnerability-artifact-digest "$VULNERABILITY_ARTIFACT_DIGEST" \
+            --vulnerability-artifact-url "$VULNERABILITY_ARTIFACT_URL" \
             --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >/dev/null
           test -s release_index_ci/release-index.json
           python -m json.tool release_index_ci/release-index.json >/dev/null
@@ -273,13 +316,18 @@ jobs:
           record=json.load(open('release_index_ci/release-index.json', encoding='utf-8'))
           assert record['schema'] == 'WS-SARA-RELEASE-EVIDENCE-INDEX-V1'
           assert record['artifacts']['software_sbom_evidence']['artifact_digest'].startswith('sha256:')
+          assert record['artifacts']['vulnerability_advisory_evidence']['artifact_digest'].startswith('sha256:')
           assert record['artifacts']['pre_full_bloom_qualification_evidence']['artifact_digest'].startswith('sha256:')
           assert record['artifacts']['partner_screening_batch_evidence']['artifact_digest'].startswith('sha256:')
           assert record['local_evidence']['sbom_component_count'] > 0
           assert record['local_evidence']['software_sbom_sha256'].startswith('sha256:')
+          assert record['local_evidence']['vulnerability_advisory_record_count'] >= 0
+          assert record['local_evidence']['vulnerability_report_sha256'].startswith('sha256:')
           assert record['release_index_digest'].startswith('sha256:')
           assert 'does not establish partner validation' in record['claims_boundary']
           assert 'software supply-chain completeness' in record['claims_boundary']
+          assert 'absence of vulnerabilities' in record['claims_boundary']
+          assert 'vulnerability remediation' in record['claims_boundary']
           merge_state = record['workflow']['merge_state']
           event_name = record['workflow']['event_name']
           ref = record['workflow']['ref']

--- a/deployments/sara_verified_local_v1/docs/WS_VULNERABILITY_EVIDENCE_GATE_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_VULNERABILITY_EVIDENCE_GATE_2026-09-01.md
@@ -1,0 +1,80 @@
+# WS Vulnerability Advisory Evidence Gate — 2026-09-01
+
+## Purpose
+
+This patch adds a CI-generated vulnerability/advisory evidence gate for SARA Verified Local v1.
+
+The gate consumes the CI dependency freeze and the generated software SBOM. It may also consume an explicitly provided local advisory-input JSON file. In the default CI path, no external advisory feed is executed.
+
+## Added behavior
+
+- Adds `worldshepherd_sara.vulnerability_cli`.
+- Registers the `ws-vulnerability-evidence` console script.
+- Emits `vulnerability-advisory-report.json`.
+- Emits `vulnerability-evidence-summary.json`.
+- Uploads a CI artifact named `vulnerability-advisory-evidence`.
+- Links the vulnerability/advisory artifact into `sara-release-evidence-index`.
+- Records vulnerability evidence summary/report hashes in the release index.
+- Preserves the same PR-candidate and merged-main release-state discipline used by PRE, partner-screening, and SBOM evidence.
+
+## Default CI posture
+
+The default CI run records dependency exposure from the SBOM and dependency-freeze inputs. It sets:
+
+```text
+advisory_input_status = NO_EXTERNAL_ADVISORY_FEED_EXECUTED
+evidence_status = INTERNAL_CI_GENERATED_UNSIGNED
+```
+
+This is intentionally not a claim that the dependency set has no vulnerabilities.
+
+## Optional advisory input
+
+When a local advisory input file is supplied, the CLI records advisory entries into a triage structure:
+
+```json
+{
+  "advisories": [
+    {
+      "advisory_id": "EXAMPLE-0001",
+      "component": "fastapi",
+      "severity": "HIGH",
+      "source": "local-fixture-or-feed-export",
+      "reference": "optional-reference"
+    }
+  ]
+}
+```
+
+Matched advisories become `OPEN_TRIAGE_REQUIRED`. Unmatched advisories become `NOT_PRESENT_IN_CURRENT_SBOM_INPUT`. The gate does not mark remediation complete.
+
+## Generated files
+
+```text
+vulnerability_evidence_ci/
+  vulnerability-advisory-report.json
+  vulnerability-evidence-summary.json
+```
+
+## Release index linkage
+
+The release index now records:
+
+- `artifacts.vulnerability_advisory_evidence`
+- `local_evidence.vulnerability_summary_sha256`
+- `local_evidence.vulnerability_report_sha256`
+- `local_evidence.vulnerability_advisory_record_count`
+- `local_evidence.vulnerability_matched_advisory_count`
+- `local_evidence.vulnerability_evidence_status`
+- `local_evidence.vulnerability_advisory_input_status`
+- `local_evidence.vulnerability_input_files`
+
+## Claims boundary
+
+This creates internal CI-generated vulnerability/advisory triage evidence only. It does not establish absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, vulnerability remediation, exploitability analysis, license legal review, SLSA compliance, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, FedRAMP authorization, ISO certification, SOC 2 attestation, supplier approval, partner validation, external reproduction, field performance, hardware performance, classified access, or operational authority.
+
+## Standards effect
+
+This improves the standards-control matrix by turning vulnerability/advisory handling into a repeatable release-custodied evidence surface.
+
+It does not promote any control to `MET` or `EXCEEDED`. Formal promotion remains blocked until the control matrix has the required assessment references, advisory-feed provenance, remediation evidence, policy mapping, and human review records.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -28,6 +28,7 @@ ws-partner-screening-batch = "worldshepherd_sara.partner_screening_cli:batch_mai
 ws-partner-screening-verify = "worldshepherd_sara.partner_screening_verify_cli:main"
 ws-release-index = "worldshepherd_sara.release_index_cli:main"
 ws-sbom-evidence = "worldshepherd_sara.sbom_cli:main"
+ws-vulnerability-evidence = "worldshepherd_sara.vulnerability_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
@@ -24,6 +24,7 @@ def _make_evidence_dirs(tmp_path):
     pre_dir = tmp_path / "qualification_evidence_ci"
     partner_dir = tmp_path / "partner_screening_ci"
     sbom_dir = tmp_path / "sbom_evidence_ci"
+    vulnerability_dir = tmp_path / "vulnerability_evidence_ci"
     _write_json(
         pre_dir / "qualification_index.json",
         {
@@ -63,11 +64,35 @@ def _make_evidence_dirs(tmp_path):
             "claims_boundary": "Software SBOM evidence does not establish certification or complete supply-chain conformance.",
         },
     )
-    return pre_dir, partner_dir, sbom_dir
+    _write_json(
+        vulnerability_dir / "vulnerability-advisory-report.json",
+        {
+            "schema": "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1",
+            "advisory_triage": {"advisory_record_count": 0, "matched_advisory_count": 0},
+        },
+    )
+    _write_json(
+        vulnerability_dir / "vulnerability-evidence-summary.json",
+        {
+            "schema": "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1",
+            "evidence_status": "INTERNAL_CI_GENERATED_UNSIGNED",
+            "component_count": 1,
+            "advisory_record_count": 0,
+            "matched_advisory_count": 0,
+            "advisory_input_status": "NO_EXTERNAL_ADVISORY_FEED_EXECUTED",
+            "vulnerability_report_sha256": "sha256:" + "5" * 64,
+            "input_files": {
+                "dependency_freeze": {"sha256": "sha256:" + "6" * 64},
+                "software_sbom": {"sha256": "sha256:" + "7" * 64},
+            },
+            "claims_boundary": "Vulnerability advisory evidence does not establish absence of vulnerabilities or remediation.",
+        },
+    )
+    return pre_dir, partner_dir, sbom_dir, vulnerability_dir
 
 
 def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir = _make_evidence_dirs(tmp_path)
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
 
     index = build_release_evidence_index(
         repository="Bdavis1390/Sara_pro",
@@ -82,6 +107,7 @@ def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> Non
         pre_dir=pre_dir,
         partner_dir=partner_dir,
         sbom_dir=sbom_dir,
+        vulnerability_dir=vulnerability_dir,
         pre_artifact_id="111",
         pre_artifact_digest="sha256:" + "a" * 64,
         pre_artifact_url="https://github.example/pre",
@@ -91,6 +117,9 @@ def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> Non
         sbom_artifact_id="333",
         sbom_artifact_digest="sha256:" + "c" * 64,
         sbom_artifact_url="https://github.example/sbom",
+        vulnerability_artifact_id="444",
+        vulnerability_artifact_digest="sha256:" + "d" * 64,
+        vulnerability_artifact_url="https://github.example/vulnerability",
         executed_utc="2026-09-01T17:10:00Z",
     )
 
@@ -99,20 +128,24 @@ def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> Non
     assert index["workflow"]["pull_request_number"] == "44"
     assert index["workflow"]["merge_state"] == MERGE_STATE_PR_CANDIDATE
     assert index["artifacts"]["software_sbom_evidence"]["artifact_digest"] == "sha256:" + "c" * 64
+    assert index["artifacts"]["vulnerability_advisory_evidence"]["artifact_digest"] == "sha256:" + "d" * 64
     assert index["artifacts"]["pre_full_bloom_qualification_evidence"]["artifact_digest"] == "sha256:" + "a" * 64
     assert index["artifacts"]["partner_screening_batch_evidence"]["artifact_digest"] == "sha256:" + "b" * 64
     assert index["local_evidence"]["sbom_component_count"] == 1
     assert index["local_evidence"]["sbom_evidence_status"] == "INTERNAL_CI_GENERATED_UNSIGNED"
+    assert index["local_evidence"]["vulnerability_advisory_record_count"] == 0
+    assert index["local_evidence"]["vulnerability_evidence_status"] == "INTERNAL_CI_GENERATED_UNSIGNED"
     assert index["local_evidence"]["partner_batch_digest"] == "sha256:" + "2" * 64
     assert index["local_evidence"]["partner_package_count"] == 4
     assert index["local_evidence"]["partner_presets"] == ["BAE_SYSTEMS", "GENERIC_PRIME"]
     assert index["release_index_digest"].startswith("sha256:")
     assert "does not establish partner validation" in index["claims_boundary"]
     assert "software supply-chain completeness" in index["claims_boundary"]
+    assert "absence of vulnerabilities" in index["claims_boundary"]
 
 
 def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir = _make_evidence_dirs(tmp_path)
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
     out_path = tmp_path / "release_index_ci" / "release-index.json"
 
     exit_code = main(
@@ -125,6 +158,8 @@ def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
             str(partner_dir),
             "--sbom-dir",
             str(sbom_dir),
+            "--vulnerability-dir",
+            str(vulnerability_dir),
             "--repository",
             "Bdavis1390/Sara_pro",
             "--commit-sha",
@@ -151,6 +186,10 @@ def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
             "333",
             "--sbom-artifact-digest",
             "sha256:" + "e" * 64,
+            "--vulnerability-artifact-id",
+            "444",
+            "--vulnerability-artifact-digest",
+            "sha256:" + "f" * 64,
             "--executed-utc",
             "2026-09-01T17:11:00Z",
         ]
@@ -164,6 +203,7 @@ def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
     assert written["workflow"]["pull_request_number"] is None
     assert written["workflow"]["merge_state"] == MERGE_STATE_MAIN_PUSH
     assert written["artifacts"]["software_sbom_evidence"]["artifact_digest"] == "sha256:" + "e" * 64
+    assert written["artifacts"]["vulnerability_advisory_evidence"]["artifact_digest"] == "sha256:" + "f" * 64
 
 
 def test_release_index_derives_manual_or_non_main_state() -> None:
@@ -172,7 +212,7 @@ def test_release_index_derives_manual_or_non_main_state() -> None:
 
 
 def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir = _make_evidence_dirs(tmp_path)
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
 
     with pytest.raises(ValueError, match="must be a SHA-256 digest"):
         build_release_evidence_index(
@@ -188,6 +228,7 @@ def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
             pre_dir=pre_dir,
             partner_dir=partner_dir,
             sbom_dir=sbom_dir,
+            vulnerability_dir=vulnerability_dir,
             pre_artifact_id="111",
             pre_artifact_digest="not-a-digest",
             pre_artifact_url=None,
@@ -197,11 +238,14 @@ def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
             sbom_artifact_id="333",
             sbom_artifact_digest="sha256:" + "f" * 64,
             sbom_artifact_url=None,
+            vulnerability_artifact_id="444",
+            vulnerability_artifact_digest="sha256:" + "d" * 64,
+            vulnerability_artifact_url=None,
         )
 
 
 def test_release_index_rejects_merge_state_mismatch(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir = _make_evidence_dirs(tmp_path)
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
 
     with pytest.raises(ValueError, match="does not match event/ref context"):
         build_release_evidence_index(
@@ -217,6 +261,7 @@ def test_release_index_rejects_merge_state_mismatch(tmp_path) -> None:
             pre_dir=pre_dir,
             partner_dir=partner_dir,
             sbom_dir=sbom_dir,
+            vulnerability_dir=vulnerability_dir,
             pre_artifact_id="111",
             pre_artifact_digest="sha256:" + "f" * 64,
             pre_artifact_url=None,
@@ -226,11 +271,14 @@ def test_release_index_rejects_merge_state_mismatch(tmp_path) -> None:
             sbom_artifact_id="333",
             sbom_artifact_digest="sha256:" + "d" * 64,
             sbom_artifact_url=None,
+            vulnerability_artifact_id="444",
+            vulnerability_artifact_digest="sha256:" + "c" * 64,
+            vulnerability_artifact_url=None,
         )
 
 
 def test_release_index_rejects_bad_sbom_summary_schema(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir = _make_evidence_dirs(tmp_path)
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
     _write_json(sbom_dir / "sbom-evidence-summary.json", {"schema": "WRONG"})
 
     with pytest.raises(ValueError, match="unexpected SBOM evidence summary schema"):
@@ -247,6 +295,7 @@ def test_release_index_rejects_bad_sbom_summary_schema(tmp_path) -> None:
             pre_dir=pre_dir,
             partner_dir=partner_dir,
             sbom_dir=sbom_dir,
+            vulnerability_dir=vulnerability_dir,
             pre_artifact_id="111",
             pre_artifact_digest="sha256:" + "f" * 64,
             pre_artifact_url=None,
@@ -256,4 +305,41 @@ def test_release_index_rejects_bad_sbom_summary_schema(tmp_path) -> None:
             sbom_artifact_id="333",
             sbom_artifact_digest="sha256:" + "d" * 64,
             sbom_artifact_url=None,
+            vulnerability_artifact_id="444",
+            vulnerability_artifact_digest="sha256:" + "c" * 64,
+            vulnerability_artifact_url=None,
+        )
+
+
+def test_release_index_rejects_bad_vulnerability_summary_schema(tmp_path) -> None:
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
+    _write_json(vulnerability_dir / "vulnerability-evidence-summary.json", {"schema": "WRONG"})
+
+    with pytest.raises(ValueError, match="unexpected vulnerability evidence summary schema"):
+        build_release_evidence_index(
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            workflow_name="SARA Verified Local v1 Gate",
+            workflow_run_id="33500000005",
+            workflow_run_number="658",
+            event_name="pull_request",
+            ref="refs/pull/45/merge",
+            pr_number="45",
+            merge_state=MERGE_STATE_PR_CANDIDATE,
+            pre_dir=pre_dir,
+            partner_dir=partner_dir,
+            sbom_dir=sbom_dir,
+            vulnerability_dir=vulnerability_dir,
+            pre_artifact_id="111",
+            pre_artifact_digest="sha256:" + "f" * 64,
+            pre_artifact_url=None,
+            partner_artifact_id="222",
+            partner_artifact_digest="sha256:" + "e" * 64,
+            partner_artifact_url=None,
+            sbom_artifact_id="333",
+            sbom_artifact_digest="sha256:" + "d" * 64,
+            sbom_artifact_url=None,
+            vulnerability_artifact_id="444",
+            vulnerability_artifact_digest="sha256:" + "c" * 64,
+            vulnerability_artifact_url=None,
         )

--- a/deployments/sara_verified_local_v1/tests/test_vulnerability_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_vulnerability_cli.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worldshepherd_sara.vulnerability_cli import (
+    ADVISORY_INPUT_NONE,
+    EVIDENCE_STATUS,
+    VULNERABILITY_EVIDENCE_SCHEMA,
+    build_vulnerability_evidence,
+    load_sbom_components,
+    main,
+)
+
+
+def _write_json(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    freeze = tmp_path / "dependency-freeze.txt"
+    sbom = tmp_path / "sbom_evidence_ci" / "software-sbom.json"
+    freeze.write_text("fastapi==0.141.1\nuvicorn==0.52.4\n", encoding="utf-8")
+    _write_json(
+        sbom,
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {"name": "fastapi", "version": "0.141.1", "bom-ref": "pkg:pypi/fastapi@0.141.1"},
+                {"name": "uvicorn", "version": "0.52.4", "bom-ref": "pkg:pypi/uvicorn@0.52.4"},
+            ],
+        },
+    )
+    return freeze, sbom
+
+
+def test_load_sbom_components_normalizes_names(tmp_path: Path) -> None:
+    _, sbom = _write_inputs(tmp_path)
+
+    components = load_sbom_components(sbom)
+
+    assert [component["name"] for component in components] == ["fastapi", "uvicorn"]
+    assert components[0]["version"] == "0.141.1"
+
+
+def test_build_vulnerability_evidence_records_no_external_advisory_scan(tmp_path: Path) -> None:
+    freeze, sbom = _write_inputs(tmp_path)
+
+    report, summary = build_vulnerability_evidence(
+        dependency_freeze=freeze,
+        sbom=sbom,
+        advisory_input=None,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+        executed_utc="2026-09-01T18:30:00Z",
+    )
+
+    assert report["schema"] == VULNERABILITY_EVIDENCE_SCHEMA
+    assert report["evidence_status"] == EVIDENCE_STATUS
+    assert report["advisory_input_status"] == ADVISORY_INPUT_NONE
+    assert report["component_exposure"]["component_count"] == 2
+    assert report["advisory_triage"]["advisory_record_count"] == 0
+    assert "not evidence that dependencies have no vulnerabilities" in report["advisory_triage"]["no_advisory_input_note"]
+    assert summary["component_count"] == 2
+    assert summary["advisory_record_count"] == 0
+    assert summary["input_files"]["software_sbom"]["sha256"].startswith("sha256:")
+    assert "does not establish absence of vulnerabilities" in summary["claims_boundary"]
+
+
+def test_vulnerability_evidence_records_optional_advisory_input_for_triage(tmp_path: Path) -> None:
+    freeze, sbom = _write_inputs(tmp_path)
+    advisory_input = tmp_path / "advisories.json"
+    _write_json(
+        advisory_input,
+        {
+            "advisories": [
+                {
+                    "advisory_id": "GHSA-TEST-0001",
+                    "component": "FastAPI",
+                    "severity": "high",
+                    "source": "fixture",
+                    "reference": "fixture-only",
+                },
+                {
+                    "advisory_id": "GHSA-TEST-0002",
+                    "component": "not-installed",
+                    "severity": "low",
+                    "source": "fixture",
+                },
+            ]
+        },
+    )
+
+    report, summary = build_vulnerability_evidence(
+        dependency_freeze=freeze,
+        sbom=sbom,
+        advisory_input=advisory_input,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+        executed_utc="2026-09-01T18:31:00Z",
+    )
+
+    assert report["advisory_input_status"] == "ADVISORY_INPUT_RECORDED_UNVERIFIED"
+    assert report["advisory_triage"]["advisory_record_count"] == 2
+    assert report["advisory_triage"]["matched_advisory_count"] == 1
+    records = {record["advisory_id"]: record for record in report["advisory_triage"]["records"]}
+    assert records["GHSA-TEST-0001"]["matched_component_in_sbom"] is True
+    assert records["GHSA-TEST-0001"]["triage_status"] == "OPEN_TRIAGE_REQUIRED"
+    assert records["GHSA-TEST-0001"]["remediation_status"] == "NOT_REMEDIATED_BY_THIS_RECORD"
+    assert records["GHSA-TEST-0002"]["matched_component_in_sbom"] is False
+    assert summary["matched_advisory_count"] == 1
+
+
+def test_vulnerability_cli_writes_report_and_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    freeze, sbom = _write_inputs(work)
+    out_dir = work / "vulnerability_evidence_ci"
+    monkeypatch.chdir(work)
+
+    exit_code = main(
+        [
+            "--dependency-freeze",
+            str(freeze.relative_to(work)),
+            "--sbom",
+            str(sbom.relative_to(work)),
+            "--out",
+            str(out_dir.relative_to(work)),
+            "--repository",
+            "Bdavis1390/Sara_pro",
+            "--commit-sha",
+            "abc123",
+            "--operator",
+            "github-actions",
+            "--executed-utc",
+            "2026-09-01T18:32:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads((out_dir / "vulnerability-advisory-report.json").read_text(encoding="utf-8"))
+    summary = json.loads((out_dir / "vulnerability-evidence-summary.json").read_text(encoding="utf-8"))
+    assert report["schema"] == VULNERABILITY_EVIDENCE_SCHEMA
+    assert summary["vulnerability_report_sha256"].startswith("sha256:")
+    assert summary["summary_digest"].startswith("sha256:")
+
+
+def test_vulnerability_cli_rejects_paths_outside_working_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    freeze, sbom = _write_inputs(work)
+    outside_advisory = tmp_path / "outside-advisories.json"
+    _write_json(outside_advisory, {"advisories": []})
+    monkeypatch.chdir(work)
+
+    with pytest.raises(ValueError, match="working directory"):
+        main(
+            [
+                "--dependency-freeze",
+                str(freeze.relative_to(work)),
+                "--sbom",
+                str(sbom.relative_to(work)),
+                "--advisory-input",
+                str(outside_advisory),
+                "--out",
+                "vulnerability_evidence_ci",
+                "--commit-sha",
+                "abc123",
+            ]
+        )
+
+
+def test_vulnerability_outputs_do_not_claim_security_or_compliance_completion(tmp_path: Path) -> None:
+    freeze, sbom = _write_inputs(tmp_path)
+
+    report, summary = build_vulnerability_evidence(
+        dependency_freeze=freeze,
+        sbom=sbom,
+        advisory_input=None,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+        executed_utc="2026-09-01T18:33:00Z",
+    )
+
+    text = json.dumps({"report": report, "summary": summary}, sort_keys=True).lower()
+    for forbidden in (
+        "no_vulnerabilities",
+        "vulnerability_free",
+        "scan_passed",
+        "remediation_complete",
+        "cmmc_certified",
+        "nist_800_171_conformant",
+        "dfars_satisfied",
+        "supplier_approved",
+        "partner_validated",
+        "field_validated",
+        "hardware_validated",
+    ):
+        assert forbidden not in text
+
+
+def test_vulnerability_evidence_rejects_missing_sbom(tmp_path: Path) -> None:
+    freeze = tmp_path / "dependency-freeze.txt"
+    freeze.write_text("fastapi==0.141.1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="required JSON file missing"):
+        load_sbom_components(tmp_path / "missing-sbom.json")

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
@@ -12,6 +12,7 @@ from .qualification import canonical_digest
 
 RELEASE_INDEX_SCHEMA = "WS-SARA-RELEASE-EVIDENCE-INDEX-V1"
 SBOM_EVIDENCE_SCHEMA = "WS-SOFTWARE-SUPPLY-CHAIN-EVIDENCE-V1"
+VULNERABILITY_EVIDENCE_SCHEMA = "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1"
 MERGE_STATE_PR_CANDIDATE = "PR_CANDIDATE_UNMERGED"
 MERGE_STATE_MAIN_PUSH = "MERGED_MAIN_PUSH"
 MERGE_STATE_MANUAL_OR_NON_MAIN = "MANUAL_OR_NON_MAIN_RUN"
@@ -25,7 +26,8 @@ CLAIMS_BOUNDARY = (
     "Release index records CI evidence custody only. It does not establish partner validation, "
     "supplier approval, certification, CMMC/NIST/DFARS conformity, classified access, DOE validation, "
     "external reproduction, field performance, hardware performance, export-control clearance, "
-    "software supply-chain completeness, vulnerability remediation, license legal review, SLSA compliance, "
+    "software supply-chain completeness, absence of vulnerabilities, advisory-feed completeness, "
+    "vulnerability scan pass, vulnerability remediation, license legal review, SLSA compliance, "
     "or operational authority."
 )
 
@@ -116,6 +118,18 @@ def _validate_sbom_summary(sbom_summary: dict[str, Any]) -> None:
         raise ValueError("SBOM summary missing claims boundary")
 
 
+def _validate_vulnerability_summary(vulnerability_summary: dict[str, Any]) -> None:
+    if vulnerability_summary.get("schema") != VULNERABILITY_EVIDENCE_SCHEMA:
+        raise ValueError("unexpected vulnerability evidence summary schema")
+    if vulnerability_summary.get("evidence_status") != "INTERNAL_CI_GENERATED_UNSIGNED":
+        raise ValueError("unexpected vulnerability evidence status")
+    if not vulnerability_summary.get("vulnerability_report_sha256", "").startswith("sha256:"):
+        raise ValueError("vulnerability summary missing vulnerability_report_sha256")
+    claims_boundary = vulnerability_summary.get("claims_boundary", "")
+    if "does not establish" not in claims_boundary:
+        raise ValueError("vulnerability summary missing claims boundary")
+
+
 def build_release_evidence_index(
     *,
     repository: str,
@@ -130,6 +144,7 @@ def build_release_evidence_index(
     pre_dir: Path,
     partner_dir: Path,
     sbom_dir: Path,
+    vulnerability_dir: Path,
     pre_artifact_id: str | None,
     pre_artifact_digest: str | None,
     pre_artifact_url: str | None,
@@ -139,6 +154,9 @@ def build_release_evidence_index(
     sbom_artifact_id: str | None,
     sbom_artifact_digest: str | None,
     sbom_artifact_url: str | None,
+    vulnerability_artifact_id: str | None,
+    vulnerability_artifact_digest: str | None,
+    vulnerability_artifact_url: str | None,
     executed_utc: str | None = None,
 ) -> dict[str, Any]:
     """Build a machine-readable release evidence index for one SARA CI run."""
@@ -148,16 +166,19 @@ def build_release_evidence_index(
     pre_root = Path(pre_dir)
     partner_root = Path(partner_dir)
     sbom_root = Path(sbom_dir)
+    vulnerability_root = Path(vulnerability_dir)
 
     qualification_index = _load_json(pre_root / "qualification_index.json")
     partner_batch_manifest = _load_json(partner_root / "batch-manifest.json")
     sbom_summary = _load_json(sbom_root / "sbom-evidence-summary.json")
+    vulnerability_summary = _load_json(vulnerability_root / "vulnerability-evidence-summary.json")
 
     if partner_batch_manifest.get("schema") != "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1":
         raise ValueError("unexpected partner batch manifest schema")
     if qualification_index.get("schema") is None:
         raise ValueError("qualification index missing schema")
     _validate_sbom_summary(sbom_summary)
+    _validate_vulnerability_summary(vulnerability_summary)
 
     generated_at = executed_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     pre_artifact = _artifact_record(
@@ -178,6 +199,12 @@ def build_release_evidence_index(
         digest=sbom_artifact_digest,
         url=sbom_artifact_url,
     )
+    vulnerability_artifact = _artifact_record(
+        name="vulnerability-advisory-evidence",
+        artifact_id=vulnerability_artifact_id,
+        digest=vulnerability_artifact_digest,
+        url=vulnerability_artifact_url,
+    )
 
     index: dict[str, Any] = {
         "schema": RELEASE_INDEX_SCHEMA,
@@ -195,6 +222,7 @@ def build_release_evidence_index(
         },
         "artifacts": {
             "software_sbom_evidence": sbom_artifact,
+            "vulnerability_advisory_evidence": vulnerability_artifact,
             "pre_full_bloom_qualification_evidence": pre_artifact,
             "partner_screening_batch_evidence": partner_artifact,
         },
@@ -206,6 +234,15 @@ def build_release_evidence_index(
             "sbom_component_count": sbom_summary.get("component_count"),
             "sbom_evidence_status": sbom_summary.get("evidence_status"),
             "sbom_input_files": sbom_summary.get("input_files", {}),
+            "vulnerability_summary_path": str(vulnerability_root / "vulnerability-evidence-summary.json"),
+            "vulnerability_summary_sha256": _sha256_file(vulnerability_root / "vulnerability-evidence-summary.json"),
+            "vulnerability_report_path": str(vulnerability_root / "vulnerability-advisory-report.json"),
+            "vulnerability_report_sha256": _sha256_file(vulnerability_root / "vulnerability-advisory-report.json"),
+            "vulnerability_advisory_record_count": vulnerability_summary.get("advisory_record_count"),
+            "vulnerability_matched_advisory_count": vulnerability_summary.get("matched_advisory_count"),
+            "vulnerability_evidence_status": vulnerability_summary.get("evidence_status"),
+            "vulnerability_advisory_input_status": vulnerability_summary.get("advisory_input_status"),
+            "vulnerability_input_files": vulnerability_summary.get("input_files", {}),
             "qualification_index_path": str(pre_root / "qualification_index.json"),
             "qualification_index_sha256": _sha256_file(pre_root / "qualification_index.json"),
             "partner_batch_manifest_path": str(partner_root / "batch-manifest.json"),
@@ -247,6 +284,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pre-dir", type=Path, required=True, help="Directory containing PRE full-bloom evidence.")
     parser.add_argument("--partner-dir", type=Path, required=True, help="Directory containing partner-screening batch evidence.")
     parser.add_argument("--sbom-dir", type=Path, required=True, help="Directory containing software SBOM evidence.")
+    parser.add_argument(
+        "--vulnerability-dir",
+        type=Path,
+        required=True,
+        help="Directory containing vulnerability/advisory evidence.",
+    )
     parser.add_argument("--repository", default=os.getenv("GITHUB_REPOSITORY", ""))
     parser.add_argument("--commit-sha", default=os.getenv("GITHUB_SHA", ""))
     parser.add_argument("--workflow-name", default=os.getenv("GITHUB_WORKFLOW", ""))
@@ -265,6 +308,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--sbom-artifact-id", default=None)
     parser.add_argument("--sbom-artifact-digest", default=None)
     parser.add_argument("--sbom-artifact-url", default=None)
+    parser.add_argument("--vulnerability-artifact-id", default=None)
+    parser.add_argument("--vulnerability-artifact-digest", default=None)
+    parser.add_argument("--vulnerability-artifact-url", default=None)
     parser.add_argument("--executed-utc", default=None)
     args = parser.parse_args(argv)
 
@@ -284,6 +330,7 @@ def main(argv: list[str] | None = None) -> int:
         pre_dir=args.pre_dir,
         partner_dir=args.partner_dir,
         sbom_dir=args.sbom_dir,
+        vulnerability_dir=args.vulnerability_dir,
         pre_artifact_id=args.pre_artifact_id,
         pre_artifact_digest=args.pre_artifact_digest,
         pre_artifact_url=args.pre_artifact_url,
@@ -293,6 +340,9 @@ def main(argv: list[str] | None = None) -> int:
         sbom_artifact_id=args.sbom_artifact_id,
         sbom_artifact_digest=args.sbom_artifact_digest,
         sbom_artifact_url=args.sbom_artifact_url,
+        vulnerability_artifact_id=args.vulnerability_artifact_id,
+        vulnerability_artifact_digest=args.vulnerability_artifact_digest,
+        vulnerability_artifact_url=args.vulnerability_artifact_url,
         executed_utc=args.executed_utc,
     )
     _write_json(args.out, index)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/vulnerability_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/vulnerability_cli.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .qualification import canonical_digest
+
+VULNERABILITY_EVIDENCE_SCHEMA = "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1"
+EVIDENCE_STATUS = "INTERNAL_CI_GENERATED_UNSIGNED"
+ADVISORY_INPUT_NONE = "NO_EXTERNAL_ADVISORY_FEED_EXECUTED"
+ADVISORY_INPUT_SUPPLIED = "ADVISORY_INPUT_RECORDED_UNVERIFIED"
+
+CLAIMS_BOUNDARY = (
+    "Vulnerability advisory evidence is generated from CI dependency-freeze, SBOM, and optional advisory input files only. "
+    "It supports internal vulnerability-response triage and release custody, but it does not establish absence of "
+    "vulnerabilities, advisory-feed completeness, vulnerability scan pass, vulnerability remediation, exploitability "
+    "analysis, license legal review, SLSA compliance, CMMC/NIST/DFARS conformity, certification, accreditation, "
+    "external reproduction, supplier approval, partner validation, field performance, hardware performance, classified "
+    "access, or operational authority."
+)
+
+NOT_CLAIMED = [
+    "absence_of_vulnerabilities",
+    "advisory_feed_completeness",
+    "vulnerability_scan_pass",
+    "vulnerability_remediation",
+    "exploitability_analysis",
+    "license_legal_review",
+    "slsa_compliance",
+    "cmmc_conformity",
+    "nist_800_171_implementation",
+    "dfars_satisfaction",
+    "fedramp_authorization",
+    "iso_certification",
+    "soc2_attestation",
+    "partner_validation",
+    "supplier_approval",
+    "external_reproduction",
+    "field_or_hardware_performance",
+]
+
+FORBIDDEN_CLAIM_TOKENS = (
+    "no_vulnerabilities",
+    "vulnerability_free",
+    "scan_passed",
+    "remediation_complete",
+    "cmmc_certified",
+    "nist_800_171_conformant",
+    "dfars_satisfied",
+    "slsa_compliant",
+    "supplier_approved",
+    "partner_validated",
+    "field_validated",
+    "hardware_validated",
+)
+
+
+def _json_text(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_text(value), encoding="utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"required file missing for digest: {path}")
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"required JSON file missing: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _optional_file_digest(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    if not path.is_file():
+        raise ValueError(f"optional input was supplied but does not exist: {path}")
+    return {
+        "path": str(path),
+        "sha256": _sha256_file(path),
+        "size_bytes": path.stat().st_size,
+    }
+
+
+def _normalize_name(value: str) -> str:
+    return value.strip().replace("_", "-").lower()
+
+
+def _resolve_cli_path(path: Path, *, base_dir: Path, must_exist: bool, allow_directory: bool) -> Path:
+    base = base_dir.resolve()
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"CLI path must resolve under working directory: {path}") from exc
+    if must_exist:
+        if allow_directory and not resolved.is_dir():
+            raise ValueError(f"expected directory input: {path}")
+        if not allow_directory and not resolved.is_file():
+            raise ValueError(f"expected file input: {path}")
+    return resolved
+
+
+def _resolve_optional_cli_file(path: Path | None, *, base_dir: Path) -> Path | None:
+    if path is None:
+        return None
+    return _resolve_cli_path(path, base_dir=base_dir, must_exist=True, allow_directory=False)
+
+
+def load_sbom_components(sbom_path: Path) -> list[dict[str, Any]]:
+    sbom = _load_json(sbom_path)
+    if sbom.get("bomFormat") != "CycloneDX":
+        raise ValueError("SBOM must use CycloneDX bomFormat")
+    components = sbom.get("components")
+    if not isinstance(components, list):
+        raise ValueError("SBOM missing components list")
+
+    normalized: list[dict[str, Any]] = []
+    seen: set[tuple[str, str | None]] = set()
+    for index, component in enumerate(components, start=1):
+        if not isinstance(component, dict):
+            raise ValueError("SBOM component entries must be objects")
+        name = str(component.get("name") or "").strip()
+        if not name:
+            raise ValueError(f"SBOM component {index} missing name")
+        version_raw = component.get("version")
+        version = str(version_raw).strip() if version_raw is not None else None
+        key = (_normalize_name(name), version)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(
+            {
+                "name": _normalize_name(name),
+                "version": version,
+                "bom_ref": component.get("bom-ref"),
+                "purl": component.get("purl"),
+            }
+        )
+    if not normalized:
+        raise ValueError("SBOM did not contain any usable components")
+    return sorted(normalized, key=lambda item: (item["name"], item.get("version") or ""))
+
+
+def _load_advisories(advisory_input: Path | None) -> list[dict[str, Any]]:
+    if advisory_input is None:
+        return []
+    payload = _load_json(advisory_input)
+    advisories = payload.get("advisories", [])
+    if not isinstance(advisories, list):
+        raise ValueError("advisory input must contain an advisories list")
+
+    records: list[dict[str, Any]] = []
+    for index, advisory in enumerate(advisories, start=1):
+        if not isinstance(advisory, dict):
+            raise ValueError("advisory entries must be objects")
+        advisory_id = str(advisory.get("advisory_id") or advisory.get("id") or f"ADVISORY-{index}").strip()
+        component = str(advisory.get("component") or advisory.get("package") or "").strip()
+        if not component:
+            raise ValueError(f"advisory {advisory_id} missing component")
+        records.append(
+            {
+                "advisory_id": advisory_id,
+                "component": _normalize_name(component),
+                "severity": str(advisory.get("severity") or "UNKNOWN").strip().upper(),
+                "source": str(advisory.get("source") or "provided-advisory-input").strip(),
+                "reference": advisory.get("reference"),
+            }
+        )
+    return records
+
+
+def _assert_no_forbidden_claims(*values: dict[str, Any]) -> None:
+    text = json.dumps(values, sort_keys=True).lower()
+    for token in FORBIDDEN_CLAIM_TOKENS:
+        if token in text:
+            raise ValueError(f"prohibited vulnerability/compliance claim present: {token}")
+
+
+def build_vulnerability_evidence(
+    *,
+    dependency_freeze: Path,
+    sbom: Path,
+    advisory_input: Path | None,
+    repository: str,
+    commit_sha: str,
+    operator: str,
+    executed_utc: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not commit_sha:
+        raise ValueError("commit_sha is required")
+    if not dependency_freeze.is_file():
+        raise ValueError(f"dependency freeze file is required: {dependency_freeze}")
+
+    generated_at = executed_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    components = load_sbom_components(sbom)
+    component_names = {component["name"] for component in components}
+    advisories = _load_advisories(advisory_input)
+
+    triage_records = []
+    for advisory in advisories:
+        matched = advisory["component"] in component_names
+        triage_records.append(
+            {
+                "advisory_id": advisory["advisory_id"],
+                "component": advisory["component"],
+                "severity": advisory["severity"],
+                "source": advisory["source"],
+                "reference": advisory["reference"],
+                "matched_component_in_sbom": matched,
+                "triage_status": "OPEN_TRIAGE_REQUIRED" if matched else "NOT_PRESENT_IN_CURRENT_SBOM_INPUT",
+                "remediation_status": "NOT_REMEDIATED_BY_THIS_RECORD",
+            }
+        )
+
+    report: dict[str, Any] = {
+        "schema": VULNERABILITY_EVIDENCE_SCHEMA,
+        "generated_utc": generated_at,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "operator": operator,
+        "evidence_status": EVIDENCE_STATUS,
+        "advisory_input_status": ADVISORY_INPUT_SUPPLIED if advisory_input else ADVISORY_INPUT_NONE,
+        "component_exposure": {
+            "component_count": len(components),
+            "components": components,
+        },
+        "advisory_triage": {
+            "advisory_record_count": len(triage_records),
+            "matched_advisory_count": sum(1 for record in triage_records if record["matched_component_in_sbom"]),
+            "records": triage_records,
+            "no_advisory_input_note": (
+                "No advisory input was supplied; this is not evidence that dependencies have no vulnerabilities."
+                if advisory_input is None
+                else None
+            ),
+        },
+        "claims_boundary": CLAIMS_BOUNDARY,
+        "not_claimed": NOT_CLAIMED,
+    }
+
+    summary: dict[str, Any] = {
+        "schema": VULNERABILITY_EVIDENCE_SCHEMA,
+        "generated_utc": generated_at,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "operator": operator,
+        "evidence_status": EVIDENCE_STATUS,
+        "advisory_input_status": report["advisory_input_status"],
+        "component_count": len(components),
+        "component_names": [component["name"] for component in components],
+        "advisory_record_count": len(triage_records),
+        "matched_advisory_count": report["advisory_triage"]["matched_advisory_count"],
+        "input_files": {
+            "dependency_freeze": _optional_file_digest(dependency_freeze),
+            "software_sbom": _optional_file_digest(sbom),
+            "advisory_input": _optional_file_digest(advisory_input),
+        },
+        "claims_boundary": CLAIMS_BOUNDARY,
+        "not_claimed": NOT_CLAIMED,
+    }
+    summary["summary_digest"] = canonical_digest(summary)
+    _assert_no_forbidden_claims(report=report, summary=summary)
+    return report, summary
+
+
+def write_vulnerability_evidence(
+    *,
+    out_dir: Path,
+    dependency_freeze: Path,
+    sbom: Path,
+    advisory_input: Path | None,
+    repository: str,
+    commit_sha: str,
+    operator: str,
+    executed_utc: str | None = None,
+) -> dict[str, Any]:
+    report, summary = build_vulnerability_evidence(
+        dependency_freeze=dependency_freeze,
+        sbom=sbom,
+        advisory_input=advisory_input,
+        repository=repository,
+        commit_sha=commit_sha,
+        operator=operator,
+        executed_utc=executed_utc,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report_path = out_dir / "vulnerability-advisory-report.json"
+    summary_path = out_dir / "vulnerability-evidence-summary.json"
+    _write_json(report_path, report)
+
+    summary["vulnerability_report_path"] = str(report_path)
+    summary["vulnerability_report_sha256"] = _sha256_file(report_path)
+    summary["summary_digest"] = canonical_digest(summary)
+    _assert_no_forbidden_claims(summary=summary)
+    _write_json(summary_path, summary)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate internal SARA vulnerability/advisory evidence from CI dependency and SBOM inputs."
+    )
+    parser.add_argument("--dependency-freeze", type=Path, required=True, help="Path to pip freeze output.")
+    parser.add_argument("--sbom", type=Path, required=True, help="Path to software-sbom.json.")
+    parser.add_argument("--advisory-input", type=Path, default=None, help="Optional local advisory input JSON.")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for vulnerability evidence files.")
+    parser.add_argument("--repository", default="", help="Repository full name.")
+    parser.add_argument("--commit-sha", required=True, help="Commit SHA for the CI run.")
+    parser.add_argument("--operator", default="github-actions", help="Evidence operator.")
+    parser.add_argument("--executed-utc", default=None, help="Optional fixed execution timestamp.")
+    args = parser.parse_args(argv)
+
+    working_dir = Path.cwd()
+    dependency_freeze = _resolve_cli_path(args.dependency_freeze, base_dir=working_dir, must_exist=True, allow_directory=False)
+    sbom = _resolve_cli_path(args.sbom, base_dir=working_dir, must_exist=True, allow_directory=False)
+    advisory_input = _resolve_optional_cli_file(args.advisory_input, base_dir=working_dir)
+    out_dir = _resolve_cli_path(args.out, base_dir=working_dir, must_exist=False, allow_directory=True)
+
+    summary = write_vulnerability_evidence(
+        out_dir=out_dir,
+        dependency_freeze=dependency_freeze,
+        sbom=sbom,
+        advisory_input=advisory_input,
+        repository=args.repository,
+        commit_sha=args.commit_sha,
+        operator=args.operator,
+        executed_utc=args.executed_utc,
+    )
+    print(_json_text(summary), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/vulnerability_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/vulnerability_cli.py
@@ -183,7 +183,7 @@ def _load_advisories(advisory_input: Path | None) -> list[dict[str, Any]]:
     return records
 
 
-def _assert_no_forbidden_claims(*values: dict[str, Any]) -> None:
+def _assert_no_forbidden_claims(**values: dict[str, Any]) -> None:
     text = json.dumps(values, sort_keys=True).lower()
     for token in FORBIDDEN_CLAIM_TOKENS:
         if token in text:


### PR DESCRIPTION
## Summary

Adds a CI-generated vulnerability/advisory evidence gate and links that artifact into the SARA release evidence index.

## Added

- `deployments/sara_verified_local_v1/worldshepherd_sara/vulnerability_cli.py`
  - Adds `ws-vulnerability-evidence`.
  - Reads `dependency-freeze.txt` and generated `software-sbom.json`.
  - Emits `vulnerability-advisory-report.json` and `vulnerability-evidence-summary.json`.
  - Supports optional local advisory input without executing an external advisory feed in default CI.
  - Records component exposure, advisory triage, matched advisory counts, input digests, and claims boundary.
  - Constrains CLI file paths under the working directory.

- `deployments/sara_verified_local_v1/tests/test_vulnerability_cli.py`
  - Verifies SBOM component normalization, default no-external-feed status, optional advisory triage, report/summary generation, path constraints, missing SBOM rejection, and no false security/compliance claims.

- `deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py`
  - Adds required `--vulnerability-dir`.
  - Adds `vulnerability_advisory_evidence` to release-index artifacts.
  - Records vulnerability summary/report digests, advisory counts, evidence status, advisory-input status, and input-file digests.

- `.github/workflows/sara-verified-local-v1.yml`
  - Installs and checks `ws-vulnerability-evidence`.
  - Builds and uploads `vulnerability-advisory-evidence`.
  - Feeds vulnerability artifact ID, digest, and URL into `sara-release-evidence-index`.

- `docs/WS_VULNERABILITY_EVIDENCE_GATE_2026-09-01.md`
  - Documents behavior, generated files, release-index linkage, standards effect, and claims boundary.

## Claims boundary

This PR creates internal CI-generated vulnerability/advisory triage evidence only. It does **not** establish absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, vulnerability remediation, exploitability analysis, license legal review, SLSA compliance, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, FedRAMP authorization, ISO certification, SOC 2 attestation, supplier approval, partner validation, external reproduction, field performance, hardware performance, classified access, or operational authority.

## Standards posture

This improves the standards-control matrix by turning vulnerability/advisory handling into a repeatable release-custodied evidence surface, but it does **not** promote any control to `MET` or `EXCEEDED`. Formal promotion remains blocked until advisory-feed provenance, remediation evidence, assessment references, policy mapping, and human review records exist.