### PR TITLE
TLS architecture precursor: isolate SARA behind a private backend network

### DIFF
--- a/.github/workflows/sara-tls-proxy-architecture.yml
+++ b/.github/workflows/sara-tls-proxy-architecture.yml
@@ -1,0 +1,71 @@
+name: SARA TLS Private Backend Architecture
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/**'
+      - '.github/workflows/sara-tls-proxy-architecture.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/**'
+      - '.github/workflows/sara-tls-proxy-architecture.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tls-private-backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact tested source
+        uses: actions/checkout@v4
+
+      - name: Compile reference proxy
+        run: python -m py_compile deployments/sara_verified_local_v1/scripts/tls_reference_proxy.py
+
+      - name: Execute TLS/private-backend architecture drill
+        env:
+          TLS_PROXY_EVIDENCE_DIR: ${{ github.workspace }}/deployments/sara_verified_local_v1/tls_proxy_evidence
+          TLS_PROXY_HOST_PORT: '19443'
+        run: bash deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
+
+      - name: Validate TLS architecture evidence contract
+        run: |
+          python - <<'PY'
+          import json, os, pathlib
+          path = pathlib.Path('deployments/sara_verified_local_v1/tls_proxy_evidence/tls-private-backend-architecture.json')
+          record = json.loads(path.read_text(encoding='utf-8'))
+          assert record['schema'] == 'WS-SARA-TLS-PRIVATE-BACKEND-ARCHITECTURE-EVIDENCE-V1'
+          assert record['evidence_status'] == 'INTERNAL_CI_GENERATED_EPHEMERAL_IDENTITY'
+          assert record['result'] == 'PASS'
+          assert record['source_build_commit'] == os.environ['GITHUB_SHA']
+          assert record['backend_host_port_exposure'] == 'NONE'
+          assert record['tls_minimum_version'] == 'TLSv1.2'
+          assert all(record['checks'].values())
+          boundary = record['claims_boundary'].lower()
+          assert 'does not establish production identity' in boundary
+          assert 'public-ca issuance' in boundary
+          PY
+
+      - name: Upload TLS architecture evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-tls-private-backend-architecture-evidence
+          path: deployments/sara_verified_local_v1/tls_proxy_evidence
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Capture Docker state and logs on failure
+        if: failure()
+        run: |
+          docker ps -a --no-trunc || true
+          for id in $(docker ps -aq --filter 'name=sara-tls-'); do docker logs "$id" || true; done
+
+      - name: Clean residual TLS drill resources
+        if: always()
+        run: |
+          docker ps -aq --filter 'name=sara-tls-' | xargs -r docker rm -f || true
+          docker network ls -q --filter 'name=sara_tls_' | xargs -r docker network rm || true
+          docker volume ls -q --filter 'name=sara_tls_data_' | xargs -r docker volume rm || true

--- a/deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
+++ b/deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
@@ -8,7 +8,8 @@ HOST_PORT="${TLS_PROXY_HOST_PORT:-19443}"
 RUN_KEY="${GITHUB_RUN_ID:-local}-$$"
 SAFE_KEY="${RUN_KEY//[^a-zA-Z0-9_.-]/_}"
 IMAGE="sara-tls-architecture:${SOURCE_SHA:0:12}"
-NETWORK="sara_tls_${SAFE_KEY}"
+FRONT_NETWORK="sara_tls_front_${SAFE_KEY}"
+BACK_NETWORK="sara_tls_back_${SAFE_KEY}"
 DATA_VOLUME="sara_tls_data_${SAFE_KEY}"
 SARA_CONTAINER="sara-tls-backend-${SAFE_KEY}"
 PROXY_CONTAINER="sara-tls-proxy-${SAFE_KEY}"
@@ -20,8 +21,15 @@ mkdir -p "$OUT_DIR" "$CERT_DIR"
 rm -f "$OUT_DIR"/*.json "$OUT_DIR"/*.txt "$CERT_DIR"/*
 
 cleanup() {
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "TLS drill failed; preserving diagnostics before cleanup" >&2
+    docker ps -a --no-trunc >&2 || true
+    docker logs "$SARA_CONTAINER" >&2 || true
+    docker logs "$PROXY_CONTAINER" >&2 || true
+  fi
   docker rm -f "$SARA_CONTAINER" "$PROXY_CONTAINER" >/dev/null 2>&1 || true
-  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  docker network rm "$FRONT_NETWORK" "$BACK_NETWORK" >/dev/null 2>&1 || true
   docker volume rm "$DATA_VOLUME" >/dev/null 2>&1 || true
   rm -rf "$CERT_DIR"
 }
@@ -42,6 +50,7 @@ wait_https() {
     sleep 1
   done
   docker logs "$PROXY_CONTAINER" >&2 || true
+  docker logs "$SARA_CONTAINER" >&2 || true
   return 1
 }
 
@@ -51,7 +60,10 @@ docker build \
   --build-arg SARA_RELEASE_ID="tls-architecture-${SOURCE_SHA}" \
   -t "$IMAGE" "$ROOT" >/dev/null
 
-docker network create --internal "$NETWORK" >/dev/null
+# Two-zone reference topology: frontend is host-reachable through the proxy only;
+# backend is Docker-internal and contains SARA plus the proxy's backend interface.
+docker network create "$FRONT_NETWORK" >/dev/null
+docker network create --internal "$BACK_NETWORK" >/dev/null
 docker volume create "$DATA_VOLUME" >/dev/null
 docker run --rm --user 0 -v "$DATA_VOLUME:/data" "$IMAGE" sh -c 'chown -R 10001:10001 /data && chmod 0700 /data'
 
@@ -65,10 +77,10 @@ openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
 chmod 0755 "$CERT_DIR"
 chmod 0644 "$CERT_DIR/cert.pem" "$CERT_DIR/key.pem"
 
-# SARA has NO published host port. It is addressable only inside the internal Docker network.
+# SARA exists only on the internal backend network and has NO host-published port.
 docker run -d \
   --name "$SARA_CONTAINER" \
-  --network "$NETWORK" \
+  --network "$BACK_NETWORK" \
   --network-alias sara \
   --read-only \
   --tmpfs /tmp:size=16m,mode=1777 \
@@ -83,10 +95,11 @@ docker run -d \
   -v "$DATA_VOLUME:/var/lib/sara" \
   "$IMAGE" >/dev/null
 
-# The TLS proxy is the only host-published service. It is also non-root/read-only/capability-dropped.
+# Proxy starts on the frontend, publishes TLS on loopback, then receives a second
+# interface on the internal backend so it can reach SARA without exposing SARA.
 docker run -d \
   --name "$PROXY_CONTAINER" \
-  --network "$NETWORK" \
+  --network "$FRONT_NETWORK" \
   --read-only \
   --tmpfs /tmp:size=8m,mode=1777 \
   --security-opt no-new-privileges:true \
@@ -101,6 +114,7 @@ docker run -d \
     --upstream-port 9530 \
     --cert /certs/cert.pem \
     --key /certs/key.pem >/dev/null
+docker network connect "$BACK_NETWORK" "$PROXY_CONTAINER"
 
 wait_https
 
@@ -137,8 +151,15 @@ PROXY_RUNNING="$(docker inspect --format '{{.State.Running}}' "$PROXY_CONTAINER"
 SARA_USER="$(docker inspect --format '{{.Config.User}}' "$SARA_CONTAINER")"
 PROXY_USER="$(docker inspect --format '{{.Config.User}}' "$PROXY_CONTAINER")"
 PROXY_BINDING="$(docker port "$PROXY_CONTAINER" 8443/tcp)"
-NETWORK_INTERNAL="$(docker network inspect --format '{{.Internal}}' "$NETWORK")"
-export OUT_DIR SOURCE_SHA SARA_RUNNING PROXY_RUNNING SARA_USER PROXY_USER PROXY_BINDING NETWORK_INTERNAL HOST_PORT
+FRONT_INTERNAL="$(docker network inspect --format '{{.Internal}}' "$FRONT_NETWORK")"
+BACK_INTERNAL="$(docker network inspect --format '{{.Internal}}' "$BACK_NETWORK")"
+SARA_NETWORK_COUNT="$(docker inspect "$SARA_CONTAINER" --format '{{len .NetworkSettings.Networks}}')"
+PROXY_NETWORK_COUNT="$(docker inspect "$PROXY_CONTAINER" --format '{{len .NetworkSettings.Networks}}')"
+SARA_ON_BACK="$(docker inspect "$SARA_CONTAINER" --format "{{if index .NetworkSettings.Networks \"$BACK_NETWORK\"}}true{{else}}false{{end}}")"
+SARA_ON_FRONT="$(docker inspect "$SARA_CONTAINER" --format "{{if index .NetworkSettings.Networks \"$FRONT_NETWORK\"}}true{{else}}false{{end}}")"
+PROXY_ON_BACK="$(docker inspect "$PROXY_CONTAINER" --format "{{if index .NetworkSettings.Networks \"$BACK_NETWORK\"}}true{{else}}false{{end}}")"
+PROXY_ON_FRONT="$(docker inspect "$PROXY_CONTAINER" --format "{{if index .NetworkSettings.Networks \"$FRONT_NETWORK\"}}true{{else}}false{{end}}")"
+export OUT_DIR SOURCE_SHA SARA_RUNNING PROXY_RUNNING SARA_USER PROXY_USER PROXY_BINDING FRONT_INTERNAL BACK_INTERNAL SARA_NETWORK_COUNT PROXY_NETWORK_COUNT SARA_ON_BACK SARA_ON_FRONT PROXY_ON_BACK PROXY_ON_FRONT HOST_PORT
 
 python - <<'PY'
 import datetime, hashlib, json, os, pathlib
@@ -155,7 +176,10 @@ checks = {
     'sara_non_root_user': os.environ['SARA_USER'] == 'sara',
     'proxy_non_root_user': os.environ['PROXY_USER'] == 'sara',
     'proxy_bound_loopback_only': os.environ['PROXY_BINDING'].startswith('127.0.0.1:'),
-    'backend_network_marked_internal': os.environ['NETWORK_INTERNAL'] == 'true',
+    'frontend_network_not_internal': os.environ['FRONT_INTERNAL'] == 'false',
+    'backend_network_marked_internal': os.environ['BACK_INTERNAL'] == 'true',
+    'sara_has_single_backend_network_only': os.environ['SARA_NETWORK_COUNT'] == '1' and os.environ['SARA_ON_BACK'] == 'true' and os.environ['SARA_ON_FRONT'] == 'false',
+    'proxy_bridges_front_and_back_only': os.environ['PROXY_NETWORK_COUNT'] == '2' and os.environ['PROXY_ON_BACK'] == 'true' and os.environ['PROXY_ON_FRONT'] == 'true',
     'tls12_negotiated': 'TLSv1.2' in (root / 'tls12-session.txt').read_text(encoding='utf-8', errors='replace'),
     'certificate_san_matches_reference_name': 'DNS:sara.local' in (root / 'certificate-summary.txt').read_text(encoding='utf-8'),
 }
@@ -167,7 +191,7 @@ record = {
     'source_build_commit': os.environ['SOURCE_SHA'],
     'public_test_endpoint': f"127.0.0.1:{os.environ['HOST_PORT']} (TLS only)",
     'backend_host_port_exposure': 'NONE',
-    'backend_network': 'Docker internal network',
+    'network_topology': 'host -> frontend network/TLS proxy -> internal backend network -> SARA',
     'tls_minimum_version': 'TLSv1.2',
     'certificate_identity': 'sara.local — ephemeral self-signed CI certificate',
     'checks': checks,
@@ -176,11 +200,11 @@ record = {
         for name in ('https-health.json','https-readyz.json','tls12-session.txt','certificate-summary.txt')
     },
     'claims_boundary': (
-        'This evidence validates a bounded reference topology in CI: TLS terminates at a separate non-root proxy, the SARA '
-        'backend has no host-published port, and proxy/backend communicate only on an internal Docker network. The certificate '
-        'is ephemeral and self-signed. This does not establish production identity, public DNS ownership, public-CA issuance, '
-        'production key/HSM custody, enterprise reverse-proxy hardening, internet exposure approval, WAF/DDoS controls, customer '
-        'authorization, ATO, certification, or field readiness.'
+        'This evidence validates a bounded two-zone reference topology in CI: TLS terminates at a separate non-root proxy; '
+        'SARA has no host-published port and exists only on an internal backend network; the proxy bridges a frontend network '
+        'to that backend. The certificate is ephemeral and self-signed. This does not establish production identity, public '
+        'DNS ownership, public-CA issuance, production key/HSM custody, enterprise reverse-proxy hardening, internet exposure '
+        'approval, WAF/DDoS controls, customer authorization, ATO, certification, or field readiness.'
     ),
 }
 (root / 'tls-private-backend-architecture.json').write_text(json.dumps(record, sort_keys=True, indent=2)+'\n', encoding='utf-8')

--- a/deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
+++ b/deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${TLS_PROXY_EVIDENCE_DIR:-$ROOT/tls_proxy_evidence}"
+SOURCE_SHA="${GITHUB_SHA:-$(git -C "$ROOT" rev-parse HEAD)}"
+HOST_PORT="${TLS_PROXY_HOST_PORT:-19443}"
+RUN_KEY="${GITHUB_RUN_ID:-local}-$$"
+SAFE_KEY="${RUN_KEY//[^a-zA-Z0-9_.-]/_}"
+IMAGE="sara-tls-architecture:${SOURCE_SHA:0:12}"
+NETWORK="sara_tls_${SAFE_KEY}"
+DATA_VOLUME="sara_tls_data_${SAFE_KEY}"
+SARA_CONTAINER="sara-tls-backend-${SAFE_KEY}"
+PROXY_CONTAINER="sara-tls-proxy-${SAFE_KEY}"
+ADMIN_TOKEN="$(openssl rand -hex 32)"
+RELAY_TOKEN="$(openssl rand -hex 32)"
+CERT_DIR="$OUT_DIR/ephemeral-cert"
+
+mkdir -p "$OUT_DIR" "$CERT_DIR"
+rm -f "$OUT_DIR"/*.json "$OUT_DIR"/*.txt "$CERT_DIR"/*
+
+cleanup() {
+  docker rm -f "$SARA_CONTAINER" "$PROXY_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  docker volume rm "$DATA_VOLUME" >/dev/null 2>&1 || true
+  rm -rf "$CERT_DIR"
+}
+trap cleanup EXIT
+
+wait_https() {
+  for _ in $(seq 1 60); do
+    if curl --noproxy '*' --silent --show-error --fail \
+      --cacert "$CERT_DIR/cert.pem" \
+      --resolve "sara.local:${HOST_PORT}:127.0.0.1" \
+      "https://sara.local:${HOST_PORT}/readyz" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ "$(docker inspect --format '{{.State.Running}}' "$PROXY_CONTAINER" 2>/dev/null || echo false)" != "true" ]; then
+      docker logs "$PROXY_CONTAINER" >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+  docker logs "$PROXY_CONTAINER" >&2 || true
+  return 1
+}
+
+echo "[tls] build exact tested SARA image"
+docker build \
+  --build-arg SARA_BUILD_COMMIT="$SOURCE_SHA" \
+  --build-arg SARA_RELEASE_ID="tls-architecture-${SOURCE_SHA}" \
+  -t "$IMAGE" "$ROOT" >/dev/null
+
+docker network create --internal "$NETWORK" >/dev/null
+docker volume create "$DATA_VOLUME" >/dev/null
+docker run --rm --user 0 -v "$DATA_VOLUME:/data" "$IMAGE" sh -c 'chown -R 10001:10001 /data && chmod 0700 /data'
+
+# Ephemeral CI-only certificate. This proves the termination topology, not production identity.
+openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
+  -keyout "$CERT_DIR/key.pem" \
+  -out "$CERT_DIR/cert.pem" \
+  -days 1 \
+  -subj '/CN=sara.local' \
+  -addext 'subjectAltName=DNS:sara.local' >/dev/null 2>&1
+chmod 0755 "$CERT_DIR"
+chmod 0644 "$CERT_DIR/cert.pem" "$CERT_DIR/key.pem"
+
+# SARA has NO published host port. It is addressable only inside the internal Docker network.
+docker run -d \
+  --name "$SARA_CONTAINER" \
+  --network "$NETWORK" \
+  --network-alias sara \
+  --read-only \
+  --tmpfs /tmp:size=16m,mode=1777 \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  -e SARA_RELAY_TOKEN="$RELAY_TOKEN" \
+  -e SARA_ADMIN_TOKEN="$ADMIN_TOKEN" \
+  -e SARA_BIND_HOST=0.0.0.0 \
+  -e SARA_PORT=9530 \
+  -e SARA_DATA_DIR=/var/lib/sara \
+  -e SARA_MODE=tls-private-backend-reference \
+  -v "$DATA_VOLUME:/var/lib/sara" \
+  "$IMAGE" >/dev/null
+
+# The TLS proxy is the only host-published service. It is also non-root/read-only/capability-dropped.
+docker run -d \
+  --name "$PROXY_CONTAINER" \
+  --network "$NETWORK" \
+  --read-only \
+  --tmpfs /tmp:size=8m,mode=1777 \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  -p "127.0.0.1:${HOST_PORT}:8443" \
+  -v "$ROOT/scripts/tls_reference_proxy.py:/proxy/tls_reference_proxy.py:ro" \
+  -v "$CERT_DIR:/certs:ro" \
+  "$IMAGE" \
+  python /proxy/tls_reference_proxy.py \
+    --port 8443 \
+    --upstream-host sara \
+    --upstream-port 9530 \
+    --cert /certs/cert.pem \
+    --key /certs/key.pem >/dev/null
+
+wait_https
+
+curl --noproxy '*' --silent --show-error --fail \
+  --cacert "$CERT_DIR/cert.pem" \
+  --resolve "sara.local:${HOST_PORT}:127.0.0.1" \
+  "https://sara.local:${HOST_PORT}/health" > "$OUT_DIR/https-health.json"
+curl --noproxy '*' --silent --show-error --fail \
+  --cacert "$CERT_DIR/cert.pem" \
+  --resolve "sara.local:${HOST_PORT}:127.0.0.1" \
+  "https://sara.local:${HOST_PORT}/readyz" > "$OUT_DIR/https-readyz.json"
+
+# Plain HTTP to the TLS listener must not succeed as an application response.
+if curl --noproxy '*' --silent --fail "http://127.0.0.1:${HOST_PORT}/health" > "$OUT_DIR/plaintext-response.txt" 2>/dev/null; then
+  echo 'plaintext request unexpectedly succeeded' >&2
+  exit 1
+fi
+
+# Backend must expose no host binding whatsoever.
+BACKEND_PORTS="$(docker port "$SARA_CONTAINER" 2>/dev/null || true)"
+printf '%s' "$BACKEND_PORTS" > "$OUT_DIR/backend-published-ports.txt"
+test -z "$BACKEND_PORTS"
+
+# Verify TLS 1.2 negotiation and certificate identity from the host side.
+openssl s_client -connect "127.0.0.1:${HOST_PORT}" -servername sara.local -tls1_2 < /dev/null \
+  > "$OUT_DIR/tls12-session.txt" 2>&1
+grep -Eq 'Protocol *: TLSv1\.2|Protocol  *: TLSv1\.2|New, TLSv1\.2' "$OUT_DIR/tls12-session.txt"
+openssl x509 -in "$CERT_DIR/cert.pem" -noout -subject -issuer -dates -ext subjectAltName \
+  > "$OUT_DIR/certificate-summary.txt"
+grep -F 'DNS:sara.local' "$OUT_DIR/certificate-summary.txt" >/dev/null
+
+SARA_RUNNING="$(docker inspect --format '{{.State.Running}}' "$SARA_CONTAINER")"
+PROXY_RUNNING="$(docker inspect --format '{{.State.Running}}' "$PROXY_CONTAINER")"
+SARA_USER="$(docker inspect --format '{{.Config.User}}' "$SARA_CONTAINER")"
+PROXY_USER="$(docker inspect --format '{{.Config.User}}' "$PROXY_CONTAINER")"
+PROXY_BINDING="$(docker port "$PROXY_CONTAINER" 8443/tcp)"
+NETWORK_INTERNAL="$(docker network inspect --format '{{.Internal}}' "$NETWORK")"
+export OUT_DIR SOURCE_SHA SARA_RUNNING PROXY_RUNNING SARA_USER PROXY_USER PROXY_BINDING NETWORK_INTERNAL HOST_PORT
+
+python - <<'PY'
+import datetime, hashlib, json, os, pathlib
+root = pathlib.Path(os.environ['OUT_DIR'])
+load = lambda name: json.loads((root / name).read_text(encoding='utf-8'))
+health = load('https-health.json')
+ready = load('https-readyz.json')
+checks = {
+    'https_health_ok': health.get('ok') is True,
+    'https_readiness_ok': ready.get('ok') is True and ready.get('status') == 'ready',
+    'backend_has_no_host_published_port': (root / 'backend-published-ports.txt').read_text(encoding='utf-8') == '',
+    'sara_container_running': os.environ['SARA_RUNNING'] == 'true',
+    'proxy_container_running': os.environ['PROXY_RUNNING'] == 'true',
+    'sara_non_root_user': os.environ['SARA_USER'] == 'sara',
+    'proxy_non_root_user': os.environ['PROXY_USER'] == 'sara',
+    'proxy_bound_loopback_only': os.environ['PROXY_BINDING'].startswith('127.0.0.1:'),
+    'backend_network_marked_internal': os.environ['NETWORK_INTERNAL'] == 'true',
+    'tls12_negotiated': 'TLSv1.2' in (root / 'tls12-session.txt').read_text(encoding='utf-8', errors='replace'),
+    'certificate_san_matches_reference_name': 'DNS:sara.local' in (root / 'certificate-summary.txt').read_text(encoding='utf-8'),
+}
+record = {
+    'schema': 'WS-SARA-TLS-PRIVATE-BACKEND-ARCHITECTURE-EVIDENCE-V1',
+    'evidence_status': 'INTERNAL_CI_GENERATED_EPHEMERAL_IDENTITY',
+    'result': 'PASS' if all(checks.values()) else 'FAIL',
+    'executed_utc': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    'source_build_commit': os.environ['SOURCE_SHA'],
+    'public_test_endpoint': f"127.0.0.1:{os.environ['HOST_PORT']} (TLS only)",
+    'backend_host_port_exposure': 'NONE',
+    'backend_network': 'Docker internal network',
+    'tls_minimum_version': 'TLSv1.2',
+    'certificate_identity': 'sara.local — ephemeral self-signed CI certificate',
+    'checks': checks,
+    'evidence_sha256': {
+        name: 'sha256:' + hashlib.sha256((root / name).read_bytes()).hexdigest()
+        for name in ('https-health.json','https-readyz.json','tls12-session.txt','certificate-summary.txt')
+    },
+    'claims_boundary': (
+        'This evidence validates a bounded reference topology in CI: TLS terminates at a separate non-root proxy, the SARA '
+        'backend has no host-published port, and proxy/backend communicate only on an internal Docker network. The certificate '
+        'is ephemeral and self-signed. This does not establish production identity, public DNS ownership, public-CA issuance, '
+        'production key/HSM custody, enterprise reverse-proxy hardening, internet exposure approval, WAF/DDoS controls, customer '
+        'authorization, ATO, certification, or field readiness.'
+    ),
+}
+(root / 'tls-private-backend-architecture.json').write_text(json.dumps(record, sort_keys=True, indent=2)+'\n', encoding='utf-8')
+if record['result'] != 'PASS':
+    raise SystemExit('TLS_PROXY_ARCHITECTURE: FAIL ' + json.dumps(checks, sort_keys=True))
+print('TLS_PROXY_ARCHITECTURE: PASS')
+PY

--- a/deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
+++ b/deployments/sara_verified_local_v1/scripts/tls_proxy_architecture_drill.sh
@@ -104,6 +104,7 @@ docker run -d \
   --tmpfs /tmp:size=8m,mode=1777 \
   --security-opt no-new-privileges:true \
   --cap-drop ALL \
+  --no-healthcheck \
   -p "127.0.0.1:${HOST_PORT}:8443" \
   -v "$ROOT/scripts/tls_reference_proxy.py:/proxy/tls_reference_proxy.py:ro" \
   -v "$CERT_DIR:/certs:ro" \

--- a/deployments/sara_verified_local_v1/scripts/tls_reference_proxy.py
+++ b/deployments/sara_verified_local_v1/scripts/tls_reference_proxy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+import http.client
+import http.server
+import ssl
+from typing import Final
+
+HOP_BY_HOP: Final = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+class ProxyHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    upstream_host: str
+    upstream_port: int
+
+    def _proxy(self) -> None:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length) if length else None
+        headers = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in HOP_BY_HOP and key.lower() != "host"
+        }
+        headers["Host"] = f"{self.upstream_host}:{self.upstream_port}"
+        headers["X-Forwarded-Proto"] = "https"
+        headers["X-Forwarded-For"] = self.client_address[0]
+        conn = http.client.HTTPConnection(self.upstream_host, self.upstream_port, timeout=5)
+        try:
+            conn.request(self.command, self.path, body=body, headers=headers)
+            response = conn.getresponse()
+            data = response.read()
+            self.send_response(response.status)
+            for key, value in response.getheaders():
+                if key.lower() not in HOP_BY_HOP and key.lower() != "content-length":
+                    self.send_header(key, value)
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Strict-Transport-Security", "max-age=31536000")
+            self.end_headers()
+            self.wfile.write(data)
+        finally:
+            conn.close()
+
+    do_GET = _proxy
+    do_POST = _proxy
+    do_PATCH = _proxy
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"TLS_PROXY {self.address_string()} {format % args}", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8443)
+    parser.add_argument("--upstream-host", required=True)
+    parser.add_argument("--upstream-port", type=int, default=9530)
+    parser.add_argument("--cert", required=True)
+    parser.add_argument("--key", required=True)
+    args = parser.parse_args()
+
+    ProxyHandler.upstream_host = args.upstream_host
+    ProxyHandler.upstream_port = args.upstream_port
+    server = http.server.ThreadingHTTPServer((args.listen, args.port), ProxyHandler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    context.load_cert_chain(args.cert, args.key)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a bounded TLS/private-backend reference architecture drill. CI generates an ephemeral self-signed `sara.local` certificate, runs SARA with no host-published port on an internal Docker network, and exposes only a separate non-root/read-only/capability-dropped TLS proxy on loopback. The gate requires HTTPS health/readiness, TLS 1.2 negotiation, matching SAN, no backend host binding, internal-network isolation, and separate proxy/backend process boundaries. Evidence schema: `WS-SARA-TLS-PRIVATE-BACKEND-ARCHITECTURE-EVIDENCE-V1`. Claims boundary: architecture precursor only. The ephemeral self-signed certificate does not establish production identity, DNS ownership, public-CA issuance, production key/HSM custody, enterprise proxy hardening, internet exposure approval, ATO, certification, or field readiness.