### PR TITLE
Evidence custody: attest successful main release indexes

### DIFF
--- a/.github/workflows/sara-release-attestation.yml
+++ b/.github/workflows/sara-release-attestation.yml
@@ -1,0 +1,111 @@
+name: SARA Release Evidence Attestation
+
+on:
+  workflow_run:
+    workflows:
+      - SARA Verified Local v1 Gate
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  attest-release-index:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Download exact triggering release index
+        uses: actions/download-artifact@v4
+        with:
+          name: sara-release-evidence-index
+          path: release_index
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Verify index belongs to successful main gate
+        env:
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          test -s release_index/release-index.json
+          python -m json.tool release_index/release-index.json >/dev/null
+          python - <<'PY'
+          import json, os, pathlib
+          path = pathlib.Path('release_index/release-index.json')
+          record = json.loads(path.read_text(encoding='utf-8'))
+          assert record['schema'] == 'WS-SARA-RELEASE-EVIDENCE-INDEX-V1'
+          assert record['commit_sha'] == os.environ['TRIGGER_SHA']
+          assert str(record['workflow']['run_id']) == os.environ['TRIGGER_RUN_ID']
+          assert record['workflow']['merge_state'] == 'MERGED_MAIN_PUSH'
+          assert record['workflow']['event_name'] == 'push'
+          assert record['workflow']['ref'] == 'refs/heads/main'
+          assert record['release_index_digest'].startswith('sha256:')
+          PY
+
+      - name: Generate signed build-provenance attestation
+        id: attest_release_index
+        uses: actions/attest@v4
+        with:
+          subject-path: release_index/release-index.json
+          create-storage-record: false
+
+      - name: Build attestation custody receipt
+        env:
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+          TRIGGER_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ATTESTATION_ID: ${{ steps.attest_release_index.outputs.attestation-id }}
+          ATTESTATION_URL: ${{ steps.attest_release_index.outputs.attestation-url }}
+          BUNDLE_PATH: ${{ steps.attest_release_index.outputs.bundle-path }}
+        run: |
+          mkdir -p attestation_evidence
+          cp "$BUNDLE_PATH" attestation_evidence/sigstore-attestation-bundle.json
+          python - <<'PY'
+          import datetime, hashlib, json, os, pathlib
+          index = pathlib.Path('release_index/release-index.json')
+          bundle = pathlib.Path('attestation_evidence/sigstore-attestation-bundle.json')
+          receipt = {
+              'schema': 'WS-SARA-RELEASE-ATTESTATION-RECEIPT-V1',
+              'evidence_status': 'GITHUB_SIGSTORE_ATTESTED_INTERNAL_RELEASE_INDEX',
+              'executed_utc': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'repository': os.environ['GITHUB_REPOSITORY'],
+              'triggering_commit_sha': os.environ['TRIGGER_SHA'],
+              'triggering_workflow_run_id': os.environ['TRIGGER_RUN_ID'],
+              'triggering_workflow_run_url': os.environ['TRIGGER_RUN_URL'],
+              'release_index_file_sha256': 'sha256:' + hashlib.sha256(index.read_bytes()).hexdigest(),
+              'attestation_bundle_file_sha256': 'sha256:' + hashlib.sha256(bundle.read_bytes()).hexdigest(),
+              'attestation_id': os.environ['ATTESTATION_ID'],
+              'attestation_url': os.environ['ATTESTATION_URL'],
+              'signing_mechanism': 'GitHub Actions artifact attestation using GitHub OIDC and Sigstore-backed signing',
+              'claims_boundary': (
+                  'This receipt establishes cryptographic provenance for the exact release-index file emitted by a successful '
+                  'main-branch SARA gate. It does not independently validate the truth of claims inside referenced artifacts, '
+                  'does not constitute customer/government approval, ATO, CMMC certification, legal review, partner validation, '
+                  'field validation, or independent third-party reproduction.'
+              ),
+          }
+          pathlib.Path('attestation_evidence/attestation-receipt.json').write_text(
+              json.dumps(receipt, sort_keys=True, indent=2) + '\n', encoding='utf-8'
+          )
+          PY
+          python -m json.tool attestation_evidence/attestation-receipt.json >/dev/null
+
+      - name: Upload attestation custody evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-release-index-attestation-evidence
+          path: attestation_evidence
+          if-no-files-found: error
+          retention-days: 90

