### PR TITLE
Add human advisory triage ledger

### DIFF
--- a/.github/workflows/sara-verified-local-v1.yml
+++ b/.github/workflows/sara-verified-local-v1.yml
@@ -41,6 +41,7 @@ jobs:
           command -v ws-pre-bloom
           command -v ws-sbom-evidence
           command -v ws-vulnerability-evidence
+          command -v ws-human-triage-ledger
           command -v ws-partner-screening
           command -v ws-partner-screening-batch
           command -v ws-partner-screening-verify
@@ -48,6 +49,7 @@ jobs:
           ws-pre-bloom --help >/dev/null
           ws-sbom-evidence --help >/dev/null
           ws-vulnerability-evidence --help >/dev/null
+          ws-human-triage-ledger --help >/dev/null
           ws-partner-screening --help >/dev/null
           ws-partner-screening-batch --help >/dev/null
           ws-partner-screening-verify --help >/dev/null
@@ -128,6 +130,41 @@ jobs:
         with:
           name: vulnerability-advisory-evidence
           path: deployments/sara_verified_local_v1/vulnerability_evidence_ci
+          if-no-files-found: error
+
+      - name: Build human-review triage ledger evidence
+        run: |
+          rm -rf human_triage_ci
+          ws-human-triage-ledger \
+            --vulnerability-report vulnerability_evidence_ci/vulnerability-advisory-report.json \
+            --vulnerability-summary vulnerability_evidence_ci/vulnerability-evidence-summary.json \
+            --out human_triage_ci \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit-sha "$GITHUB_SHA" \
+            --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --operator "github-actions"
+          test -s human_triage_ci/human-triage-ledger.json
+          test -s human_triage_ci/human-triage-summary.json
+          python -m json.tool human_triage_ci/human-triage-ledger.json >/dev/null
+          python -m json.tool human_triage_ci/human-triage-summary.json >/dev/null
+          python - <<'PY'
+          import json
+          summary=json.load(open('human_triage_ci/human-triage-summary.json', encoding='utf-8'))
+          assert summary['schema'] == 'WS-VULNERABILITY-HUMAN-TRIAGE-LEDGER-V1'
+          assert summary['evidence_status'] == 'INTERNAL_REVIEW_LEDGER_UNSIGNED'
+          assert summary['ledger_record_count'] >= 0
+          assert summary['human_review_required_count'] >= 0
+          assert summary['human_triage_ledger_sha256'].startswith('sha256:')
+          assert 'does not establish absence of vulnerabilities' in summary['claims_boundary']
+          assert 'remediation completion' in summary['claims_boundary']
+          PY
+
+      - name: Upload human-review triage ledger evidence
+        id: upload_human_triage_evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: human-triage-ledger-evidence
+          path: deployments/sara_verified_local_v1/human_triage_ci
           if-no-files-found: error
 
       - name: Validate operations policy
@@ -260,6 +297,9 @@ jobs:
           VULNERABILITY_ARTIFACT_ID: ${{ steps.upload_vulnerability_evidence.outputs.artifact-id }}
           VULNERABILITY_ARTIFACT_DIGEST: ${{ steps.upload_vulnerability_evidence.outputs.artifact-digest }}
           VULNERABILITY_ARTIFACT_URL: ${{ steps.upload_vulnerability_evidence.outputs.artifact-url }}
+          HUMAN_TRIAGE_ARTIFACT_ID: ${{ steps.upload_human_triage_evidence.outputs.artifact-id }}
+          HUMAN_TRIAGE_ARTIFACT_DIGEST: ${{ steps.upload_human_triage_evidence.outputs.artifact-digest }}
+          HUMAN_TRIAGE_ARTIFACT_URL: ${{ steps.upload_human_triage_evidence.outputs.artifact-url }}
           PRE_ARTIFACT_ID: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-id }}
           PRE_ARTIFACT_DIGEST: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-digest }}
           PRE_ARTIFACT_URL: ${{ steps.upload_pre_qualification_evidence.outputs.artifact-url }}
@@ -287,6 +327,7 @@ jobs:
             --partner-dir partner_screening_ci \
             --sbom-dir sbom_evidence_ci \
             --vulnerability-dir vulnerability_evidence_ci \
+            --human-triage-dir human_triage_ci \
             --repository "$GITHUB_REPOSITORY" \
             --commit-sha "$GITHUB_SHA" \
             --workflow-name "$GITHUB_WORKFLOW" \
@@ -308,6 +349,9 @@ jobs:
             --vulnerability-artifact-id "$VULNERABILITY_ARTIFACT_ID" \
             --vulnerability-artifact-digest "$VULNERABILITY_ARTIFACT_DIGEST" \
             --vulnerability-artifact-url "$VULNERABILITY_ARTIFACT_URL" \
+            --human-triage-artifact-id "$HUMAN_TRIAGE_ARTIFACT_ID" \
+            --human-triage-artifact-digest "$HUMAN_TRIAGE_ARTIFACT_DIGEST" \
+            --human-triage-artifact-url "$HUMAN_TRIAGE_ARTIFACT_URL" \
             --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >/dev/null
           test -s release_index_ci/release-index.json
           python -m json.tool release_index_ci/release-index.json >/dev/null
@@ -317,17 +361,21 @@ jobs:
           assert record['schema'] == 'WS-SARA-RELEASE-EVIDENCE-INDEX-V1'
           assert record['artifacts']['software_sbom_evidence']['artifact_digest'].startswith('sha256:')
           assert record['artifacts']['vulnerability_advisory_evidence']['artifact_digest'].startswith('sha256:')
+          assert record['artifacts']['human_triage_ledger_evidence']['artifact_digest'].startswith('sha256:')
           assert record['artifacts']['pre_full_bloom_qualification_evidence']['artifact_digest'].startswith('sha256:')
           assert record['artifacts']['partner_screening_batch_evidence']['artifact_digest'].startswith('sha256:')
           assert record['local_evidence']['sbom_component_count'] > 0
           assert record['local_evidence']['software_sbom_sha256'].startswith('sha256:')
           assert record['local_evidence']['vulnerability_advisory_record_count'] >= 0
           assert record['local_evidence']['vulnerability_report_sha256'].startswith('sha256:')
+          assert record['local_evidence']['human_triage_ledger_record_count'] >= 0
+          assert record['local_evidence']['human_triage_ledger_sha256'].startswith('sha256:')
           assert record['release_index_digest'].startswith('sha256:')
           assert 'does not establish partner validation' in record['claims_boundary']
           assert 'software supply-chain completeness' in record['claims_boundary']
           assert 'absence of vulnerabilities' in record['claims_boundary']
           assert 'vulnerability remediation' in record['claims_boundary']
+          assert 'human-review completion' in record['claims_boundary']
           merge_state = record['workflow']['merge_state']
           event_name = record['workflow']['event_name']
           ref = record['workflow']['ref']

