### PR TITLE
Add intake minimum standard ledger

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_2026-09-01.md
@@ -1,0 +1,153 @@
+# WS Intake Minimum Standard — 2026-09-01
+
+## Purpose
+
+This document defines the minimum evidence posture for every new Worldshepherd/SARA intake.
+
+The intent is simple: a new intake should never enter the active pipeline as a loose assertion. It must arrive with source custody, review status, routing status, and a claims boundary before it can influence PRE, partner-screening, release evidence, outreach, opportunity scoring, or standards-readiness claims.
+
+## Scope
+
+This applies to at least the following intake classes:
+
+- User directives
+- Gmail/email signals
+- Opportunity intelligence records
+- PRE Requirement Delta Records
+- Research/source references
+- Software SBOM evidence
+- Vulnerability/advisory evidence
+- Human-review triage decisions
+- Partner-screening packages
+- Release evidence indexes
+- Operational/recovery evidence
+- Future standards-control or remediation evidence
+
+## New CLI
+
+```bash
+ws-intake-minimum-ledger \
+  --intake-file intakes.json \
+  --out intake_minimum_ci \
+  --repository "$GITHUB_REPOSITORY" \
+  --commit-sha "$GITHUB_SHA" \
+  --operator "github-actions" \
+  --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+The command writes:
+
+- `intake-minimum-ledger.json`
+- `intake-minimum-summary.json`
+
+## Required fields
+
+Every intake record must include:
+
+```json
+{
+  "intake_id": "WS-INTAKE-YYYY-MM-DD-NNN",
+  "intake_type": "USER_DIRECTIVE",
+  "source_system": "chatgpt_conversation",
+  "source_locator": "conversation:<stable-reference>",
+  "source_retrieved_utc": "2026-09-01T18:25:00Z",
+  "source_sha256": "sha256:<64 hex chars>",
+  "evidence_status": "RAW_INTAKE_UNSIGNED",
+  "maturity_label": "RAW_INTAKE",
+  "human_review_status": "PENDING_HUMAN_REVIEW",
+  "routing_status": "ROUTED_TO_BACKLOG",
+  "downstream_route": "Describe the next governed route.",
+  "claims_boundary": "This intake does not establish validation, compliance, remediation, award probability, partner interest, or operational authority."
+}
+```
+
+## Minimum controls
+
+The ledger validates and records these controls per intake:
+
+| Control | Required posture |
+|---|---|
+| Source custody | Source system, locator, retrieval timestamp, and SHA-256 digest recorded |
+| Source hash | `source_sha256` must be a SHA-256 digest |
+| Claims boundary | Explicit non-claim language required |
+| Human-review status | Must be one of the bounded review states |
+| Routing status | Must be one of the bounded routing states |
+| Downstream route/evidence | Either a downstream route or downstream artifact evidence is required |
+| False-claim guard | Prohibited readiness assertions are rejected |
+
+## Bounded review states
+
+Allowed `human_review_status` values:
+
+- `PENDING_HUMAN_REVIEW`
+- `HUMAN_REVIEW_NOT_REQUIRED`
+- `REVIEWED_ACCEPTED_RISK`
+- `REVIEWED_ACTION_REQUIRED`
+- `REVIEWED_NOT_APPLICABLE`
+- `DEFERRED`
+
+Reviewed states require `review_rationale`.
+
+## Bounded routing states
+
+Allowed `routing_status` values:
+
+- `PENDING_ROUTE`
+- `ROUTED_TO_PRE`
+- `ROUTED_TO_TRIAGE`
+- `ROUTED_TO_PARTNER_SCREENING`
+- `ROUTED_TO_RELEASE_INDEX`
+- `ROUTED_TO_BACKLOG`
+- `NOT_MATERIAL`
+
+## Prohibited readiness assertions
+
+The ledger rejects explicit marker claims such as:
+
+- `BAE_VALIDATED`
+- `BAE_CERTIFIED`
+- `BAE_APPROVED`
+- `PARTNER_VALIDATED`
+- `SUPPLIER_APPROVED`
+- `CMMC_CERTIFIED`
+- `NIST_800_171_CONFORMANT`
+- `DFARS_SATISFIED`
+- `FEDRAMP_AUTHORIZED`
+- `ISO_CERTIFIED`
+- `SOC2_ATTESTED`
+- `CLASSIFIED_ACCESS_GRANTED`
+- `DOE_VALIDATED`
+- `FIELD_VALIDATED`
+- `HARDWARE_VALIDATED`
+- `VULNERABILITY_REMEDIATED`
+- `SECURE_BY_DESIGN_VALIDATED`
+- `OPERATIONAL_AUTHORITY_GRANTED`
+
+A later evidence package can support stronger claims only if a separate validated evidence path exists. This intake ledger never upgrades maturity by itself.
+
+## Claims boundary
+
+This standard records intake governance and custody only. It does **not** establish source truth, partner validation, supplier approval, certification, CMMC/NIST/DFARS conformity, classified access, DOE validation, external reproduction, field performance, hardware performance, export-control clearance, software supply-chain completeness, absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, vulnerability remediation, human-review completion, exploitability analysis, license legal review, SLSA compliance, opportunity eligibility, award probability, or operational authority.
+
+## Operating rule
+
+Every new intake should be represented by an intake record before it is used to change:
+
+1. PRE demand posture
+2. Opportunity ranking
+3. Partner-screening priority
+4. Outreach content
+5. Standards-control status
+6. Security/remediation status
+7. Release evidence index posture
+
+The first safe default for any new signal is:
+
+```text
+maturity_label: RAW_INTAKE
+human_review_status: PENDING_HUMAN_REVIEW
+routing_status: PENDING_ROUTE or ROUTED_TO_BACKLOG
+claims_boundary: explicit non-claim language
+```
+
+Promotion requires separate evidence, not intake existence.

--- a/deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_ADOPTION_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_ADOPTION_2026-09-01.md
@@ -1,0 +1,26 @@
+# WS Intake Minimum Standard Adoption — 2026-09-01
+
+## Adoption posture
+
+The intake minimum standard is now the baseline intake-control surface for new Worldshepherd/SARA signals. The immediate implementation is intentionally bounded:
+
+- It provides a CLI and library validator.
+- It provides a checked fixture representing the current CRE1AWS directive.
+- It adds regression tests that fail if required custody, routing, review, or claims-boundary fields are missing.
+- It does not change release-index inputs yet, so the existing post-merge evidence workflow remains stable.
+
+## Required next integration
+
+After this standard lands, the next increment should wire `ws-intake-minimum-ledger` into the SARA Verified Local v1 workflow as an uploaded artifact and then add release-index custody for that artifact.
+
+Recommended sequence:
+
+1. Build `intake_minimum_ci` from `fixtures/intake_minimum_standard.json`.
+2. Assert both `intake-minimum-ledger.json` and `intake-minimum-summary.json` exist.
+3. Upload the artifact as `intake-minimum-standard-evidence`.
+4. Add optional or required intake-minimum fields to `ws-release-index`.
+5. Extend release-index tests to verify intake custody without weakening the existing SBOM, vulnerability, human-triage, PRE, partner-screening, recovery, and operational snapshot checks.
+
+## Claims boundary
+
+This adoption record does not establish implementation completion across every future intake. It establishes the first enforced validator and fixture for minimum intake governance. Workflow-level artifact custody and release-index linkage remain the next integration step.

--- a/deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_PR_NOTES_2026-09-01.md
+++ b/deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_PR_NOTES_2026-09-01.md
@@ -1,0 +1,27 @@
+# WS Intake Minimum Standard PR Notes — 2026-09-01
+
+## What this increment proves
+
+This increment proves that Worldshepherd/SARA has an enforced intake-minimum validator in code and tests. New intakes can now be checked for the minimum fields required before they are used to move PRE, opportunity, partner, security, release, or standards posture.
+
+## What this increment does not prove
+
+This increment does not prove that every future external intake has already been processed through the standard. It creates the gate and fixture. The next pull request should wire the gate into the SARA Verified Local v1 workflow and add release-index custody for the resulting artifact.
+
+## Safe operating interpretation
+
+Until workflow integration lands, use this as the standing source-of-truth rule:
+
+```text
+No new intake should be promoted unless it has:
+  - source custody
+  - source digest
+  - evidence status
+  - maturity label
+  - human-review status
+  - routing status
+  - downstream route or evidence
+  - explicit non-claim boundary
+```
+
+Any intake missing those fields remains `RAW_INTAKE` or `PENDING_ROUTE`; it must not raise maturity, probability, compliance, partner, remediation, or operational-authority posture.

--- a/deployments/sara_verified_local_v1/fixtures/intake_minimum_standard.json
+++ b/deployments/sara_verified_local_v1/fixtures/intake_minimum_standard.json
@@ -1,0 +1,20 @@
+{
+  "intakes": [
+    {
+      "intake_id": "WS-INTAKE-2026-09-01-001",
+      "intake_type": "USER_DIRECTIVE",
+      "source_system": "chatgpt_conversation",
+      "source_locator": "conversation:continue-to-this-extent-with-every-new-intake",
+      "source_retrieved_utc": "2026-09-01T18:25:00Z",
+      "source_sha256": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "evidence_status": "RAW_INTAKE_UNSIGNED",
+      "maturity_label": "RAW_INTAKE",
+      "human_review_status": "PENDING_HUMAN_REVIEW",
+      "routing_status": "ROUTED_TO_BACKLOG",
+      "downstream_route": "Apply the intake minimum standard to future Worldshepherd/SARA intakes before pipeline promotion.",
+      "claims_boundary": "This intake does not establish validation, compliance, remediation, award probability, partner interest, or operational authority.",
+      "owner": "CRE1AWS",
+      "priority": "HIGH"
+    }
+  ]
+}

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -30,6 +30,7 @@ ws-release-index = "worldshepherd_sara.release_index_cli:main"
 ws-sbom-evidence = "worldshepherd_sara.sbom_cli:main"
 ws-vulnerability-evidence = "worldshepherd_sara.vulnerability_cli:main"
 ws-human-triage-ledger = "worldshepherd_sara.human_triage_cli:main"
+ws-intake-minimum-ledger = "worldshepherd_sara.intake_minimum_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/scripts/verify_intake_minimum_artifact.sh
+++ b/deployments/sara_verified_local_v1/scripts/verify_intake_minimum_artifact.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-}"
+if [[ -z "$ROOT" ]]; then
+  echo "usage: $0 <intake-minimum-artifact-dir>" >&2
+  exit 2
+fi
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "intake minimum artifact directory missing: $ROOT" >&2
+  exit 1
+fi
+
+test -s "$ROOT/intake-minimum-ledger.json"
+test -s "$ROOT/intake-minimum-summary.json"
+
+python - "$ROOT" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+ledger = json.loads((root / "intake-minimum-ledger.json").read_text(encoding="utf-8"))
+summary = json.loads((root / "intake-minimum-summary.json").read_text(encoding="utf-8"))
+
+assert ledger["schema"] == "WS-INTAKE-MINIMUM-STANDARD-LEDGER-V1"
+assert summary["schema"] == "WS-INTAKE-MINIMUM-STANDARD-LEDGER-V1"
+assert summary["evidence_status"] == "INTERNAL_INTAKE_STANDARD_UNSIGNED"
+assert summary["intake_count"] > 0
+assert summary["intake_minimum_ledger_sha256"].startswith("sha256:")
+assert summary["intake_minimum_ledger_file_sha256"].startswith("sha256:")
+assert "does not establish" in summary["claims_boundary"]
+assert "award probability" in summary["claims_boundary"]
+for record in ledger["records"]:
+    assert record["minimum_controls"]["source_custody"] == "PASS"
+    assert record["minimum_controls"]["source_hash"] == "PASS"
+    assert record["minimum_controls"]["claims_boundary"] == "PASS"
+    assert record["minimum_controls"]["human_review_status"] == "PASS"
+    assert record["minimum_controls"]["routing_status"] == "PASS"
+    assert record["minimum_controls"]["downstream_route_or_evidence"] == "PASS"
+    assert record["minimum_controls"]["false_claim_guard"] == "PASS"
+    assert record["record_digest"].startswith("sha256:")
+text = "\n".join(path.read_text(encoding="utf-8") for path in root.rglob("*") if path.is_file())
+for forbidden in (
+    "BAE_VALIDATED",
+    "PARTNER_VALIDATED",
+    "SUPPLIER_APPROVED",
+    "CMMC_CERTIFIED",
+    "NIST_800_171_CONFORMANT",
+    "VULNERABILITY_REMEDIATED",
+    "OPERATIONAL_AUTHORITY_GRANTED",
+):
+    assert forbidden not in text
+PY

--- a/deployments/sara_verified_local_v1/tests/test_intake_minimum_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_intake_minimum_cli.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldshepherd_sara.intake_minimum_cli import (
+    INTAKE_MINIMUM_SCHEMA,
+    build_intake_minimum_ledger,
+    main,
+    normalize_intake_record,
+)
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _base_intake(**overrides):
+    record = {
+        "intake_id": "WS-INTAKE-2026-09-01-001",
+        "intake_type": "USER_DIRECTIVE",
+        "source_system": "chatgpt_conversation",
+        "source_locator": "conversation:continue-to-this-extent-with-every-new-intake",
+        "source_retrieved_utc": "2026-09-01T18:25:00Z",
+        "source_sha256": "sha256:" + "1" * 64,
+        "evidence_status": "RAW_INTAKE_UNSIGNED",
+        "maturity_label": "RAW_INTAKE",
+        "human_review_status": "PENDING_HUMAN_REVIEW",
+        "routing_status": "ROUTED_TO_BACKLOG",
+        "downstream_route": "Convert directive into intake minimum standard ledger and CI enforcement.",
+        "claims_boundary": "This intake does not establish validation, compliance, remediation, award probability, partner interest, or operational authority.",
+        "owner": "CRE1AWS",
+        "priority": "HIGH",
+    }
+    record.update(overrides)
+    return record
+
+
+def test_normalize_intake_record_requires_every_minimum_control() -> None:
+    record = normalize_intake_record(_base_intake())
+
+    assert record["intake_id"] == "WS-INTAKE-2026-09-01-001"
+    assert record["source_sha256"] == "sha256:" + "1" * 64
+    assert record["minimum_controls"] == {
+        "source_custody": "PASS",
+        "source_hash": "PASS",
+        "claims_boundary": "PASS",
+        "human_review_status": "PASS",
+        "routing_status": "PASS",
+        "downstream_route_or_evidence": "PASS",
+        "false_claim_guard": "PASS",
+    }
+    assert record["record_digest"].startswith("sha256:")
+
+
+def test_build_intake_minimum_ledger_summarizes_review_and_routing_counts(tmp_path) -> None:
+    intake_file = tmp_path / "intakes.json"
+    _write_json(
+        intake_file,
+        {
+            "intakes": [
+                _base_intake(),
+                _base_intake(
+                    intake_id="WS-INTAKE-2026-09-01-002",
+                    source_sha256="sha256:" + "2" * 64,
+                    human_review_status="REVIEWED_ACTION_REQUIRED",
+                    routing_status="ROUTED_TO_TRIAGE",
+                    review_rationale="Human owner identified this as actionable but not yet remediated.",
+                    downstream_route="Create a remediation-action evidence record before any claim upgrade.",
+                ),
+                _base_intake(
+                    intake_id="WS-INTAKE-2026-09-01-003",
+                    source_sha256="sha256:" + "3" * 64,
+                    human_review_status="HUMAN_REVIEW_NOT_REQUIRED",
+                    routing_status="NOT_MATERIAL",
+                    maturity_label="NOT_CURRENTLY_CLAIMED",
+                    downstream_route="No follow-on route because the source was screened as not material.",
+                    claims_boundary="No validation, compliance, remediation, partner-interest, or operational-authority claim is made.",
+                ),
+            ]
+        },
+    )
+
+    ledger = build_intake_minimum_ledger(
+        intake_file=intake_file,
+        repository="Bdavis1390/Sara_pro",
+        commit_sha="abc123",
+        operator="github-actions",
+        executed_utc="2026-09-01T18:30:00Z",
+    )
+
+    assert ledger["schema"] == INTAKE_MINIMUM_SCHEMA
+    assert ledger["summary"]["intake_count"] == 3
+    assert ledger["summary"]["pending_human_review_count"] == 1
+    assert ledger["summary"]["reviewed_action_required_count"] == 1
+    assert ledger["summary"]["not_material_count"] == 1
+    assert ledger["ledger_digest"].startswith("sha256:")
+    assert "does not establish" in ledger["claims_boundary"]
+    assert "award probability" in ledger["claims_boundary"]
+
+
+def test_intake_minimum_cli_writes_ledger_and_summary(tmp_path) -> None:
+    intake_file = tmp_path / "intakes.json"
+    out_dir = tmp_path / "intake_minimum_ci"
+    _write_json(intake_file, {"intakes": [_base_intake()]})
+
+    exit_code = main(
+        [
+            "--intake-file",
+            str(intake_file),
+            "--out",
+            str(out_dir),
+            "--repository",
+            "Bdavis1390/Sara_pro",
+            "--commit-sha",
+            "abc123",
+            "--operator",
+            "github-actions",
+            "--executed-utc",
+            "2026-09-01T18:31:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    ledger = json.loads((out_dir / "intake-minimum-ledger.json").read_text(encoding="utf-8"))
+    summary = json.loads((out_dir / "intake-minimum-summary.json").read_text(encoding="utf-8"))
+    assert ledger["schema"] == INTAKE_MINIMUM_SCHEMA
+    assert summary["schema"] == INTAKE_MINIMUM_SCHEMA
+    assert summary["evidence_status"] == "INTERNAL_INTAKE_STANDARD_UNSIGNED"
+    assert summary["intake_count"] == 1
+    assert summary["pending_human_review_count"] == 1
+    assert summary["intake_minimum_ledger_sha256"].startswith("sha256:")
+    assert summary["intake_minimum_ledger_file_sha256"].startswith("sha256:")
+
+
+def test_intake_minimum_rejects_missing_required_field() -> None:
+    record = _base_intake()
+    record.pop("source_locator")
+
+    with pytest.raises(ValueError, match="missing required fields: source_locator"):
+        normalize_intake_record(record)
+
+
+def test_intake_minimum_rejects_bad_source_digest() -> None:
+    with pytest.raises(ValueError, match="source_sha256 must be a SHA-256 digest"):
+        normalize_intake_record(_base_intake(source_sha256="not-a-digest"))
+
+
+def test_intake_minimum_rejects_claim_boundary_without_non_claim_language() -> None:
+    with pytest.raises(ValueError, match="claims_boundary must contain explicit non-claim language"):
+        normalize_intake_record(_base_intake(claims_boundary="Validated compliance and remediation are complete."))
+
+
+def test_intake_minimum_rejects_prohibited_assertion() -> None:
+    with pytest.raises(ValueError, match="prohibited assertion"):
+        normalize_intake_record(_base_intake(claims_boundary="No false claim, but CMMC_CERTIFIED is still prohibited text."))
+
+
+def test_intake_minimum_rejects_reviewed_without_rationale() -> None:
+    with pytest.raises(ValueError, match="reviewed intakes require review_rationale"):
+        normalize_intake_record(_base_intake(human_review_status="REVIEWED_ACTION_REQUIRED"))
+
+
+def test_intake_minimum_rejects_missing_downstream_route() -> None:
+    with pytest.raises(ValueError, match="downstream_evidence or downstream_route is required"):
+        normalize_intake_record(_base_intake(downstream_route=""))
+
+
+def test_intake_minimum_rejects_duplicate_ids(tmp_path) -> None:
+    intake_file = tmp_path / "intakes.json"
+    _write_json(intake_file, {"intakes": [_base_intake(), _base_intake()]})
+
+    with pytest.raises(ValueError, match="duplicate intake_id values"):
+        build_intake_minimum_ledger(
+            intake_file=intake_file,
+            repository="Bdavis1390/Sara_pro",
+            commit_sha="abc123",
+            operator="github-actions",
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/intake_minimum_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/intake_minimum_cli.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .qualification import canonical_digest
+
+INTAKE_MINIMUM_SCHEMA = "WS-INTAKE-MINIMUM-STANDARD-LEDGER-V1"
+EVIDENCE_STATUS = "INTERNAL_INTAKE_STANDARD_UNSIGNED"
+
+REQUIRED_FIELDS = (
+    "intake_id",
+    "intake_type",
+    "source_system",
+    "source_locator",
+    "source_retrieved_utc",
+    "source_sha256",
+    "evidence_status",
+    "maturity_label",
+    "human_review_status",
+    "routing_status",
+    "claims_boundary",
+)
+
+ALLOWED_REVIEW_STATUSES = {
+    "PENDING_HUMAN_REVIEW",
+    "HUMAN_REVIEW_NOT_REQUIRED",
+    "REVIEWED_ACCEPTED_RISK",
+    "REVIEWED_ACTION_REQUIRED",
+    "REVIEWED_NOT_APPLICABLE",
+    "DEFERRED",
+}
+
+ALLOWED_ROUTING_STATUSES = {
+    "PENDING_ROUTE",
+    "ROUTED_TO_PRE",
+    "ROUTED_TO_TRIAGE",
+    "ROUTED_TO_PARTNER_SCREENING",
+    "ROUTED_TO_RELEASE_INDEX",
+    "ROUTED_TO_BACKLOG",
+    "NOT_MATERIAL",
+}
+
+RECOGNIZED_EVIDENCE_STATUSES = {
+    "RAW_INTAKE_UNSIGNED",
+    "EXTERNAL_SOURCE_REFERENCE_ONLY",
+    "INTERNAL_CI_GENERATED_UNSIGNED",
+    "INTERNAL_REVIEW_LEDGER_UNSIGNED",
+    "INTERNAL_INTAKE_STANDARD_UNSIGNED",
+    "SCREENING_PACKAGE_UNSIGNED",
+    "SIMULATION",
+    "SIMULATED_ONLY",
+}
+
+RECOGNIZED_MATURITY_LABELS = {
+    "NOT_CURRENTLY_CLAIMED",
+    "RAW_INTAKE",
+    "SUPPORTED_BY_SOURCE",
+    "PROVEN_INTERNALLY",
+    "IMPLEMENTED_IN_SOFTWARE",
+    "SIMULATED_ONLY",
+    "REQUIRES_LAB_VALIDATION",
+    "REQUIRES_PARTNER_VALIDATION",
+    "REQUIRES_LEGAL_REVIEW",
+    "REQUIRES_EXTERNAL_VALIDATION",
+}
+
+NON_CLAIM_MARKERS = ("does not", "do not", "not", "no", "without", "unless", "never")
+
+PROHIBITED_ASSERTIONS = {
+    "BAE_VALIDATED",
+    "BAE_CERTIFIED",
+    "BAE_APPROVED",
+    "BAE_ADOPTED",
+    "PARTNER_VALIDATED",
+    "PARTNER_APPROVED",
+    "PARTNER_ADOPTED",
+    "SUPPLIER_APPROVED",
+    "CMMC_CERTIFIED",
+    "NIST_800_171_CONFORMANT",
+    "DFARS_SATISFIED",
+    "FEDRAMP_AUTHORIZED",
+    "ISO_CERTIFIED",
+    "SOC2_ATTESTED",
+    "CLASSIFIED_ACCESS_GRANTED",
+    "DOE_VALIDATED",
+    "FIELD_VALIDATED",
+    "HARDWARE_VALIDATED",
+    "VULNERABILITY_REMEDIATED",
+    "SECURE_BY_DESIGN_VALIDATED",
+    "OPERATIONAL_AUTHORITY_GRANTED",
+}
+
+CLAIMS_BOUNDARY = (
+    "Intake minimum standard ledger records intake governance and custody only. It does not establish "
+    "source truth, partner validation, supplier approval, certification, CMMC/NIST/DFARS conformity, "
+    "classified access, DOE validation, external reproduction, field performance, hardware performance, "
+    "export-control clearance, software supply-chain completeness, absence of vulnerabilities, advisory-feed "
+    "completeness, vulnerability scan pass, vulnerability remediation, human-review completion, exploitability "
+    "analysis, license legal review, SLSA compliance, opportunity eligibility, award probability, or operational authority."
+)
+
+
+def _json_text(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_text(value), encoding="utf-8")
+
+
+def _load_json(path: Path) -> Any:
+    if not path.is_file():
+        raise ValueError(f"required JSON file missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"required file missing for digest: {path}")
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _normalize_digest(value: str, *, field: str) -> str:
+    if not value:
+        raise ValueError(f"{field} is required")
+    raw = str(value).strip()
+    if raw.startswith("sha256:"):
+        raw = raw[len("sha256:") :]
+    if len(raw) != 64 or any(ch not in "0123456789abcdefABCDEF" for ch in raw):
+        raise ValueError(f"{field} must be a SHA-256 digest")
+    return "sha256:" + raw.lower()
+
+
+def _normalized_words(text: str) -> str:
+    normalized = str(text).lower().replace("-", " ").replace("/", " ")
+    return " " + " ".join(normalized.split()) + " "
+
+
+def _has_non_claim_language(text: str) -> bool:
+    normalized = _normalized_words(text)
+    return any(f" {marker} " in normalized for marker in NON_CLAIM_MARKERS)
+
+
+def _require_string(record: dict[str, Any], field: str) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"intake {record.get('intake_id', '<unknown>')}: {field} is required")
+    return value.strip()
+
+
+def _require_claims_boundary(record: dict[str, Any]) -> str:
+    boundary = _require_string(record, "claims_boundary")
+    if not _has_non_claim_language(boundary):
+        raise ValueError(f"intake {record.get('intake_id')}: claims_boundary must contain explicit non-claim language")
+    for assertion in PROHIBITED_ASSERTIONS:
+        if assertion in boundary:
+            raise ValueError(f"intake {record.get('intake_id')}: prohibited assertion found in claims_boundary: {assertion}")
+    return boundary
+
+
+def _require_downstream_route(record: dict[str, Any]) -> list[dict[str, Any]]:
+    downstream = record.get("downstream_evidence")
+    route = record.get("downstream_route")
+    if downstream is None:
+        downstream = []
+    if not isinstance(downstream, list):
+        raise ValueError(f"intake {record.get('intake_id')}: downstream_evidence must be a list")
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(downstream):
+        if not isinstance(item, dict):
+            raise ValueError(f"intake {record.get('intake_id')}: downstream_evidence[{index}] must be an object")
+        artifact_name = item.get("artifact_name")
+        artifact_digest = item.get("artifact_digest")
+        relation = item.get("relation")
+        if not isinstance(artifact_name, str) or not artifact_name.strip():
+            raise ValueError(f"intake {record.get('intake_id')}: downstream_evidence[{index}].artifact_name is required")
+        if not isinstance(relation, str) or not relation.strip():
+            raise ValueError(f"intake {record.get('intake_id')}: downstream_evidence[{index}].relation is required")
+        normalized.append(
+            {
+                "artifact_name": artifact_name.strip(),
+                "relation": relation.strip(),
+                "artifact_digest": _normalize_digest(artifact_digest, field=f"downstream_evidence[{index}].artifact_digest")
+                if artifact_digest
+                else None,
+                "artifact_url": item.get("artifact_url") or None,
+            }
+        )
+    if not normalized and not (isinstance(route, str) and route.strip()):
+        raise ValueError(
+            f"intake {record.get('intake_id')}: downstream_evidence or downstream_route is required for every intake"
+        )
+    return normalized
+
+
+def _minimum_controls_for(record: dict[str, Any], downstream: list[dict[str, Any]]) -> dict[str, str]:
+    return {
+        "source_custody": "PASS",
+        "source_hash": "PASS",
+        "claims_boundary": "PASS",
+        "human_review_status": "PASS",
+        "routing_status": "PASS",
+        "downstream_route_or_evidence": "PASS" if downstream or record.get("downstream_route") else "FAIL",
+        "false_claim_guard": "PASS",
+    }
+
+
+def normalize_intake_record(record: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(record, dict):
+        raise ValueError("each intake must be a JSON object")
+    missing = [field for field in REQUIRED_FIELDS if field not in record]
+    if missing:
+        raise ValueError(f"intake {record.get('intake_id', '<unknown>')}: missing required fields: {', '.join(missing)}")
+
+    intake_id = _require_string(record, "intake_id")
+    source_sha256 = _normalize_digest(_require_string(record, "source_sha256"), field="source_sha256")
+    evidence_status = _require_string(record, "evidence_status")
+    maturity_label = _require_string(record, "maturity_label")
+    human_review_status = _require_string(record, "human_review_status")
+    routing_status = _require_string(record, "routing_status")
+    claims_boundary = _require_claims_boundary(record)
+    downstream = _require_downstream_route(record)
+
+    if evidence_status not in RECOGNIZED_EVIDENCE_STATUSES:
+        raise ValueError(f"intake {intake_id}: unrecognized evidence_status {evidence_status!r}")
+    if maturity_label not in RECOGNIZED_MATURITY_LABELS:
+        raise ValueError(f"intake {intake_id}: unrecognized maturity_label {maturity_label!r}")
+    if human_review_status not in ALLOWED_REVIEW_STATUSES:
+        raise ValueError(f"intake {intake_id}: unsupported human_review_status {human_review_status!r}")
+    if routing_status not in ALLOWED_ROUTING_STATUSES:
+        raise ValueError(f"intake {intake_id}: unsupported routing_status {routing_status!r}")
+
+    review_rationale = record.get("review_rationale")
+    if human_review_status.startswith("REVIEWED_") and not (isinstance(review_rationale, str) and review_rationale.strip()):
+        raise ValueError(f"intake {intake_id}: reviewed intakes require review_rationale")
+
+    normalized = {
+        "intake_id": intake_id,
+        "intake_type": _require_string(record, "intake_type"),
+        "source_system": _require_string(record, "source_system"),
+        "source_locator": _require_string(record, "source_locator"),
+        "source_retrieved_utc": _require_string(record, "source_retrieved_utc"),
+        "source_sha256": source_sha256,
+        "evidence_status": evidence_status,
+        "maturity_label": maturity_label,
+        "human_review_status": human_review_status,
+        "routing_status": routing_status,
+        "downstream_route": record.get("downstream_route") or None,
+        "downstream_evidence": downstream,
+        "owner": record.get("owner") or None,
+        "priority": record.get("priority") or "UNSPECIFIED",
+        "reviewer": record.get("reviewer") or None,
+        "review_rationale": review_rationale or None,
+        "claims_boundary": claims_boundary,
+        "minimum_controls": _minimum_controls_for(record, downstream),
+    }
+    normalized["record_digest"] = canonical_digest(normalized)
+    return normalized
+
+
+def _records_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict):
+        if "intakes" in payload:
+            records = payload["intakes"]
+        elif "records" in payload:
+            records = payload["records"]
+        else:
+            records = [payload]
+    else:
+        raise ValueError("intake file must contain an object, an intakes list, or a records list")
+    if not isinstance(records, list) or not records:
+        raise ValueError("at least one intake record is required")
+    return records
+
+
+def build_intake_minimum_ledger(
+    *,
+    intake_file: Path,
+    repository: str,
+    commit_sha: str,
+    operator: str,
+    executed_utc: str | None = None,
+) -> dict[str, Any]:
+    payload = _load_json(intake_file)
+    records = [normalize_intake_record(record) for record in _records_from_payload(payload)]
+    record_ids = [record["intake_id"] for record in records]
+    duplicate_ids = sorted({record_id for record_id in record_ids if record_ids.count(record_id) > 1})
+    if duplicate_ids:
+        raise ValueError(f"duplicate intake_id values: {', '.join(duplicate_ids)}")
+
+    generated_at = executed_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    review_counts = {status: 0 for status in sorted(ALLOWED_REVIEW_STATUSES)}
+    routing_counts = {status: 0 for status in sorted(ALLOWED_ROUTING_STATUSES)}
+    for record in records:
+        review_counts[record["human_review_status"]] += 1
+        routing_counts[record["routing_status"]] += 1
+
+    ledger: dict[str, Any] = {
+        "schema": INTAKE_MINIMUM_SCHEMA,
+        "generated_utc": generated_at,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "operator": operator,
+        "input_files": {
+            "intake_file": {
+                "path": str(intake_file),
+                "sha256": _sha256_file(intake_file),
+            }
+        },
+        "required_fields": list(REQUIRED_FIELDS),
+        "records": records,
+        "summary": {
+            "intake_count": len(records),
+            "review_counts": review_counts,
+            "routing_counts": routing_counts,
+            "pending_human_review_count": review_counts["PENDING_HUMAN_REVIEW"],
+            "reviewed_action_required_count": review_counts["REVIEWED_ACTION_REQUIRED"],
+            "not_material_count": routing_counts["NOT_MATERIAL"],
+        },
+        "claims_boundary": CLAIMS_BOUNDARY,
+    }
+    ledger["ledger_digest"] = canonical_digest(ledger)
+    return ledger
+
+
+def build_summary(ledger: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": INTAKE_MINIMUM_SCHEMA,
+        "generated_utc": ledger["generated_utc"],
+        "repository": ledger["repository"],
+        "commit_sha": ledger["commit_sha"],
+        "operator": ledger["operator"],
+        "evidence_status": EVIDENCE_STATUS,
+        "intake_count": ledger["summary"]["intake_count"],
+        "pending_human_review_count": ledger["summary"]["pending_human_review_count"],
+        "reviewed_action_required_count": ledger["summary"]["reviewed_action_required_count"],
+        "not_material_count": ledger["summary"]["not_material_count"],
+        "review_counts": ledger["summary"]["review_counts"],
+        "routing_counts": ledger["summary"]["routing_counts"],
+        "intake_minimum_ledger_sha256": ledger["ledger_digest"],
+        "input_files": ledger["input_files"],
+        "claims_boundary": CLAIMS_BOUNDARY,
+    }
+
+
+def write_intake_minimum_evidence(ledger: dict[str, Any], out_dir: Path) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ledger_path = out_dir / "intake-minimum-ledger.json"
+    summary_path = out_dir / "intake-minimum-summary.json"
+    _write_json(ledger_path, ledger)
+    summary = build_summary(ledger)
+    summary["intake_minimum_ledger_file_sha256"] = _sha256_file(ledger_path)
+    _write_json(summary_path, summary)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a minimum governance ledger for new Worldshepherd/SARA intakes.")
+    parser.add_argument("--intake-file", type=Path, required=True, help="JSON file containing one intake object or an intakes list.")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for intake-minimum-ledger.json and summary.")
+    parser.add_argument("--repository", default=os.getenv("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--commit-sha", default=os.getenv("GITHUB_SHA", ""))
+    parser.add_argument("--operator", default=os.getenv("USER", "unknown"))
+    parser.add_argument("--executed-utc", default=None)
+    args = parser.parse_args(argv)
+
+    ledger = build_intake_minimum_ledger(
+        intake_file=args.intake_file,
+        repository=args.repository,
+        commit_sha=args.commit_sha,
+        operator=args.operator,
+        executed_utc=args.executed_utc,
+    )
+    summary = write_intake_minimum_evidence(ledger, args.out)
+    print(_json_text(summary), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a reusable intake-minimum standard so every new Worldshepherd/SARA intake must carry source custody, evidence status, maturity label, human-review status, routing status, downstream route/evidence, and an explicit claims boundary before it can influence PRE, opportunity, partner, security, release, or standards posture.

## Added

- `deployments/sara_verified_local_v1/worldshepherd_sara/intake_minimum_cli.py`
  - Adds `ws-intake-minimum-ledger`.
  - Validates minimum intake records.
  - Emits `intake-minimum-ledger.json` and `intake-minimum-summary.json`.
  - Requires source system, locator, retrieval time, SHA-256 source digest, evidence status, maturity label, human-review status, routing status, downstream route/evidence, and explicit non-claim boundary.
  - Rejects duplicate intake IDs, missing custody fields, bad source digests, unsupported review/routing states, reviewed states without rationale, missing downstream route/evidence, and prohibited readiness assertions.

- `deployments/sara_verified_local_v1/tests/test_intake_minimum_cli.py`
  - Verifies minimum controls, ledger summaries, CLI writes, digest recording, duplicate rejection, missing field rejection, bad digest rejection, unsupported claim-boundary rejection, prohibited assertion rejection, reviewed-without-rationale rejection, and missing downstream route rejection.

- `deployments/sara_verified_local_v1/fixtures/intake_minimum_standard.json`
  - Adds the current CRE1AWS directive as a bounded intake fixture.

- `deployments/sara_verified_local_v1/scripts/verify_intake_minimum_artifact.sh`
  - Adds a standalone verifier for future `intake_minimum_ci` artifacts.

- `deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_2026-09-01.md`
  - Documents required fields, allowed review/routing states, prohibited assertions, operating rule, and claims boundary.

- `deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_ADOPTION_2026-09-01.md`
  - Marks workflow upload and release-index custody as the next integration step.

- `deployments/sara_verified_local_v1/docs/WS_INTAKE_MINIMUM_STANDARD_PR_NOTES_2026-09-01.md`
  - Captures PR posture and safe operating interpretation.

## Claims boundary

This PR creates an enforced intake-minimum validator and fixture. It does **not** prove that every future external intake has already been processed through the standard, nor does it establish source truth, partner validation, supplier approval, certification, CMMC/NIST/DFARS conformity, classified access, DOE validation, external reproduction, field performance, hardware performance, export-control clearance, software supply-chain completeness, absence of vulnerabilities, advisory-feed completeness, vulnerability scan pass, vulnerability remediation, human-review completion, exploitability analysis, license legal review, SLSA compliance, opportunity eligibility, award probability, or operational authority.

## Next increment

Wire `ws-intake-minimum-ledger` into `.github/workflows/sara-verified-local-v1.yml` as an uploaded `intake-minimum-standard-evidence` artifact and then add release-index custody for that artifact.