--- a/deployments/sara_verified_local_v1/docs/EVIDENCE_ATTESTATION_POLICY.md
+++ b/deployments/sara_verified_local_v1/docs/EVIDENCE_ATTESTATION_POLICY.md
@@ -1,0 +1,40 @@
+# SARA Release Evidence Attestation Policy
+
+## Purpose
+
+This policy defines the internal signing and retention boundary for SARA release-evidence indexes. It is an engineering-control document, not an external compliance certification.
+
+## Authoritative internal subject
+
+The attested subject is `release-index.json` emitted by a successful `SARA Verified Local v1 Gate` push run on `main`. The release index binds the triggering repository commit to the artifact IDs and SHA-256 digests produced by that gate.
+
+A pull-request candidate, failed workflow, non-main branch run, or manually generated local file is not eligible for this automated release-index attestation.
+
+## Privilege separation
+
+The build/test job does not receive OIDC or attestation-write authority merely to produce evidence. A separate `workflow_run` job starts only after the main SARA gate reports success. That job receives the minimum signing-related permissions required by GitHub artifact attestations, downloads the release-index artifact from the exact triggering run, and verifies its recorded commit, workflow run, event, ref, and merge state before signing.
+
+## Signing mechanism
+
+The attestation workflow uses GitHub artifact attestations through `actions/attest`, which uses a short-lived GitHub Actions OIDC identity and Sigstore-backed signing. The resulting attestation is persisted by GitHub's attestation service and a serialized Sigstore bundle is also retained as workflow evidence.
+
+## Retention
+
+The workflow retains an `attestation-receipt.json` and `sigstore-attestation-bundle.json` as a GitHub Actions artifact for 90 days. The GitHub attestation itself is stored separately by GitHub's attestation service. This is off-runner custody, but it is not described as independent third-party archival custody.
+
+For any contract requiring independent/off-platform archival retention, externally controlled signing keys, WORM storage, legal-hold retention, classified/CUI storage, or customer-specific retention periods, this internal mechanism is insufficient until the corresponding authoritative architecture and evidence exist.
+
+## Verification requirements
+
+Before relying on an attested release index internally, verify all of the following:
+
+- the attested file digest matches the intended `release-index.json`;
+- the release index names the intended Git commit;
+- the index records `MERGED_MAIN_PUSH`, event `push`, and ref `refs/heads/main`;
+- the triggering SARA gate completed successfully;
+- the attestation identity and repository correspond to `Bdavis1390/Sara_pro`;
+- referenced evidence artifacts remain within their own claims boundaries.
+
+## Claims boundary
+
+A valid cryptographic attestation proves provenance and integrity of the attested release-index file under the GitHub/Sigstore workflow identity. It does **not** prove that every scientific, technical, legal, security, partner, physical, or compliance claim referenced by the index is externally true or validated. It does not constitute ATO, CMMC certification, RMF authorization, legal review, government acceptance, partner validation, laboratory validation, field validation, or independent reproduction.


### PR DESCRIPTION
Adds a privilege-separated post-gate attestation workflow and internal evidence-attestation policy. After a successful `SARA Verified Local v1 Gate` push on `main`, the new workflow downloads the exact triggering run's `sara-release-evidence-index`, verifies its commit/run/ref/merge-state binding, then creates a GitHub/Sigstore-backed artifact attestation for `release-index.json`. It retains a machine-readable custody receipt and serialized Sigstore bundle for 90 days. Signing authority is deliberately separated from the build/test job. Claims boundary: cryptographic provenance/integrity only; this does not establish truth of referenced claims, independent third-party archival custody, ATO, CMMC, RMF authorization, legal review, partner/lab/field validation, or government acceptance.