--- a/deployments/sara_verified_local_v1/docs/WS_HUMAN_TRIAGE_LEDGER_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HUMAN_TRIAGE_LEDGER_2026-09-01.md
@@ -1,0 +1,105 @@
+# WS Human-Review Advisory Triage Ledger — 2026-09-01
+
+## Purpose
+
+`ws-human-triage-ledger` turns vulnerability/advisory evidence into a bounded human-review ledger for SARA Verified Local v1.
+
+It consumes the CI-generated `vulnerability-advisory-report.json` and `vulnerability-evidence-summary.json` produced by `ws-vulnerability-evidence`, then emits:
+
+- `human-triage-ledger.json`
+- `human-triage-summary.json`
+
+The ledger records review decisions, reviewer identity, rationale, optional evidence references, and digest-bound source vulnerability evidence.
+
+## Schema
+
+The emitted schema is:
+
+```text
+WS-VULNERABILITY-HUMAN-TRIAGE-LEDGER-V1
+```
+
+The evidence status is:
+
+```text
+INTERNAL_REVIEW_LEDGER_UNSIGNED
+```
+
+## Decision states
+
+The ledger allows only these human-supplied decisions:
+
+- `ACCEPTED_RISK`
+- `PATCH_REQUIRED`
+- `NOT_APPLICABLE`
+- `DEFERRED`
+
+If a matched advisory from the vulnerability evidence has no review input, it remains:
+
+```text
+PENDING_HUMAN_REVIEW
+```
+
+If the vulnerability evidence contains no advisory records, the ledger summary records:
+
+```text
+NO_ADVISORY_RECORDS
+```
+
+## Review input format
+
+Optional review input is local JSON:
+
+```json
+{
+  "reviews": [
+    {
+      "advisory_id": "CVE-2099-0001",
+      "decision": "PATCH_REQUIRED",
+      "reviewer": "CRE1AWS",
+      "rationale": "Matched component requires an explicit patch plan and evidence bundle before closure.",
+      "reviewed_utc": "2026-09-01T18:10:00Z",
+      "evidence_refs": ["vulnerability-advisory-report.json#CVE-2099-0001"]
+    }
+  ]
+}
+```
+
+Review input must reference advisory IDs already present in the vulnerability report. Unknown advisory IDs, duplicate reviews, missing rationale, missing reviewer, or disallowed decisions are rejected.
+
+## CI integration
+
+The SARA Verified Local v1 workflow now:
+
+1. Builds dependency-freeze evidence.
+2. Builds SBOM evidence.
+3. Builds vulnerability/advisory evidence.
+4. Builds human-review triage ledger evidence.
+5. Uploads `human-triage-ledger-evidence`.
+6. Links the uploaded artifact into `sara-release-evidence-index`.
+
+The release index records:
+
+- human triage artifact ID/digest/URL
+- human triage summary digest
+- human triage ledger digest
+- review input status
+- overall ledger status
+- record counts
+- pending review count
+- patch-required count
+- accepted-risk count
+- deferred count
+- source input-file digests
+
+## Claims boundary
+
+This ledger records internal review decisions only.
+
+It does **not** establish absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, remediation completion, exploitability analysis, secure-by-design status, license legal review, SLSA compliance, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, FedRAMP authorization, ISO certification, SOC 2 attestation, supplier approval, partner validation, external reproduction, field performance, hardware performance, classified access, or operational authority.
+
+## Standards effect
+
+This increment improves standards-control readiness by adding a repeatable review ledger and release-custody surface.
+
+It does not promote a control to `MET` or `EXCEEDED`. Formal promotion remains blocked until there is independently reviewed evidence for advisory feed provenance, remediation evidence, exploitability or non-applicability rationale, policy/control mapping, and accountable approval.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -29,6 +29,7 @@ ws-partner-screening-verify = "worldshepherd_sara.partner_screening_verify_cli:m
 ws-release-index = "worldshepherd_sara.release_index_cli:main"
 ws-sbom-evidence = "worldshepherd_sara.sbom_cli:main"
 ws-vulnerability-evidence = "worldshepherd_sara.vulnerability_cli:main"
