### PR TITLE
Recovery precursor: restore into a clean replacement environment

### DIFF
--- a/.github/workflows/sara-replacement-environment-restore.yml
+++ b/.github/workflows/sara-replacement-environment-restore.yml
@@ -1,0 +1,65 @@
+name: SARA Replacement Environment Restore
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/**'
+      - '.github/workflows/sara-replacement-environment-restore.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/**'
+      - '.github/workflows/sara-replacement-environment-restore.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  replacement-environment-restore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out exact tested source
+        uses: actions/checkout@v4
+
+      - name: Execute clean replacement-environment restore
+        env:
+          REPLACEMENT_RECOVERY_DIR: ${{ github.workspace }}/deployments/sara_verified_local_v1/replacement_recovery_evidence
+          REPLACEMENT_HOST_PORT: '19532'
+        run: bash deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
+
+      - name: Validate replacement restore evidence contract
+        run: |
+          python - <<'PY'
+          import json, os, pathlib
+          path=pathlib.Path('deployments/sara_verified_local_v1/replacement_recovery_evidence/replacement-environment-restore.json')
+          record=json.loads(path.read_text(encoding='utf-8'))
+          assert record['schema']=='WS-SARA-REPLACEMENT-ENVIRONMENT-RESTORE-EVIDENCE-V1'
+          assert record['evidence_status']=='INTERNAL_CI_GENERATED_UNSIGNED'
+          assert record['result']=='PASS'
+          assert record['source_build_commit']==os.environ['GITHUB_SHA']
+          assert record['source_volume_destroyed_before_restore'] is True
+          assert record['source_volume_name'] != record['replacement_volume_name']
+          assert all(record['checks'].values())
+          assert 'does not establish recovery on a physically separate host' in record['claims_boundary'].lower()
+          PY
+
+      - name: Upload replacement restore evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-replacement-environment-restore-evidence
+          path: deployments/sara_verified_local_v1/replacement_recovery_evidence
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Capture Docker state on failure
+        if: failure()
+        run: docker ps -a --no-trunc || true
+
+      - name: Clean residual replacement resources
+        if: always()
+        run: |
+          docker ps -aq --filter 'name=sara-source-' | xargs -r docker rm -f || true
+          docker ps -aq --filter 'name=sara-replacement-' | xargs -r docker rm -f || true
+          docker volume ls -q --filter 'name=sara_source_' | xargs -r docker volume rm || true
+          docker volume ls -q --filter 'name=sara_replacement_' | xargs -r docker volume rm || true

--- a/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
+++ b/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
@@ -48,7 +48,7 @@ wait_ready() {
 
 prepare_volume() {
   local volume="$1"
-  docker run --rm --user 0 -v "$volume:/data" "$IMAGE" sh -c 'chown 10001:10001 /data && chmod 0700 /data'
+  docker run --rm --user 0 -v "$volume:/data" "$IMAGE" sh -c 'chown -R 10001:10001 /data && chmod 0700 /data'
 }
 
 run_sara() {
@@ -126,6 +126,7 @@ root=pathlib.Path("/data"); root.mkdir(parents=True,exist_ok=True)
 with tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz") as tf:
     tf.extractall(root,filter="data")
 ' < "$ARCHIVE"
+prepare_volume "$REPLACEMENT_VOLUME"
 
 run_sara "$REPLACEMENT_CONTAINER" "$REPLACEMENT_VOLUME"
 wait_ready "$REPLACEMENT_CONTAINER"
@@ -169,6 +170,7 @@ record={
   'source_volume_name':os.environ['SOURCE_VOLUME'],
   'replacement_volume_name':os.environ['REPLACEMENT_VOLUME'],
   'backup_sha256':'sha256:'+hashlib.sha256(archive.read_bytes()).hexdigest(),
+  'restore_ownership_normalization':'recursive chown to UID/GID 10001 after extraction; root volume mode 0700',
   'checks':checks,
   'data_scope':'synthetic/public/releasable CI data only',
   'claims_boundary':(

--- a/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
+++ b/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${REPLACEMENT_RECOVERY_DIR:-$ROOT/replacement_recovery_evidence}"
+HOST_PORT="${REPLACEMENT_HOST_PORT:-19532}"
+SOURCE_SHA="${GITHUB_SHA:-$(git -C "$ROOT" rev-parse HEAD)}"
+RUN_KEY="${GITHUB_RUN_ID:-local}-$$"
+SAFE_KEY="${RUN_KEY//[^a-zA-Z0-9_.-]/_}"
+IMAGE="sara-replacement-restore:${SOURCE_SHA:0:12}"
+SOURCE_VOLUME="sara_source_${SAFE_KEY}"
+REPLACEMENT_VOLUME="sara_replacement_${SAFE_KEY}"
+SOURCE_CONTAINER="sara-source-${SAFE_KEY}"
+REPLACEMENT_CONTAINER="sara-replacement-${SAFE_KEY}"
+ADMIN_TOKEN="$(openssl rand -hex 32)"
+RELAY_TOKEN="$(openssl rand -hex 32)"
+MARKER="replacement-restore-${SAFE_KEY}"
+ARCHIVE="$OUT_DIR/source-backup.tar.gz"
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/*.json "$ARCHIVE" "$ARCHIVE.sha256"
+
+cleanup() {
+  docker rm -f "$SOURCE_CONTAINER" "$REPLACEMENT_CONTAINER" >/dev/null 2>&1 || true
+  docker volume rm "$SOURCE_VOLUME" "$REPLACEMENT_VOLUME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_ready() {
+  for _ in $(seq 1 60); do
+    if curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" >/dev/null 2>&1; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+run_sara() {
+  local name="$1" volume="$2"
+  docker run -d \
+    --name "$name" \
+    --read-only \
+    --tmpfs /tmp:size=16m,mode=1777 \
+    --security-opt no-new-privileges:true \
+    --cap-drop ALL \
+    -e SARA_RELAY_TOKEN="$RELAY_TOKEN" \
+    -e SARA_ADMIN_TOKEN="$ADMIN_TOKEN" \
+    -e SARA_BIND_HOST=0.0.0.0 \
+    -e SARA_PORT=9530 \
+    -e SARA_DATA_DIR=/var/lib/sara \
+    -e SARA_MODE=replacement-environment-drill \
+    -p "127.0.0.1:${HOST_PORT}:9530" \
+    -v "$volume:/var/lib/sara" \
+    "$IMAGE" >/dev/null
+}
+
+inventory_volume() {
+  local volume="$1" output="$2"
+  docker run --rm --user 0 -v "$volume:/data:ro" "$IMAGE" python -c '
+import hashlib,json,pathlib
+root=pathlib.Path("/data"); rows=[]
+for p in sorted(x for x in root.rglob("*") if x.is_file()):
+    rows.append({"path":str(p.relative_to(root)),"size":p.stat().st_size,"sha256":hashlib.sha256(p.read_bytes()).hexdigest()})
+print(json.dumps(rows,sort_keys=True,indent=2))
+' > "$output"
+}
+
+echo "[replacement] build tested source image"
+docker build \
+  --build-arg SARA_BUILD_COMMIT="$SOURCE_SHA" \
+  --build-arg SARA_RELEASE_ID="replacement-drill-${SOURCE_SHA}" \
+  -t "$IMAGE" "$ROOT" >/dev/null
+
+docker volume create "$SOURCE_VOLUME" >/dev/null
+run_sara "$SOURCE_CONTAINER" "$SOURCE_VOLUME"
+wait_ready
+
+python - "$MARKER" "$SOURCE_SHA" > "$OUT_DIR/marker-request.json" <<'PY'
+import json,sys
+marker, sha=sys.argv[1:]
+print(json.dumps({"values":{"REPLACEMENT_RESTORE_MARKER":{"marker":marker,"written_by_commit":sha}}},sort_keys=True))
+PY
+curl -fsS -X PATCH \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$OUT_DIR/marker-request.json" \
+  "http://127.0.0.1:${HOST_PORT}/admin/registry" > "$OUT_DIR/source-registry.json"
+inventory_volume "$SOURCE_VOLUME" "$OUT_DIR/source-inventory.json"
+
+# Export backup to runner-owned storage before deleting the entire source runtime and volume.
+docker run --rm --user 0 -v "$SOURCE_VOLUME:/data:ro" "$IMAGE" python -c '
+import pathlib,sys,tarfile
+root=pathlib.Path("/data")
+with tarfile.open(fileobj=sys.stdout.buffer,mode="w|gz") as tf:
+    for p in sorted(root.rglob("*")):
+        tf.add(p,arcname=str(p.relative_to(root)),recursive=False)
+' > "$ARCHIVE"
+sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+
+# Hard destruction boundary: the source container and source volume must cease to exist.
+docker rm -f "$SOURCE_CONTAINER" >/dev/null
+docker volume rm "$SOURCE_VOLUME" >/dev/null
+if docker inspect "$SOURCE_CONTAINER" >/dev/null 2>&1; then echo 'source container still exists' >&2; exit 1; fi
+if docker volume inspect "$SOURCE_VOLUME" >/dev/null 2>&1; then echo 'source volume still exists' >&2; exit 1; fi
+
+# Create an independently named clean replacement volume and restore only from exported backup bytes.
+docker volume create "$REPLACEMENT_VOLUME" >/dev/null
+docker run --rm --user 0 -i -v "$REPLACEMENT_VOLUME:/data" "$IMAGE" python -c '
+import pathlib,sys,tarfile
+root=pathlib.Path("/data"); root.mkdir(parents=True,exist_ok=True)
+with tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz") as tf:
+    tf.extractall(root,filter="data")
+' < "$ARCHIVE"
+
+run_sara "$REPLACEMENT_CONTAINER" "$REPLACEMENT_VOLUME"
+wait_ready
+curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" > "$OUT_DIR/replacement-readyz.json"
+curl -fsS "http://127.0.0.1:${HOST_PORT}/health" > "$OUT_DIR/replacement-health.json"
+curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  "http://127.0.0.1:${HOST_PORT}/admin/registry" > "$OUT_DIR/replacement-registry.json"
+curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  "http://127.0.0.1:${HOST_PORT}/admin/selftest" > "$OUT_DIR/replacement-selftest.json"
+inventory_volume "$REPLACEMENT_VOLUME" "$OUT_DIR/replacement-inventory.json"
+
+export OUT_DIR SOURCE_SHA MARKER SOURCE_VOLUME REPLACEMENT_VOLUME ARCHIVE
+python - <<'PY'
+import datetime,hashlib,json,os,pathlib
+root=pathlib.Path(os.environ['OUT_DIR'])
+load=lambda n: json.loads((root/n).read_text(encoding='utf-8'))
+source_inv=load('source-inventory.json')
+replacement_inv=load('replacement-inventory.json')
+registry=load('replacement-registry.json')['registry']
+ready=load('replacement-readyz.json')
+selftest=load('replacement-selftest.json')
+health=load('replacement-health.json')
+marker=registry['REPLACEMENT_RESTORE_MARKER']
+archive=pathlib.Path(os.environ['ARCHIVE'])
+checks={
+  'source_and_replacement_volume_names_differ': os.environ['SOURCE_VOLUME'] != os.environ['REPLACEMENT_VOLUME'],
+  'restored_file_inventory_matches_source': source_inv == replacement_inv,
+  'synthetic_marker_preserved': marker.get('marker') == os.environ['MARKER'],
+  'marker_origin_preserved': marker.get('written_by_commit') == os.environ['SOURCE_SHA'],
+  'replacement_ready': ready.get('ok') is True and ready.get('status') == 'ready',
+  'replacement_selftest_passed': selftest.get('ok') is True,
+  'replacement_build_identity_matches_source': health.get('release_identity',{}).get('build_commit') == os.environ['SOURCE_SHA'],
+}
+record={
+  'schema':'WS-SARA-REPLACEMENT-ENVIRONMENT-RESTORE-EVIDENCE-V1',
+  'evidence_status':'INTERNAL_CI_GENERATED_UNSIGNED',
+  'result':'PASS' if all(checks.values()) else 'FAIL',
+  'executed_utc':datetime.datetime.now(datetime.timezone.utc).isoformat(),
+  'source_build_commit':os.environ['SOURCE_SHA'],
+  'source_volume_destroyed_before_restore':True,
+  'source_volume_name':os.environ['SOURCE_VOLUME'],
+  'replacement_volume_name':os.environ['REPLACEMENT_VOLUME'],
+  'backup_sha256':'sha256:'+hashlib.sha256(archive.read_bytes()).hexdigest(),
+  'checks':checks,
+  'data_scope':'synthetic/public/releasable CI data only',
+  'claims_boundary':(
+    'This demonstrates restore into a clean, independently named replacement Docker runtime/volume after complete deletion '
+    'of the original source container and volume on one GitHub-hosted runner. It is a replacement-environment precursor only. '
+    'It does not establish recovery on a physically separate host or failure domain, site disaster recovery, hardware failure '
+    'recovery, external custody, production RTO/RPO, customer acceptance, certification, or field readiness.'
+  )
+}
+(root/'replacement-environment-restore.json').write_text(json.dumps(record,sort_keys=True,indent=2)+'\n',encoding='utf-8')
+if record['result']!='PASS': raise SystemExit('REPLACEMENT_ENVIRONMENT_RESTORE: FAIL '+json.dumps(checks,sort_keys=True))
+print('REPLACEMENT_ENVIRONMENT_RESTORE: PASS')
+PY

--- a/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
+++ b/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
@@ -70,6 +70,12 @@ run_sara() {
     "$IMAGE" >/dev/null
 }
 
+container_env_value() {
+  local name="$1" key="$2"
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$name" \
+    | sed -n "s/^${key}=//p" | head -n 1
+}
+
 inventory_volume() {
   local volume="$1" output="$2"
   docker run --rm --user 0 -v "$volume:/data:ro" "$IMAGE" python -c '
@@ -102,8 +108,10 @@ curl -fsS -X PATCH \
   -H 'Content-Type: application/json' \
   --data-binary "@$OUT_DIR/marker-request.json" \
   "http://127.0.0.1:${HOST_PORT}/admin/registry" > "$OUT_DIR/source-registry.json"
-inventory_volume "$SOURCE_VOLUME" "$OUT_DIR/source-inventory.json"
 
+# Quiesce the source before taking the authoritative byte inventory and backup.
+docker stop "$SOURCE_CONTAINER" >/dev/null
+inventory_volume "$SOURCE_VOLUME" "$OUT_DIR/source-inventory.json"
 docker run --rm --user 0 -v "$SOURCE_VOLUME:/data:ro" "$IMAGE" python -c '
 import pathlib,sys,tarfile
 root=pathlib.Path("/data")
@@ -113,11 +121,13 @@ with tarfile.open(fileobj=sys.stdout.buffer,mode="w|gz") as tf:
 ' > "$ARCHIVE"
 sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
 
-docker rm -f "$SOURCE_CONTAINER" >/dev/null
+# Hard destruction boundary: source runtime and source volume cease to exist before replacement creation.
+docker rm "$SOURCE_CONTAINER" >/dev/null
 docker volume rm "$SOURCE_VOLUME" >/dev/null
 if docker inspect "$SOURCE_CONTAINER" >/dev/null 2>&1; then echo 'source container still exists' >&2; exit 1; fi
 if docker volume inspect "$SOURCE_VOLUME" >/dev/null 2>&1; then echo 'source volume still exists' >&2; exit 1; fi
 
+# Restore only from exported backup bytes into a separately named clean volume.
 docker volume create "$REPLACEMENT_VOLUME" >/dev/null
 prepare_volume "$REPLACEMENT_VOLUME"
 docker run --rm --user 0 -i -v "$REPLACEMENT_VOLUME:/data" "$IMAGE" python -c '
@@ -128,37 +138,41 @@ with tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz") as tf:
 ' < "$ARCHIVE"
 prepare_volume "$REPLACEMENT_VOLUME"
 
+# Compare restored bytes before SARA startup legitimately appends fresh service audit records.
+inventory_volume "$REPLACEMENT_VOLUME" "$OUT_DIR/replacement-prestart-inventory.json"
+
 run_sara "$REPLACEMENT_CONTAINER" "$REPLACEMENT_VOLUME"
 wait_ready "$REPLACEMENT_CONTAINER"
+REPLACEMENT_RUNTIME_COMMIT="$(container_env_value "$REPLACEMENT_CONTAINER" SARA_BUILD_COMMIT)"
+REPLACEMENT_OCI_REVISION="$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$REPLACEMENT_CONTAINER")"
 curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" > "$OUT_DIR/replacement-readyz.json"
 curl -fsS "http://127.0.0.1:${HOST_PORT}/health" > "$OUT_DIR/replacement-health.json"
 curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
   "http://127.0.0.1:${HOST_PORT}/admin/registry" > "$OUT_DIR/replacement-registry.json"
 curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
   "http://127.0.0.1:${HOST_PORT}/admin/selftest" > "$OUT_DIR/replacement-selftest.json"
-inventory_volume "$REPLACEMENT_VOLUME" "$OUT_DIR/replacement-inventory.json"
 
-export OUT_DIR SOURCE_SHA MARKER SOURCE_VOLUME REPLACEMENT_VOLUME ARCHIVE
+export OUT_DIR SOURCE_SHA MARKER SOURCE_VOLUME REPLACEMENT_VOLUME ARCHIVE REPLACEMENT_RUNTIME_COMMIT REPLACEMENT_OCI_REVISION
 python - <<'PY'
 import datetime,hashlib,json,os,pathlib
 root=pathlib.Path(os.environ['OUT_DIR'])
 load=lambda n: json.loads((root/n).read_text(encoding='utf-8'))
 source_inv=load('source-inventory.json')
-replacement_inv=load('replacement-inventory.json')
+replacement_inv=load('replacement-prestart-inventory.json')
 registry=load('replacement-registry.json')['registry']
 ready=load('replacement-readyz.json')
 selftest=load('replacement-selftest.json')
-health=load('replacement-health.json')
 marker=registry['REPLACEMENT_RESTORE_MARKER']
 archive=pathlib.Path(os.environ['ARCHIVE'])
 checks={
   'source_and_replacement_volume_names_differ': os.environ['SOURCE_VOLUME'] != os.environ['REPLACEMENT_VOLUME'],
-  'restored_file_inventory_matches_source': source_inv == replacement_inv,
+  'restored_prestart_file_inventory_matches_source': source_inv == replacement_inv,
   'synthetic_marker_preserved': marker.get('marker') == os.environ['MARKER'],
   'marker_origin_preserved': marker.get('written_by_commit') == os.environ['SOURCE_SHA'],
   'replacement_ready': ready.get('ok') is True and ready.get('status') == 'ready',
   'replacement_selftest_passed': selftest.get('ok') is True,
-  'replacement_build_identity_matches_source': health.get('release_identity',{}).get('build_commit') == os.environ['SOURCE_SHA'],
+  'replacement_runtime_build_identity_matches_source': os.environ['REPLACEMENT_RUNTIME_COMMIT'] == os.environ['SOURCE_SHA'],
+  'replacement_oci_revision_matches_source': os.environ['REPLACEMENT_OCI_REVISION'] == os.environ['SOURCE_SHA'],
 }
 record={
   'schema':'WS-SARA-REPLACEMENT-ENVIRONMENT-RESTORE-EVIDENCE-V1',
@@ -166,6 +180,8 @@ record={
   'result':'PASS' if all(checks.values()) else 'FAIL',
   'executed_utc':datetime.datetime.now(datetime.timezone.utc).isoformat(),
   'source_build_commit':os.environ['SOURCE_SHA'],
+  'replacement_runtime_build_commit':os.environ['REPLACEMENT_RUNTIME_COMMIT'],
+  'replacement_oci_revision':os.environ['REPLACEMENT_OCI_REVISION'],
   'source_volume_destroyed_before_restore':True,
   'source_volume_name':os.environ['SOURCE_VOLUME'],
   'replacement_volume_name':os.environ['REPLACEMENT_VOLUME'],

--- a/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
+++ b/deployments/sara_verified_local_v1/scripts/replacement_environment_restore.sh
@@ -27,11 +27,28 @@ cleanup() {
 trap cleanup EXIT
 
 wait_ready() {
+  local name="$1"
   for _ in $(seq 1 60); do
     if curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" >/dev/null 2>&1; then return 0; fi
+    if ! docker inspect "$name" >/dev/null 2>&1; then
+      echo "container ${name} disappeared before readiness" >&2
+      return 1
+    fi
+    if [ "$(docker inspect --format '{{.State.Running}}' "$name")" != "true" ]; then
+      echo "container ${name} exited before readiness" >&2
+      docker logs "$name" >&2 || true
+      return 1
+    fi
     sleep 1
   done
+  echo "container ${name} did not become ready" >&2
+  docker logs "$name" >&2 || true
   return 1
+}
+
+prepare_volume() {
+  local volume="$1"
+  docker run --rm --user 0 -v "$volume:/data" "$IMAGE" sh -c 'chown 10001:10001 /data && chmod 0700 /data'
 }
 
 run_sara() {
@@ -71,8 +88,9 @@ docker build \
   -t "$IMAGE" "$ROOT" >/dev/null
 
 docker volume create "$SOURCE_VOLUME" >/dev/null
+prepare_volume "$SOURCE_VOLUME"
 run_sara "$SOURCE_CONTAINER" "$SOURCE_VOLUME"
-wait_ready
+wait_ready "$SOURCE_CONTAINER"
 
 python - "$MARKER" "$SOURCE_SHA" > "$OUT_DIR/marker-request.json" <<'PY'
 import json,sys
@@ -86,7 +104,6 @@ curl -fsS -X PATCH \
   "http://127.0.0.1:${HOST_PORT}/admin/registry" > "$OUT_DIR/source-registry.json"
 inventory_volume "$SOURCE_VOLUME" "$OUT_DIR/source-inventory.json"
 
-# Export backup to runner-owned storage before deleting the entire source runtime and volume.
 docker run --rm --user 0 -v "$SOURCE_VOLUME:/data:ro" "$IMAGE" python -c '
 import pathlib,sys,tarfile
 root=pathlib.Path("/data")
@@ -96,14 +113,13 @@ with tarfile.open(fileobj=sys.stdout.buffer,mode="w|gz") as tf:
 ' > "$ARCHIVE"
 sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
 
-# Hard destruction boundary: the source container and source volume must cease to exist.
 docker rm -f "$SOURCE_CONTAINER" >/dev/null
 docker volume rm "$SOURCE_VOLUME" >/dev/null
 if docker inspect "$SOURCE_CONTAINER" >/dev/null 2>&1; then echo 'source container still exists' >&2; exit 1; fi
 if docker volume inspect "$SOURCE_VOLUME" >/dev/null 2>&1; then echo 'source volume still exists' >&2; exit 1; fi
 
-# Create an independently named clean replacement volume and restore only from exported backup bytes.
 docker volume create "$REPLACEMENT_VOLUME" >/dev/null
+prepare_volume "$REPLACEMENT_VOLUME"
 docker run --rm --user 0 -i -v "$REPLACEMENT_VOLUME:/data" "$IMAGE" python -c '
 import pathlib,sys,tarfile
 root=pathlib.Path("/data"); root.mkdir(parents=True,exist_ok=True)
@@ -112,7 +128,7 @@ with tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz") as tf:
 ' < "$ARCHIVE"
 
 run_sara "$REPLACEMENT_CONTAINER" "$REPLACEMENT_VOLUME"
-wait_ready
+wait_ready "$REPLACEMENT_CONTAINER"
 curl -fsS "http://127.0.0.1:${HOST_PORT}/readyz" > "$OUT_DIR/replacement-readyz.json"
 curl -fsS "http://127.0.0.1:${HOST_PORT}/health" > "$OUT_DIR/replacement-health.json"
 curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \


### PR DESCRIPTION
Adds a clean replacement-environment restore drill. CI writes synthetic authenticated state under a source SARA runtime, inventories and exports its persistent volume, then destroys the source container and source volume entirely. It creates a separately named clean replacement volume, restores only from the exported backup bytes, starts SARA, and requires exact file-inventory equivalence, preserved marker/origin, readiness, self-test, and source build identity. Evidence schema: `WS-SARA-REPLACEMENT-ENVIRONMENT-RESTORE-EVIDENCE-V1`. Claims boundary: this is a one-runner replacement-environment precursor only; it does not establish recovery on a physically separate host/failure domain, site disaster recovery, production RTO/RPO, external custody, customer acceptance, certification, or field readiness.