+ws-human-triage-ledger = "worldshepherd_sara.human_triage_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_human_triage_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_human_triage_cli.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldshepherd_sara.human_triage_cli import (
+    DECISION_ACCEPTED_RISK,
+    DECISION_NOT_APPLICABLE,
+    DECISION_PATCH_REQUIRED,
+    EVIDENCE_STATUS,
+    REVIEW_INPUT_NONE,
+    REVIEW_INPUT_SUPPLIED,
+    TRIAGE_LEDGER_SCHEMA,
+    build_human_triage_ledger,
+    main,
+    write_human_triage_ledger,
+)
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _make_vulnerability_evidence(tmp_path, *, with_advisory: bool = True):
+    root = tmp_path / "vulnerability_evidence_ci"
+    records = []
+    if with_advisory:
+        records = [
+            {
+                "advisory_id": "CVE-2099-0001",
+                "component": "fastapi",
+                "severity": "HIGH",
+                "source": "test-advisory-input",
+                "reference": "https://example.invalid/CVE-2099-0001",
+                "matched_component_in_sbom": True,
+                "triage_status": "OPEN_TRIAGE_REQUIRED",
+                "remediation_status": "NOT_REMEDIATED_BY_THIS_RECORD",
+            },
+            {
+                "advisory_id": "CVE-2099-0002",
+                "component": "unused-package",
+                "severity": "LOW",
+                "source": "test-advisory-input",
+                "reference": "https://example.invalid/CVE-2099-0002",
+                "matched_component_in_sbom": False,
+                "triage_status": "NOT_PRESENT_IN_CURRENT_SBOM_INPUT",
+                "remediation_status": "NOT_REMEDIATED_BY_THIS_RECORD",
+            },
+        ]
+    _write_json(
+        root / "vulnerability-advisory-report.json",
+        {
+            "schema": "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1",
+            "generated_utc": "2026-09-01T18:00:00Z",
+            "repository": "Bdavis1390/Sara_pro",
+            "commit_sha": "abc123",
+            "operator": "github-actions",
+            "evidence_status": "INTERNAL_CI_GENERATED_UNSIGNED",
+            "advisory_input_status": "ADVISORY_INPUT_RECORDED_UNVERIFIED" if with_advisory else "NO_EXTERNAL_ADVISORY_FEED_EXECUTED",
+            "advisory_triage": {
+                "advisory_record_count": len(records),
+                "matched_advisory_count": sum(1 for record in records if record["matched_component_in_sbom"]),
+                "records": records,
+            },
+            "claims_boundary": "Vulnerability advisory evidence does not establish absence of vulnerabilities or remediation.",
+        },
+    )
+    _write_json(
+        root / "vulnerability-evidence-summary.json",
+        {
+            "schema": "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1",
+            "generated_utc": "2026-09-01T18:00:00Z",
+            "repository": "Bdavis1390/Sara_pro",
+            "commit_sha": "abc123",
+            "operator": "github-actions",
+            "evidence_status": "INTERNAL_CI_GENERATED_UNSIGNED",
+            "advisory_input_status": "ADVISORY_INPUT_RECORDED_UNVERIFIED" if with_advisory else "NO_EXTERNAL_ADVISORY_FEED_EXECUTED",
+            "component_count": 1,
+            "advisory_record_count": len(records),
+            "matched_advisory_count": sum(1 for record in records if record["matched_component_in_sbom"]),
+            "vulnerability_report_sha256": "sha256:" + "1" * 64,
+            "claims_boundary": "Vulnerability advisory evidence does not establish absence of vulnerabilities or remediation.",
+        },
+    )
+    return root / "vulnerability-advisory-report.json", root / "vulnerability-evidence-summary.json"
+
+
+def test_human_triage_records_pending_and_not_applicable_decisions(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+
+    ledger, summary = build_human_triage_ledger(
+        vulnerability_report=report_path,
+        vulnerability_summary=summary_path,
+        review_input=None,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+        executed_utc="2026-09-01T18:05:00Z",
+    )
+
+    assert ledger["schema"] == TRIAGE_LEDGER_SCHEMA
+    assert ledger["evidence_status"] == EVIDENCE_STATUS
+    assert ledger["review_input_status"] == REVIEW_INPUT_NONE
+    assert ledger["review_summary"]["overall_status"] == "HUMAN_REVIEW_PENDING"
+    assert ledger["review_summary"]["ledger_record_count"] == 2
+    assert ledger["review_summary"]["human_review_required_count"] == 1
+    assert ledger["review_summary"]["pending_review_count"] == 1
+    assert ledger["review_summary"]["not_applicable_count"] == 1
+    assert ledger["records"][0]["advisory_id"] == "CVE-2099-0001"
+    assert ledger["records"][0]["decision"] == "PENDING_HUMAN_REVIEW"
+    assert ledger["records"][0]["remediation_status"] == "NOT_RECORDED_BY_THIS_LEDGER"
+    assert ledger["records"][1]["decision"] == DECISION_NOT_APPLICABLE
+    assert summary["schema"] == TRIAGE_LEDGER_SCHEMA
+    assert summary["pending_review_count"] == 1
+    assert summary["summary_digest"].startswith("sha256:")
+    assert "does not establish absence of vulnerabilities" in summary["claims_boundary"]
+    assert "remediation completion" in summary["claims_boundary"]
+
+
+def test_human_triage_applies_review_input_without_claiming_remediation(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+    review_input = tmp_path / "reviews.json"
+    _write_json(
+        review_input,
+        {
+            "reviews": [
+                {
+                    "advisory_id": "CVE-2099-0001",
+                    "decision": "PATCH_REQUIRED",
+                    "reviewer": "CRE1AWS",
+                    "rationale": "Matched component requires an explicit patch plan and evidence bundle before closure.",
+                    "reviewed_utc": "2026-09-01T18:10:00Z",
+                    "evidence_refs": ["vulnerability-advisory-report.json#CVE-2099-0001"],
+                }
+            ]
+        },
+    )
+
+    ledger, summary = build_human_triage_ledger(
+        vulnerability_report=report_path,
+        vulnerability_summary=summary_path,
+        review_input=review_input,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="CRE1AWS",
+        executed_utc="2026-09-01T18:11:00Z",
+    )
+
+    assert ledger["review_input_status"] == REVIEW_INPUT_SUPPLIED
+    assert ledger["review_summary"]["overall_status"] == "HUMAN_REVIEW_RECORDED_UNSIGNED"
+    assert ledger["review_summary"]["patch_required_count"] == 1
+    assert ledger["review_summary"]["pending_review_count"] == 0
+    reviewed = next(record for record in ledger["records"] if record["advisory_id"] == "CVE-2099-0001")
+    assert reviewed["decision"] == DECISION_PATCH_REQUIRED
+    assert reviewed["reviewer"] == "CRE1AWS"
+    assert reviewed["rationale"].startswith("Matched component requires")
+    assert reviewed["remediation_status"] == "NOT_RECORDED_BY_THIS_LEDGER"
+    assert summary["patch_required_count"] == 1
+    text = json.dumps(ledger).lower()
+    for forbidden in ("remediation_complete", "cmmc_certified", "partner_validated", "scan_passed"):
+        assert forbidden not in text
+
+
+def test_human_triage_supports_no_advisory_records(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=False)
+
+    ledger, summary = build_human_triage_ledger(
+        vulnerability_report=report_path,
+        vulnerability_summary=summary_path,
+        review_input=None,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+        executed_utc="2026-09-01T18:12:00Z",
+    )
+
+    assert ledger["review_summary"]["overall_status"] == "NO_ADVISORY_RECORDS"
+    assert ledger["records"] == []
+    assert summary["ledger_record_count"] == 0
+    assert summary["human_review_required_count"] == 0
+
+
+def test_human_triage_cli_writes_ledger_and_summary(tmp_path, monkeypatch) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+    out_dir = tmp_path / "human_triage_ci"
+
+    monkeypatch.chdir(tmp_path)
+    exit_code = main(
+        [
+            "--vulnerability-report",
+            str(report_path.relative_to(tmp_path)),
+            "--vulnerability-summary",
+            str(summary_path.relative_to(tmp_path)),
+            "--out",
+            str(out_dir.relative_to(tmp_path)),
+            "--repository",
+            "Bdavis1390/Sara_pro",
+            "--commit-sha",
+            "abc123",
+            "--operator",
+            "github-actions",
+            "--executed-utc",
+            "2026-09-01T18:13:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    ledger = json.loads((out_dir / "human-triage-ledger.json").read_text(encoding="utf-8"))
+    summary = json.loads((out_dir / "human-triage-summary.json").read_text(encoding="utf-8"))
+    assert ledger["schema"] == TRIAGE_LEDGER_SCHEMA
+    assert summary["human_triage_ledger_sha256"].startswith("sha256:")
+    assert summary["input_files"]["vulnerability_report"]["sha256"].startswith("sha256:")
+
+
+def test_human_triage_rejects_unknown_review_advisory(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+    review_input = tmp_path / "reviews.json"
+    _write_json(
+        review_input,
+        {
+            "reviews": [
+                {
+                    "advisory_id": "CVE-2099-9999",
+                    "decision": "ACCEPTED_RISK",
+                    "reviewer": "CRE1AWS",
+                    "rationale": "Unknown advisory should be rejected.",
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="unknown advisory_id"):
+        build_human_triage_ledger(
+            vulnerability_report=report_path,
+            vulnerability_summary=summary_path,
+            review_input=review_input,
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            operator="CRE1AWS",
+        )
+
+
+def test_human_triage_rejects_disallowed_review_decision(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+    review_input = tmp_path / "reviews.json"
+    _write_json(
+        review_input,
+        {
+            "reviews": [
+                {
+                    "advisory_id": "CVE-2099-0001",
+                    "decision": "REMEDIATION_COMPLETE",
+                    "reviewer": "CRE1AWS",
+                    "rationale": "This would make a false closure claim.",
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="decision must be one of"):
+        build_human_triage_ledger(
+            vulnerability_report=report_path,
+            vulnerability_summary=summary_path,
+            review_input=review_input,
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            operator="CRE1AWS",
+        )
+
+
+def test_human_triage_rejects_bad_source_schema(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+    _write_json(report_path, {"schema": "WRONG"})
+
+    with pytest.raises(ValueError, match="unexpected vulnerability advisory report schema"):
+        build_human_triage_ledger(
+            vulnerability_report=report_path,
+            vulnerability_summary=summary_path,
+            review_input=None,
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            operator="github-actions",
+        )
+
+
+def test_human_triage_rejects_paths_outside_working_directory(tmp_path, monkeypatch) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=False)
+    outside = tmp_path.parent / "outside-vulnerability-summary.json"
+    outside.write_text(summary_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="CLI path must resolve under working directory"):
+        main(
+            [
+                "--vulnerability-report",
+                str(report_path.relative_to(tmp_path)),
+                "--vulnerability-summary",
+                str(outside),
+                "--out",
+                "human_triage_ci",
+                "--repository",
+                "Bdavis1390/Sara_pro",
+                "--commit-sha",
+                "abc123",
+            ]
+        )
+
+
+def test_write_human_triage_summary_contains_ledger_digest(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+
+    summary = write_human_triage_ledger(
+        out_dir=tmp_path / "human_triage_ci",
+        vulnerability_report=report_path,
+        vulnerability_summary=summary_path,
+        review_input=None,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+    )
+
+    assert summary["human_triage_ledger_path"].endswith("human-triage-ledger.json")
+    assert summary["human_triage_ledger_sha256"].startswith("sha256:")
+    assert summary["summary_digest"].startswith("sha256:")
+
+
+def test_human_triage_accepts_accepted_risk_decision_with_rationale(tmp_path) -> None:
+    report_path, summary_path = _make_vulnerability_evidence(tmp_path, with_advisory=True)
+    review_input = tmp_path / "reviews.json"
+    _write_json(
+        review_input,
+        {
+            "reviews": [
+                {
+                    "advisory_id": "CVE-2099-0001",
+                    "decision": "ACCEPTED_RISK",
+                    "reviewer": "CRE1AWS",
+                    "rationale": "Accepted for bounded prototype only; must be revisited before external release.",
+                    "evidence_refs": ["risk-register#RISK-001"],
+                }
+            ]
+        },
+    )
+
+    ledger, summary = build_human_triage_ledger(
+        vulnerability_report=report_path,
+        vulnerability_summary=summary_path,
+        review_input=review_input,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="CRE1AWS",
+    )
+
+    assert ledger["review_summary"]["accepted_risk_count"] == 1
+    assert summary["accepted_risk_count"] == 1
+    assert next(record for record in ledger["records"] if record["advisory_id"] == "CVE-2099-0001")[
+        "decision"
+    ] == DECISION_ACCEPTED_RISK

--- a/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_release_index_cli.py
@@ -25,6 +25,8 @@ def _make_evidence_dirs(tmp_path):
     partner_dir = tmp_path / "partner_screening_ci"
     sbom_dir = tmp_path / "sbom_evidence_ci"
     vulnerability_dir = tmp_path / "vulnerability_evidence_ci"
+    human_triage_dir = tmp_path / "human_triage_ci"
+
     _write_json(
         pre_dir / "qualification_index.json",
         {
@@ -68,7 +70,7 @@ def _make_evidence_dirs(tmp_path):
         vulnerability_dir / "vulnerability-advisory-report.json",
         {
             "schema": "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1",
-            "advisory_triage": {"advisory_record_count": 0, "matched_advisory_count": 0},
+            "advisory_triage": {"advisory_record_count": 0, "matched_advisory_count": 0, "records": []},
         },
     )
     _write_json(
@@ -88,64 +90,104 @@ def _make_evidence_dirs(tmp_path):
             "claims_boundary": "Vulnerability advisory evidence does not establish absence of vulnerabilities or remediation.",
         },
     )
-    return pre_dir, partner_dir, sbom_dir, vulnerability_dir
+    _write_json(
+        human_triage_dir / "human-triage-ledger.json",
+        {
+            "schema": "WS-VULNERABILITY-HUMAN-TRIAGE-LEDGER-V1",
+            "records": [],
+            "review_summary": {"overall_status": "NO_ADVISORY_RECORDS"},
+        },
+    )
+    _write_json(
+        human_triage_dir / "human-triage-summary.json",
+        {
+            "schema": "WS-VULNERABILITY-HUMAN-TRIAGE-LEDGER-V1",
+            "evidence_status": "INTERNAL_REVIEW_LEDGER_UNSIGNED",
+            "review_input_status": "NO_HUMAN_REVIEW_INPUT_SUPPLIED",
+            "overall_status": "NO_ADVISORY_RECORDS",
+            "ledger_record_count": 0,
+            "human_review_required_count": 0,
+            "pending_review_count": 0,
+            "patch_required_count": 0,
+            "accepted_risk_count": 0,
+            "not_applicable_count": 0,
+            "deferred_count": 0,
+            "human_triage_ledger_sha256": "sha256:" + "8" * 64,
+            "input_files": {
+                "vulnerability_report": {"sha256": "sha256:" + "9" * 64},
+                "vulnerability_summary": {"sha256": "sha256:" + "a" * 64},
+            },
+            "claims_boundary": "Human-review advisory triage ledger does not establish absence of vulnerabilities or remediation completion.",
+        },
+    )
+    return pre_dir, partner_dir, sbom_dir, vulnerability_dir, human_triage_dir
+
+
+def _index_kwargs(tmp_path, **overrides):
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir, human_triage_dir = _make_evidence_dirs(tmp_path)
+    kwargs = {
+        "repository": "Bdavis1390/Sara_pro",
+        "commit_sha": "abc123",
+        "workflow_name": "SARA Verified Local v1 Gate",
+        "workflow_run_id": "33500000000",
+        "workflow_run_number": "653",
+        "event_name": "pull_request",
+        "ref": "refs/pull/44/merge",
+        "pr_number": "44",
+        "merge_state": MERGE_STATE_PR_CANDIDATE,
+        "pre_dir": pre_dir,
+        "partner_dir": partner_dir,
+        "sbom_dir": sbom_dir,
+        "vulnerability_dir": vulnerability_dir,
+        "human_triage_dir": human_triage_dir,
+        "pre_artifact_id": "111",
+        "pre_artifact_digest": "sha256:" + "b" * 64,
+        "pre_artifact_url": "https://github.example/pre",
+        "partner_artifact_id": "222",
+        "partner_artifact_digest": "sha256:" + "c" * 64,
+        "partner_artifact_url": "https://github.example/partner",
+        "sbom_artifact_id": "333",
+        "sbom_artifact_digest": "sha256:" + "d" * 64,
+        "sbom_artifact_url": "https://github.example/sbom",
+        "vulnerability_artifact_id": "444",
+        "vulnerability_artifact_digest": "sha256:" + "e" * 64,
+        "vulnerability_artifact_url": "https://github.example/vulnerability",
+        "human_triage_artifact_id": "555",
+        "human_triage_artifact_digest": "sha256:" + "f" * 64,
+        "human_triage_artifact_url": "https://github.example/human-triage",
+        "executed_utc": "2026-09-01T17:10:00Z",
+    }
+    kwargs.update(overrides)
+    return kwargs
 
 
 def test_release_index_records_ci_artifacts_and_claims_boundary(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
-
-    index = build_release_evidence_index(
-        repository="Bdavis1390/Sara_pro",
-        commit_sha="abc123",
-        workflow_name="SARA Verified Local v1 Gate",
-        workflow_run_id="33500000000",
-        workflow_run_number="653",
-        event_name="pull_request",
-        ref="refs/pull/44/merge",
-        pr_number="44",
-        merge_state=MERGE_STATE_PR_CANDIDATE,
-        pre_dir=pre_dir,
-        partner_dir=partner_dir,
-        sbom_dir=sbom_dir,
-        vulnerability_dir=vulnerability_dir,
-        pre_artifact_id="111",
-        pre_artifact_digest="sha256:" + "a" * 64,
-        pre_artifact_url="https://github.example/pre",
-        partner_artifact_id="222",
-        partner_artifact_digest="b" * 64,
-        partner_artifact_url="https://github.example/partner",
-        sbom_artifact_id="333",
-        sbom_artifact_digest="sha256:" + "c" * 64,
-        sbom_artifact_url="https://github.example/sbom",
-        vulnerability_artifact_id="444",
-        vulnerability_artifact_digest="sha256:" + "d" * 64,
-        vulnerability_artifact_url="https://github.example/vulnerability",
-        executed_utc="2026-09-01T17:10:00Z",
-    )
+    index = build_release_evidence_index(**_index_kwargs(tmp_path))
 
     assert index["schema"] == RELEASE_INDEX_SCHEMA
     assert index["commit_sha"] == "abc123"
     assert index["workflow"]["pull_request_number"] == "44"
     assert index["workflow"]["merge_state"] == MERGE_STATE_PR_CANDIDATE
-    assert index["artifacts"]["software_sbom_evidence"]["artifact_digest"] == "sha256:" + "c" * 64
-    assert index["artifacts"]["vulnerability_advisory_evidence"]["artifact_digest"] == "sha256:" + "d" * 64
-    assert index["artifacts"]["pre_full_bloom_qualification_evidence"]["artifact_digest"] == "sha256:" + "a" * 64
-    assert index["artifacts"]["partner_screening_batch_evidence"]["artifact_digest"] == "sha256:" + "b" * 64
+    assert index["artifacts"]["software_sbom_evidence"]["artifact_digest"] == "sha256:" + "d" * 64
+    assert index["artifacts"]["vulnerability_advisory_evidence"]["artifact_digest"] == "sha256:" + "e" * 64
+    assert index["artifacts"]["human_triage_ledger_evidence"]["artifact_digest"] == "sha256:" + "f" * 64
+    assert index["artifacts"]["pre_full_bloom_qualification_evidence"]["artifact_digest"] == "sha256:" + "b" * 64
+    assert index["artifacts"]["partner_screening_batch_evidence"]["artifact_digest"] == "sha256:" + "c" * 64
     assert index["local_evidence"]["sbom_component_count"] == 1
-    assert index["local_evidence"]["sbom_evidence_status"] == "INTERNAL_CI_GENERATED_UNSIGNED"
     assert index["local_evidence"]["vulnerability_advisory_record_count"] == 0
-    assert index["local_evidence"]["vulnerability_evidence_status"] == "INTERNAL_CI_GENERATED_UNSIGNED"
+    assert index["local_evidence"]["human_triage_evidence_status"] == "INTERNAL_REVIEW_LEDGER_UNSIGNED"
+    assert index["local_evidence"]["human_triage_overall_status"] == "NO_ADVISORY_RECORDS"
+    assert index["local_evidence"]["human_triage_ledger_record_count"] == 0
     assert index["local_evidence"]["partner_batch_digest"] == "sha256:" + "2" * 64
-    assert index["local_evidence"]["partner_package_count"] == 4
-    assert index["local_evidence"]["partner_presets"] == ["BAE_SYSTEMS", "GENERIC_PRIME"]
     assert index["release_index_digest"].startswith("sha256:")
     assert "does not establish partner validation" in index["claims_boundary"]
     assert "software supply-chain completeness" in index["claims_boundary"]
     assert "absence of vulnerabilities" in index["claims_boundary"]
+    assert "human-review completion" in index["claims_boundary"]
 
 
 def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
+    pre_dir, partner_dir, sbom_dir, vulnerability_dir, human_triage_dir = _make_evidence_dirs(tmp_path)
     out_path = tmp_path / "release_index_ci" / "release-index.json"
 
     exit_code = main(
@@ -160,6 +202,8 @@ def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
             str(sbom_dir),
             "--vulnerability-dir",
             str(vulnerability_dir),
+            "--human-triage-dir",
+            str(human_triage_dir),
             "--repository",
             "Bdavis1390/Sara_pro",
             "--commit-sha",
@@ -190,6 +234,10 @@ def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
             "444",
             "--vulnerability-artifact-digest",
             "sha256:" + "f" * 64,
+            "--human-triage-artifact-id",
+            "555",
+            "--human-triage-artifact-digest",
+            "sha256:" + "1" * 64,
             "--executed-utc",
             "2026-09-01T17:11:00Z",
         ]
@@ -204,6 +252,7 @@ def test_release_index_cli_writes_main_push_index_file(tmp_path) -> None:
     assert written["workflow"]["merge_state"] == MERGE_STATE_MAIN_PUSH
     assert written["artifacts"]["software_sbom_evidence"]["artifact_digest"] == "sha256:" + "e" * 64
     assert written["artifacts"]["vulnerability_advisory_evidence"]["artifact_digest"] == "sha256:" + "f" * 64
+    assert written["artifacts"]["human_triage_ledger_evidence"]["artifact_digest"] == "sha256:" + "1" * 64
 
 
 def test_release_index_derives_manual_or_non_main_state() -> None:
@@ -212,134 +261,42 @@ def test_release_index_derives_manual_or_non_main_state() -> None:
 
 
 def test_release_index_rejects_bad_artifact_digest(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
-
     with pytest.raises(ValueError, match="must be a SHA-256 digest"):
-        build_release_evidence_index(
-            repository="Bdavis1390/Sara_pro",
-            commit_sha="abc123",
-            workflow_name="SARA Verified Local v1 Gate",
-            workflow_run_id="33500000002",
-            workflow_run_number="655",
-            event_name="pull_request",
-            ref="refs/pull/44/merge",
-            pr_number="44",
-            merge_state=MERGE_STATE_PR_CANDIDATE,
-            pre_dir=pre_dir,
-            partner_dir=partner_dir,
-            sbom_dir=sbom_dir,
-            vulnerability_dir=vulnerability_dir,
-            pre_artifact_id="111",
-            pre_artifact_digest="not-a-digest",
-            pre_artifact_url=None,
-            partner_artifact_id="222",
-            partner_artifact_digest="sha256:" + "e" * 64,
-            partner_artifact_url=None,
-            sbom_artifact_id="333",
-            sbom_artifact_digest="sha256:" + "f" * 64,
-            sbom_artifact_url=None,
-            vulnerability_artifact_id="444",
-            vulnerability_artifact_digest="sha256:" + "d" * 64,
-            vulnerability_artifact_url=None,
-        )
+        build_release_evidence_index(**_index_kwargs(tmp_path, pre_artifact_digest="not-a-digest"))
 
 
 def test_release_index_rejects_merge_state_mismatch(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
-
     with pytest.raises(ValueError, match="does not match event/ref context"):
         build_release_evidence_index(
-            repository="Bdavis1390/Sara_pro",
-            commit_sha="abc123",
-            workflow_name="SARA Verified Local v1 Gate",
-            workflow_run_id="33500000003",
-            workflow_run_number="656",
-            event_name="push",
-            ref="refs/heads/main",
-            pr_number=None,
-            merge_state=MERGE_STATE_PR_CANDIDATE,
-            pre_dir=pre_dir,
-            partner_dir=partner_dir,
-            sbom_dir=sbom_dir,
-            vulnerability_dir=vulnerability_dir,
-            pre_artifact_id="111",
-            pre_artifact_digest="sha256:" + "f" * 64,
-            pre_artifact_url=None,
-            partner_artifact_id="222",
-            partner_artifact_digest="sha256:" + "e" * 64,
-            partner_artifact_url=None,
-            sbom_artifact_id="333",
-            sbom_artifact_digest="sha256:" + "d" * 64,
-            sbom_artifact_url=None,
-            vulnerability_artifact_id="444",
-            vulnerability_artifact_digest="sha256:" + "c" * 64,
-            vulnerability_artifact_url=None,
+            **_index_kwargs(
+                tmp_path,
+                event_name="push",
+                ref="refs/heads/main",
+                pr_number=None,
+                merge_state=MERGE_STATE_PR_CANDIDATE,
+            )
         )
 
 
 def test_release_index_rejects_bad_sbom_summary_schema(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
-    _write_json(sbom_dir / "sbom-evidence-summary.json", {"schema": "WRONG"})
+    kwargs = _index_kwargs(tmp_path)
+    _write_json(kwargs["sbom_dir"] / "sbom-evidence-summary.json", {"schema": "WRONG"})
 
     with pytest.raises(ValueError, match="unexpected SBOM evidence summary schema"):
-        build_release_evidence_index(
-            repository="Bdavis1390/Sara_pro",
-            commit_sha="abc123",
-            workflow_name="SARA Verified Local v1 Gate",
-            workflow_run_id="33500000004",
-            workflow_run_number="657",
-            event_name="pull_request",
-            ref="refs/pull/44/merge",
-            pr_number="44",
-            merge_state=MERGE_STATE_PR_CANDIDATE,
-            pre_dir=pre_dir,
-            partner_dir=partner_dir,
-            sbom_dir=sbom_dir,
-            vulnerability_dir=vulnerability_dir,
-            pre_artifact_id="111",
-            pre_artifact_digest="sha256:" + "f" * 64,
-            pre_artifact_url=None,
-            partner_artifact_id="222",
-            partner_artifact_digest="sha256:" + "e" * 64,
-            partner_artifact_url=None,
-            sbom_artifact_id="333",
-            sbom_artifact_digest="sha256:" + "d" * 64,
-            sbom_artifact_url=None,
-            vulnerability_artifact_id="444",
-            vulnerability_artifact_digest="sha256:" + "c" * 64,
-            vulnerability_artifact_url=None,
-        )
+        build_release_evidence_index(**kwargs)
 
 
 def test_release_index_rejects_bad_vulnerability_summary_schema(tmp_path) -> None:
-    pre_dir, partner_dir, sbom_dir, vulnerability_dir = _make_evidence_dirs(tmp_path)
-    _write_json(vulnerability_dir / "vulnerability-evidence-summary.json", {"schema": "WRONG"})
+    kwargs = _index_kwargs(tmp_path)
+    _write_json(kwargs["vulnerability_dir"] / "vulnerability-evidence-summary.json", {"schema": "WRONG"})
 
     with pytest.raises(ValueError, match="unexpected vulnerability evidence summary schema"):
-        build_release_evidence_index(
-            repository="Bdavis1390/Sara_pro",
-            commit_sha="abc123",
-            workflow_name="SARA Verified Local v1 Gate",
-            workflow_run_id="33500000005",
-            workflow_run_number="658",
-            event_name="pull_request",
-            ref="refs/pull/45/merge",
-            pr_number="45",
-            merge_state=MERGE_STATE_PR_CANDIDATE,
-            pre_dir=pre_dir,
-            partner_dir=partner_dir,
-            sbom_dir=sbom_dir,
-            vulnerability_dir=vulnerability_dir,
-            pre_artifact_id="111",
-            pre_artifact_digest="sha256:" + "f" * 64,
-            pre_artifact_url=None,
-            partner_artifact_id="222",
-            partner_artifact_digest="sha256:" + "e" * 64,
-            partner_artifact_url=None,
-            sbom_artifact_id="333",
-            sbom_artifact_digest="sha256:" + "d" * 64,
-            sbom_artifact_url=None,
-            vulnerability_artifact_id="444",
-            vulnerability_artifact_digest="sha256:" + "c" * 64,
-            vulnerability_artifact_url=None,
-        )
+        build_release_evidence_index(**kwargs)
+
+
+def test_release_index_rejects_bad_human_triage_summary_schema(tmp_path) -> None:
+    kwargs = _index_kwargs(tmp_path)
+    _write_json(kwargs["human_triage_dir"] / "human-triage-summary.json", {"schema": "WRONG"})
+
+    with pytest.raises(ValueError, match="unexpected human triage summary schema"):
+        build_release_evidence_index(**kwargs)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/human_triage_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/human_triage_cli.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .qualification import canonical_digest
+
+TRIAGE_LEDGER_SCHEMA = "WS-VULNERABILITY-HUMAN-TRIAGE-LEDGER-V1"
+VULNERABILITY_EVIDENCE_SCHEMA = "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1"
+EVIDENCE_STATUS = "INTERNAL_REVIEW_LEDGER_UNSIGNED"
+REVIEW_INPUT_NONE = "NO_HUMAN_REVIEW_INPUT_SUPPLIED"
+REVIEW_INPUT_SUPPLIED = "HUMAN_REVIEW_INPUT_RECORDED_UNSIGNED"
+
+DECISION_PENDING = "PENDING_HUMAN_REVIEW"
+DECISION_ACCEPTED_RISK = "ACCEPTED_RISK"
+DECISION_PATCH_REQUIRED = "PATCH_REQUIRED"
+DECISION_NOT_APPLICABLE = "NOT_APPLICABLE"
+DECISION_DEFERRED = "DEFERRED"
+DECISION_NO_ADVISORY_RECORDS = "NO_ADVISORY_RECORDS"
+
+ALLOWED_DECISIONS = {
+    DECISION_ACCEPTED_RISK,
+    DECISION_PATCH_REQUIRED,
+    DECISION_NOT_APPLICABLE,
+    DECISION_DEFERRED,
+}
+
+CLAIMS_BOUNDARY = (
+    "Human-review advisory triage ledger records internal review decisions, rationale, and evidence references only. "
+    "It does not establish absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, remediation "
+    "completion, exploitability analysis, secure-by-design status, license legal review, SLSA compliance, CMMC/NIST/DFARS "
+    "conformity, FedRAMP authorization, ISO certification, SOC 2 attestation, supplier approval, partner validation, "
+    "external reproduction, field performance, hardware performance, classified access, or operational authority."
+)
+
+NOT_CLAIMED = [
+    "absence_of_vulnerabilities",
+    "advisory_feed_completeness",
+    "vulnerability_scan_pass",
+    "remediation_completion",
+    "exploitability_analysis",
+    "secure_by_design_status",
+    "license_legal_review",
+    "slsa_compliance",
+    "cmmc_conformity",
+    "nist_800_171_implementation",
+    "dfars_satisfaction",
+    "fedramp_authorization",
+    "iso_certification",
+    "soc2_attestation",
+    "supplier_approval",
+    "partner_validation",
+    "external_reproduction",
+    "field_or_hardware_performance",
+]
+
+FORBIDDEN_CLAIM_TOKENS = (
+    "no_vulnerabilities",
+    "vulnerability_free",
+    "scan_passed",
+    "remediation_complete",
+    "cmmc_certified",
+    "nist_800_171_conformant",
+    "dfars_satisfied",
+    "slsa_compliant",
+    "fedramp_authorized",
+    "iso_certified",
+    "soc2_attested",
+    "supplier_approved",
+    "partner_validated",
+    "field_validated",
+    "hardware_validated",
+)
+
+
+def _json_text(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_text(value), encoding="utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"required file missing for digest: {path}")
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"required JSON file missing: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _optional_file_digest(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    if not path.is_file():
+        raise ValueError(f"optional input was supplied but does not exist: {path}")
+    return {"path": str(path), "sha256": _sha256_file(path), "size_bytes": path.stat().st_size}
+
+
+def _resolve_cli_path(path: Path, *, base_dir: Path, must_exist: bool, allow_directory: bool) -> Path:
+    base = base_dir.resolve()
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"CLI path must resolve under working directory: {path}") from exc
+    if must_exist:
+        if allow_directory and not resolved.is_dir():
+            raise ValueError(f"expected directory input: {path}")
+        if not allow_directory and not resolved.is_file():
+            raise ValueError(f"expected file input: {path}")
+    return resolved
+
+
+def _resolve_optional_cli_file(path: Path | None, *, base_dir: Path) -> Path | None:
+    if path is None:
+        return None
+    return _resolve_cli_path(path, base_dir=base_dir, must_exist=True, allow_directory=False)
+
+
+def _assert_no_forbidden_claims(**values: dict[str, Any]) -> None:
+    text = json.dumps(values, sort_keys=True).lower()
+    for token in FORBIDDEN_CLAIM_TOKENS:
+        if token in text:
+            raise ValueError(f"prohibited security/compliance claim present: {token}")
+
+
+def _validate_vulnerability_evidence(report: dict[str, Any], summary: dict[str, Any]) -> None:
+    if report.get("schema") != VULNERABILITY_EVIDENCE_SCHEMA:
+        raise ValueError("unexpected vulnerability advisory report schema")
+    if summary.get("schema") != VULNERABILITY_EVIDENCE_SCHEMA:
+        raise ValueError("unexpected vulnerability evidence summary schema")
+    if report.get("commit_sha") and summary.get("commit_sha") and report["commit_sha"] != summary["commit_sha"]:
+        raise ValueError("vulnerability report and summary commit_sha values do not match")
+    if "does not establish" not in str(report.get("claims_boundary", "")):
+        raise ValueError("vulnerability report missing claims boundary")
+    if "does not establish" not in str(summary.get("claims_boundary", "")):
+        raise ValueError("vulnerability summary missing claims boundary")
+
+
+def _load_review_input(review_input: Path | None) -> list[dict[str, Any]]:
+    if review_input is None:
+        return []
+    payload = _load_json(review_input)
+    reviews = payload.get("reviews", [])
+    if not isinstance(reviews, list):
+        raise ValueError("review input must contain a reviews list")
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, review in enumerate(reviews, start=1):
+        if not isinstance(review, dict):
+            raise ValueError("review entries must be objects")
+        advisory_id = str(review.get("advisory_id") or "").strip()
+        if not advisory_id:
+            raise ValueError(f"review {index} missing advisory_id")
+        if advisory_id in seen:
+            raise ValueError(f"duplicate review decision for advisory_id: {advisory_id}")
+        seen.add(advisory_id)
+        decision = str(review.get("decision") or "").strip().upper()
+        if decision not in ALLOWED_DECISIONS:
+            raise ValueError(f"review {advisory_id} decision must be one of {sorted(ALLOWED_DECISIONS)}")
+        reviewer = str(review.get("reviewer") or "").strip()
+        if not reviewer:
+            raise ValueError(f"review {advisory_id} missing reviewer")
+        rationale = str(review.get("rationale") or "").strip()
+        if not rationale:
+            raise ValueError(f"review {advisory_id} missing rationale")
+        evidence_refs = review.get("evidence_refs", [])
+        if evidence_refs is None:
+            evidence_refs = []
+        if not isinstance(evidence_refs, list) or not all(isinstance(item, str) and item.strip() for item in evidence_refs):
+            raise ValueError(f"review {advisory_id} evidence_refs must be a list of non-empty strings")
+        normalized.append(
+            {
+                "advisory_id": advisory_id,
+                "decision": decision,
+                "reviewer": reviewer,
+                "rationale": rationale,
+                "reviewed_utc": review.get("reviewed_utc"),
+                "evidence_refs": [item.strip() for item in evidence_refs],
+            }
+        )
+    return normalized
+
+
+def _severity_sort_key(record: dict[str, Any]) -> tuple[int, str]:
+    priority = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+    return (priority.get(str(record.get("severity", "UNKNOWN")).upper(), 4), str(record.get("advisory_id", "")))
+
+
+def build_human_triage_ledger(
+    *,
+    vulnerability_report: Path,
+    vulnerability_summary: Path,
+    review_input: Path | None,
+    repository: str,
+    commit_sha: str,
+    operator: str,
+    executed_utc: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build an unsigned internal human-review ledger from vulnerability advisory evidence."""
+    if not commit_sha:
+        raise ValueError("commit_sha is required")
+
+    report = _load_json(vulnerability_report)
+    summary_source = _load_json(vulnerability_summary)
+    _validate_vulnerability_evidence(report, summary_source)
+
+    source_commit = str(summary_source.get("commit_sha") or report.get("commit_sha") or "")
+    if source_commit and source_commit != commit_sha:
+        raise ValueError("triage ledger commit_sha must match vulnerability evidence commit_sha")
+
+    advisory_triage = report.get("advisory_triage", {})
+    source_records = advisory_triage.get("records", [])
+    if not isinstance(source_records, list):
+        raise ValueError("vulnerability advisory report records must be a list")
+
+    reviews = _load_review_input(review_input)
+    review_by_advisory = {review["advisory_id"]: review for review in reviews}
+    source_ids = {str(record.get("advisory_id") or "") for record in source_records if isinstance(record, dict)}
+    unknown_review_ids = sorted(set(review_by_advisory) - source_ids)
+    if unknown_review_ids:
+        raise ValueError(f"review input references unknown advisory_id values: {unknown_review_ids}")
+
+    generated_at = executed_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    ledger_records: list[dict[str, Any]] = []
+    for source_record in sorted(source_records, key=_severity_sort_key):
+        if not isinstance(source_record, dict):
+            raise ValueError("vulnerability advisory record entries must be objects")
+        advisory_id = str(source_record.get("advisory_id") or "").strip()
+        if not advisory_id:
+            raise ValueError("vulnerability advisory record missing advisory_id")
+        matched = bool(source_record.get("matched_component_in_sbom"))
+        source_status = str(source_record.get("triage_status") or "")
+        review = review_by_advisory.get(advisory_id)
+        if review:
+            decision = review["decision"]
+            reviewer = review["reviewer"]
+            rationale = review["rationale"]
+            reviewed_utc = review["reviewed_utc"]
+            evidence_refs = review["evidence_refs"]
+            decision_source = REVIEW_INPUT_SUPPLIED
+        elif matched and source_status == "OPEN_TRIAGE_REQUIRED":
+            decision = DECISION_PENDING
+            reviewer = None
+            rationale = "Matched advisory requires human review; no review input was supplied for this advisory."
+            reviewed_utc = None
+            evidence_refs = []
+            decision_source = REVIEW_INPUT_NONE
+        else:
+            decision = DECISION_NOT_APPLICABLE
+            reviewer = "system"
+            rationale = "Advisory was not present in the current SBOM input or did not require review in source evidence."
+            reviewed_utc = generated_at
+            evidence_refs = []
+            decision_source = "SYSTEM_DERIVED_FROM_VULNERABILITY_EVIDENCE"
+
+        ledger_records.append(
+            {
+                "advisory_id": advisory_id,
+                "component": source_record.get("component"),
+                "severity": source_record.get("severity"),
+                "source_triage_status": source_status,
+                "matched_component_in_sbom": matched,
+                "decision": decision,
+                "decision_source": decision_source,
+                "reviewer": reviewer,
+                "rationale": rationale,
+                "reviewed_utc": reviewed_utc,
+                "evidence_refs": evidence_refs,
+                "remediation_status": "NOT_RECORDED_BY_THIS_LEDGER",
+            }
+        )
+
+    pending_count = sum(1 for record in ledger_records if record["decision"] == DECISION_PENDING)
+    patch_required_count = sum(1 for record in ledger_records if record["decision"] == DECISION_PATCH_REQUIRED)
+    accepted_risk_count = sum(1 for record in ledger_records if record["decision"] == DECISION_ACCEPTED_RISK)
+    not_applicable_count = sum(1 for record in ledger_records if record["decision"] == DECISION_NOT_APPLICABLE)
+    deferred_count = sum(1 for record in ledger_records if record["decision"] == DECISION_DEFERRED)
+    human_review_required_count = sum(
+        1
+        for record in ledger_records
+        if record["matched_component_in_sbom"] and record["source_triage_status"] == "OPEN_TRIAGE_REQUIRED"
+    )
+
+    if not ledger_records:
+        overall_status = DECISION_NO_ADVISORY_RECORDS
+    elif pending_count:
+        overall_status = "HUMAN_REVIEW_PENDING"
+    else:
+        overall_status = "HUMAN_REVIEW_RECORDED_UNSIGNED"
+
+    ledger: dict[str, Any] = {
+        "schema": TRIAGE_LEDGER_SCHEMA,
+        "generated_utc": generated_at,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "operator": operator,
+        "evidence_status": EVIDENCE_STATUS,
+        "review_input_status": REVIEW_INPUT_SUPPLIED if review_input else REVIEW_INPUT_NONE,
+        "source_vulnerability_evidence": {
+            "vulnerability_report_path": str(vulnerability_report),
+            "vulnerability_report_sha256": _sha256_file(vulnerability_report),
+            "vulnerability_summary_path": str(vulnerability_summary),
+            "vulnerability_summary_sha256": _sha256_file(vulnerability_summary),
+            "source_advisory_record_count": len(source_records),
+            "source_matched_advisory_count": summary_source.get("matched_advisory_count"),
+            "source_advisory_input_status": summary_source.get("advisory_input_status"),
+        },
+        "review_summary": {
+            "overall_status": overall_status,
+            "ledger_record_count": len(ledger_records),
+            "human_review_required_count": human_review_required_count,
+            "pending_review_count": pending_count,
+            "patch_required_count": patch_required_count,
+            "accepted_risk_count": accepted_risk_count,
+            "not_applicable_count": not_applicable_count,
+            "deferred_count": deferred_count,
+        },
+        "records": ledger_records,
+        "claims_boundary": CLAIMS_BOUNDARY,
+        "not_claimed": NOT_CLAIMED,
+    }
+
+    summary: dict[str, Any] = {
+        "schema": TRIAGE_LEDGER_SCHEMA,
+        "generated_utc": generated_at,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "operator": operator,
+        "evidence_status": EVIDENCE_STATUS,
+        "review_input_status": ledger["review_input_status"],
+        "overall_status": overall_status,
+        "ledger_record_count": len(ledger_records),
+        "human_review_required_count": human_review_required_count,
+        "pending_review_count": pending_count,
+        "patch_required_count": patch_required_count,
+        "accepted_risk_count": accepted_risk_count,
+        "not_applicable_count": not_applicable_count,
+        "deferred_count": deferred_count,
+        "input_files": {
+            "vulnerability_report": _optional_file_digest(vulnerability_report),
+            "vulnerability_summary": _optional_file_digest(vulnerability_summary),
+            "review_input": _optional_file_digest(review_input),
+        },
+        "claims_boundary": CLAIMS_BOUNDARY,
+        "not_claimed": NOT_CLAIMED,
+    }
+    summary["summary_digest"] = canonical_digest(summary)
+    _assert_no_forbidden_claims(ledger=ledger, summary=summary)
+    return ledger, summary
+
+
+def write_human_triage_ledger(
+    *,
+    out_dir: Path,
+    vulnerability_report: Path,
+    vulnerability_summary: Path,
+    review_input: Path | None,
+    repository: str,
+    commit_sha: str,
+    operator: str,
+    executed_utc: str | None = None,
+) -> dict[str, Any]:
+    ledger, summary = build_human_triage_ledger(
+        vulnerability_report=vulnerability_report,
+        vulnerability_summary=vulnerability_summary,
+        review_input=review_input,
+        repository=repository,
+        commit_sha=commit_sha,
+        operator=operator,
+        executed_utc=executed_utc,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ledger_path = out_dir / "human-triage-ledger.json"
+    summary_path = out_dir / "human-triage-summary.json"
+    _write_json(ledger_path, ledger)
+
+    summary["human_triage_ledger_path"] = str(ledger_path)
+    summary["human_triage_ledger_sha256"] = _sha256_file(ledger_path)
+    summary["summary_digest"] = canonical_digest(summary)
+    _assert_no_forbidden_claims(summary=summary)
+    _write_json(summary_path, summary)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate unsigned internal SARA human-review advisory triage ledger evidence."
+    )
+    parser.add_argument("--vulnerability-report", type=Path, required=True)
+    parser.add_argument("--vulnerability-summary", type=Path, required=True)
+    parser.add_argument("--review-input", type=Path, default=None, help="Optional local human review input JSON.")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for human triage ledger files.")
+    parser.add_argument("--repository", default="", help="Repository full name.")
+    parser.add_argument("--commit-sha", required=True, help="Commit SHA for the CI run.")
+    parser.add_argument("--operator", default="github-actions", help="Evidence operator.")
+    parser.add_argument("--executed-utc", default=None, help="Optional fixed execution timestamp.")
+    args = parser.parse_args(argv)
+
+    working_dir = Path.cwd()
+    vulnerability_report = _resolve_cli_path(
+        args.vulnerability_report, base_dir=working_dir, must_exist=True, allow_directory=False
+    )
+    vulnerability_summary = _resolve_cli_path(
+        args.vulnerability_summary, base_dir=working_dir, must_exist=True, allow_directory=False
+    )
+    review_input = _resolve_optional_cli_file(args.review_input, base_dir=working_dir)
+    out_dir = _resolve_cli_path(args.out, base_dir=working_dir, must_exist=False, allow_directory=True)
+
+    summary = write_human_triage_ledger(
+        out_dir=out_dir,
+        vulnerability_report=vulnerability_report,
+        vulnerability_summary=vulnerability_summary,
+        review_input=review_input,
+        repository=args.repository,
+        commit_sha=args.commit_sha,
+        operator=args.operator,
+        executed_utc=args.executed_utc,
+    )
+    print(_json_text(summary), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py
@@ -13,6 +13,7 @@ from .qualification import canonical_digest
 RELEASE_INDEX_SCHEMA = "WS-SARA-RELEASE-EVIDENCE-INDEX-V1"
 SBOM_EVIDENCE_SCHEMA = "WS-SOFTWARE-SUPPLY-CHAIN-EVIDENCE-V1"
 VULNERABILITY_EVIDENCE_SCHEMA = "WS-VULNERABILITY-ADVISORY-EVIDENCE-V1"
+HUMAN_TRIAGE_LEDGER_SCHEMA = "WS-VULNERABILITY-HUMAN-TRIAGE-LEDGER-V1"
 MERGE_STATE_PR_CANDIDATE = "PR_CANDIDATE_UNMERGED"
 MERGE_STATE_MAIN_PUSH = "MERGED_MAIN_PUSH"
 MERGE_STATE_MANUAL_OR_NON_MAIN = "MANUAL_OR_NON_MAIN_RUN"
@@ -27,8 +28,8 @@ CLAIMS_BOUNDARY = (
     "supplier approval, certification, CMMC/NIST/DFARS conformity, classified access, DOE validation, "
     "external reproduction, field performance, hardware performance, export-control clearance, "
     "software supply-chain completeness, absence of vulnerabilities, advisory-feed completeness, "
-    "vulnerability scan pass, vulnerability remediation, license legal review, SLSA compliance, "
-    "or operational authority."
+    "vulnerability scan pass, vulnerability remediation, human-review completion, exploitability analysis, "
+    "license legal review, SLSA compliance, or operational authority."
 )
 
 
@@ -130,6 +131,18 @@ def _validate_vulnerability_summary(vulnerability_summary: dict[str, Any]) -> No
         raise ValueError("vulnerability summary missing claims boundary")
 
 
+def _validate_human_triage_summary(human_triage_summary: dict[str, Any]) -> None:
+    if human_triage_summary.get("schema") != HUMAN_TRIAGE_LEDGER_SCHEMA:
+        raise ValueError("unexpected human triage summary schema")
+    if human_triage_summary.get("evidence_status") != "INTERNAL_REVIEW_LEDGER_UNSIGNED":
+        raise ValueError("unexpected human triage evidence status")
+    if not human_triage_summary.get("human_triage_ledger_sha256", "").startswith("sha256:"):
+        raise ValueError("human triage summary missing human_triage_ledger_sha256")
+    claims_boundary = human_triage_summary.get("claims_boundary", "")
+    if "does not establish" not in claims_boundary:
+        raise ValueError("human triage summary missing claims boundary")
+
+
 def build_release_evidence_index(
     *,
     repository: str,
@@ -145,6 +158,7 @@ def build_release_evidence_index(
     partner_dir: Path,
     sbom_dir: Path,
     vulnerability_dir: Path,
+    human_triage_dir: Path,
     pre_artifact_id: str | None,
     pre_artifact_digest: str | None,
     pre_artifact_url: str | None,
@@ -157,6 +171,9 @@ def build_release_evidence_index(
     vulnerability_artifact_id: str | None,
     vulnerability_artifact_digest: str | None,
     vulnerability_artifact_url: str | None,
+    human_triage_artifact_id: str | None,
+    human_triage_artifact_digest: str | None,
+    human_triage_artifact_url: str | None,
     executed_utc: str | None = None,
 ) -> dict[str, Any]:
     """Build a machine-readable release evidence index for one SARA CI run."""
@@ -167,11 +184,13 @@ def build_release_evidence_index(
     partner_root = Path(partner_dir)
     sbom_root = Path(sbom_dir)
     vulnerability_root = Path(vulnerability_dir)
+    human_triage_root = Path(human_triage_dir)
 
     qualification_index = _load_json(pre_root / "qualification_index.json")
     partner_batch_manifest = _load_json(partner_root / "batch-manifest.json")
     sbom_summary = _load_json(sbom_root / "sbom-evidence-summary.json")
     vulnerability_summary = _load_json(vulnerability_root / "vulnerability-evidence-summary.json")
+    human_triage_summary = _load_json(human_triage_root / "human-triage-summary.json")
 
     if partner_batch_manifest.get("schema") != "WS-PARTNER-SCREENING-BATCH-MANIFEST-V1":
         raise ValueError("unexpected partner batch manifest schema")
@@ -179,6 +198,7 @@ def build_release_evidence_index(
         raise ValueError("qualification index missing schema")
     _validate_sbom_summary(sbom_summary)
     _validate_vulnerability_summary(vulnerability_summary)
+    _validate_human_triage_summary(human_triage_summary)
 
     generated_at = executed_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     pre_artifact = _artifact_record(
@@ -205,6 +225,12 @@ def build_release_evidence_index(
         digest=vulnerability_artifact_digest,
         url=vulnerability_artifact_url,
     )
+    human_triage_artifact = _artifact_record(
+        name="human-triage-ledger-evidence",
+        artifact_id=human_triage_artifact_id,
+        digest=human_triage_artifact_digest,
+        url=human_triage_artifact_url,
+    )
 
     index: dict[str, Any] = {
         "schema": RELEASE_INDEX_SCHEMA,
@@ -223,6 +249,7 @@ def build_release_evidence_index(
         "artifacts": {
             "software_sbom_evidence": sbom_artifact,
             "vulnerability_advisory_evidence": vulnerability_artifact,
+            "human_triage_ledger_evidence": human_triage_artifact,
             "pre_full_bloom_qualification_evidence": pre_artifact,
             "partner_screening_batch_evidence": partner_artifact,
         },
@@ -243,6 +270,20 @@ def build_release_evidence_index(
             "vulnerability_evidence_status": vulnerability_summary.get("evidence_status"),
             "vulnerability_advisory_input_status": vulnerability_summary.get("advisory_input_status"),
             "vulnerability_input_files": vulnerability_summary.get("input_files", {}),
+            "human_triage_summary_path": str(human_triage_root / "human-triage-summary.json"),
+            "human_triage_summary_sha256": _sha256_file(human_triage_root / "human-triage-summary.json"),
+            "human_triage_ledger_path": str(human_triage_root / "human-triage-ledger.json"),
+            "human_triage_ledger_sha256": _sha256_file(human_triage_root / "human-triage-ledger.json"),
+            "human_triage_evidence_status": human_triage_summary.get("evidence_status"),
+            "human_triage_review_input_status": human_triage_summary.get("review_input_status"),
+            "human_triage_overall_status": human_triage_summary.get("overall_status"),
+            "human_triage_ledger_record_count": human_triage_summary.get("ledger_record_count"),
+            "human_triage_review_required_count": human_triage_summary.get("human_review_required_count"),
+            "human_triage_pending_review_count": human_triage_summary.get("pending_review_count"),
+            "human_triage_patch_required_count": human_triage_summary.get("patch_required_count"),
+            "human_triage_accepted_risk_count": human_triage_summary.get("accepted_risk_count"),
+            "human_triage_deferred_count": human_triage_summary.get("deferred_count"),
+            "human_triage_input_files": human_triage_summary.get("input_files", {}),
             "qualification_index_path": str(pre_root / "qualification_index.json"),
             "qualification_index_sha256": _sha256_file(pre_root / "qualification_index.json"),
             "partner_batch_manifest_path": str(partner_root / "batch-manifest.json"),
@@ -290,6 +331,12 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         help="Directory containing vulnerability/advisory evidence.",
     )
+    parser.add_argument(
+        "--human-triage-dir",
+        type=Path,
+        required=True,
+        help="Directory containing human-review advisory triage ledger evidence.",
+    )
     parser.add_argument("--repository", default=os.getenv("GITHUB_REPOSITORY", ""))
     parser.add_argument("--commit-sha", default=os.getenv("GITHUB_SHA", ""))
     parser.add_argument("--workflow-name", default=os.getenv("GITHUB_WORKFLOW", ""))
@@ -311,6 +358,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vulnerability-artifact-id", default=None)
     parser.add_argument("--vulnerability-artifact-digest", default=None)
     parser.add_argument("--vulnerability-artifact-url", default=None)
+    parser.add_argument("--human-triage-artifact-id", default=None)
+    parser.add_argument("--human-triage-artifact-digest", default=None)
+    parser.add_argument("--human-triage-artifact-url", default=None)
     parser.add_argument("--executed-utc", default=None)
     args = parser.parse_args(argv)
 
@@ -331,6 +381,7 @@ def main(argv: list[str] | None = None) -> int:
         partner_dir=args.partner_dir,
         sbom_dir=args.sbom_dir,
         vulnerability_dir=args.vulnerability_dir,
+        human_triage_dir=args.human_triage_dir,
         pre_artifact_id=args.pre_artifact_id,
         pre_artifact_digest=args.pre_artifact_digest,
         pre_artifact_url=args.pre_artifact_url,
@@ -343,6 +394,9 @@ def main(argv: list[str] | None = None) -> int:
         vulnerability_artifact_id=args.vulnerability_artifact_id,
         vulnerability_artifact_digest=args.vulnerability_artifact_digest,
         vulnerability_artifact_url=args.vulnerability_artifact_url,
+        human_triage_artifact_id=args.human_triage_artifact_id,
+        human_triage_artifact_digest=args.human_triage_artifact_digest,
+        human_triage_artifact_url=args.human_triage_artifact_url,
         executed_utc=args.executed_utc,
     )
     _write_json(args.out, index)


### PR DESCRIPTION
## Summary

Adds an unsigned human-review advisory triage ledger that consumes vulnerability/advisory evidence and links the resulting artifact into the SARA release evidence index.

## Added

- `deployments/sara_verified_local_v1/worldshepherd_sara/human_triage_cli.py`
  - Adds `ws-human-triage-ledger`.
  - Consumes `vulnerability-advisory-report.json` and `vulnerability-evidence-summary.json`.
  - Emits `human-triage-ledger.json` and `human-triage-summary.json`.
  - Supports optional local review input with bounded decisions: `ACCEPTED_RISK`, `PATCH_REQUIRED`, `NOT_APPLICABLE`, `DEFERRED`.
  - Leaves matched, unreviewed advisories as `PENDING_HUMAN_REVIEW`.
  - Rejects duplicate reviews, unknown advisory IDs, unsupported decisions, missing rationale/reviewer, and paths outside the working directory.

- `deployments/sara_verified_local_v1/tests/test_human_triage_cli.py`
  - Verifies pending review behavior, not-applicable behavior, supplied review decisions, no-advisory mode, CLI writes, digest recording, unknown-advisory rejection, unsupported-decision rejection, source-schema rejection, and path constraints.

- `deployments/sara_verified_local_v1/worldshepherd_sara/release_index_cli.py`
  - Adds required `--human-triage-dir`.
  - Adds `human_triage_ledger_evidence` to release-index artifacts.
  - Records human triage summary/ledger digests, review status, record counts, pending/patch/accepted-risk/deferred counts, and input-file digests.

- `.github/workflows/sara-verified-local-v1.yml`
  - Installs and checks `ws-human-triage-ledger`.
  - Builds and uploads `human-triage-ledger-evidence`.
  - Feeds the human triage artifact ID, digest, and URL into `sara-release-evidence-index`.

- `docs/WS_HUMAN_TRIAGE_LEDGER_2026-09-01.md`
  - Documents decision states, review input format, CI integration, release-index linkage, and claims boundary.

## Claims boundary

This PR creates internal unsigned human-review triage ledger evidence only. It does **not** establish absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, remediation completion, exploitability analysis, secure-by-design status, license legal review, SLSA compliance, CMMC conformity, NIST SP 800-171 implementation, DFARS satisfaction, FedRAMP authorization, ISO certification, SOC 2 attestation, supplier approval, partner validation, external reproduction, field performance, hardware performance, classified access, or operational authority.

## Standards posture

This improves the standards-control matrix by adding a repeatable review ledger and release-custody surface. It does **not** promote any control to `MET` or `EXCEEDED`; promotion remains blocked until advisory-feed provenance, remediation evidence, exploitability/non-applicability rationale, policy-control mapping, and accountable approval exist.