### PR TITLE
Evidence custody precursor: attest one commit-bound closure manifest

### DIFF
--- a/.github/workflows/sara-commit-closure-evidence.yml
+++ b/.github/workflows/sara-commit-closure-evidence.yml
@@ -9,12 +9,6 @@ on:
       - SARA Verified Local v1 Gate
     types:
       - completed
-  workflow_dispatch:
-    inputs:
-      target_sha:
-        description: Exact commit SHA to inventory
-        required: true
-        type: string
 
 permissions: {}
 
@@ -22,28 +16,70 @@ jobs:
   validate-pr-closure-manifest:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     permissions:
-      actions: read
       contents: read
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TARGET_SHA: ${{ github.event.pull_request.head.sha }}
       CLOSURE_MANIFEST_DIR: closure_manifest
-      CLOSURE_WAIT_SECONDS: '420'
+      CLOSURE_SNAPSHOT_FILE: closure-fixture.json
     steps:
-      - name: Check out exact PR head
+      - name: Check out exact PR head without persisted credentials
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
-      - name: Compile closure manifest builder
+      - name: Compile offline closure manifest builder
         run: python -m py_compile deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
 
-      - name: Build exact-commit closure evidence manifest
+      - name: Build synthetic exact-commit fixture
+        run: |
+          python - <<'PY'
+          import json, os, pathlib
+          names = [
+              ('SARA Verified Local v1 Gate', 'sara-release-evidence-index'),
+              ('SARA Rollback Drill', 'sara-rollback-drill-evidence'),
+              ('SARA Replacement Environment Restore', 'sara-replacement-environment-restore-evidence'),
+              ('SARA TLS Private Backend Architecture', 'sara-tls-private-backend-architecture-evidence'),
+              ('SARA Operational Resilience Drill', 'sara-operational-resilience-evidence'),
+          ]
+          sha = os.environ['TARGET_SHA']
+          entries = []
+          for i, (workflow, artifact_name) in enumerate(names, 1):
+              entries.append({
+                  'workflow_name': workflow,
+                  'run': {
+                      'id': 1000 + i,
+                      'run_attempt': 1,
+                      'event': 'pull_request',
+                      'head_branch': 'synthetic-contract-test',
+                      'head_sha': sha,
+                      'conclusion': 'success',
+                      'html_url': f'https://github.com/example/example/actions/runs/{1000+i}',
+                  },
+                  'artifact': {
+                      'id': 2000 + i,
+                      'name': artifact_name,
+                      'digest': 'sha256:' + format(i, '064x'),
+                      'size_in_bytes': 100 + i,
+                      'created_at': '2026-01-01T00:00:00Z',
+                      'expires_at': '2099-01-01T00:00:00Z',
+                      'expired': False,
+                  },
+              })
+          pathlib.Path('closure-fixture.json').write_text(json.dumps({
+              'schema': 'WS-SARA-CLOSURE-SNAPSHOT-V1',
+              'repository': os.environ['GITHUB_REPOSITORY'],
+              'target_commit_sha': sha,
+              'entries': entries,
+          }, sort_keys=True, indent=2) + '\n')
+          PY
+
+      - name: Exercise offline closure manifest contract
         run: python deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
 
-      - name: Validate closure manifest contract
+      - name: Validate PR qualification output
         run: |
           python - <<'PY'
           import json, pathlib
@@ -56,14 +92,6 @@ jobs:
           assert pathlib.Path('closure_manifest/commit-closure-evidence-manifest.sha256').is_file()
           PY
 
-      - name: Upload PR closure manifest evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: sara-commit-closure-evidence-pr
-          path: closure_manifest/
-          if-no-files-found: error
-          retention-days: 30
-
   attest-main-closure-manifest:
     if: >-
       github.event_name == 'workflow_run' &&
@@ -71,7 +99,7 @@ jobs:
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions:
       actions: read
       contents: read
@@ -79,20 +107,95 @@ jobs:
       attestations: write
       artifact-metadata: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
       CLOSURE_MANIFEST_DIR: closure_manifest
-      CLOSURE_WAIT_SECONDS: '420'
+      CLOSURE_SNAPSHOT_FILE: closure-snapshot.json
     steps:
-      - name: Check out exact main commit
+      - name: Check out exact trusted main commit without persisted credentials
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - name: Compile closure manifest builder
+      - name: Compile offline closure manifest builder
         run: python -m py_compile deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
 
-      - name: Build exact-commit closure evidence manifest
+      - name: Collect exact-main workflow and artifact metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_SHA" in
+            (*[!0-9a-f]*|'') echo 'invalid target SHA' >&2; exit 1 ;;
+          esac
+          test "${#TARGET_SHA}" -eq 40
+          case "$GITHUB_REPOSITORY" in
+            (*[!A-Za-z0-9_.\/-]*|''|*//*|/*|*/) echo 'invalid repository identifier' >&2; exit 1 ;;
+          esac
+
+          cat > required-evidence.tsv <<'EOF'
+          SARA Verified Local v1 Gate|sara-release-evidence-index
+          SARA Rollback Drill|sara-rollback-drill-evidence
+          SARA Replacement Environment Restore|sara-replacement-environment-restore-evidence
+          SARA TLS Private Backend Architecture|sara-tls-private-backend-architecture-evidence
+          SARA Operational Resilience Drill|sara-operational-resilience-evidence
+          EOF
+
+          printf '[]\n' > closure-entries.json
+          deadline=$((SECONDS + 420))
+          while :; do
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
+              -f head_sha="$TARGET_SHA" -f per_page=100 > closure-runs.json
+            printf '[]\n' > closure-entries.next.json
+            missing=0
+
+            while IFS='|' read -r workflow_name artifact_name; do
+              run="$(jq -c --arg n "$workflow_name" --arg s "$TARGET_SHA" '
+                [.workflow_runs[] | select(.name == $n and .head_sha == $s and .status == "completed" and .conclusion == "success")]
+                | sort_by(.id) | last // empty
+              ' closure-runs.json)"
+              if [ -z "$run" ]; then
+                echo "waiting for successful workflow: $workflow_name"
+                missing=1
+                continue
+              fi
+              run_id="$(jq -r '.id' <<<"$run")"
+              case "$run_id" in (*[!0-9]*|'') echo 'invalid run id' >&2; exit 1 ;; esac
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
+                -f per_page=100 > closure-artifacts.json
+              artifact="$(jq -c --arg n "$artifact_name" '
+                [.artifacts[] | select(.name == $n and .expired == false)] | sort_by(.id) | last // empty
+              ' closure-artifacts.json)"
+              if [ -z "$artifact" ]; then
+                echo "waiting for retained artifact: $artifact_name"
+                missing=1
+                continue
+              fi
+              jq --arg name "$workflow_name" --argjson run "$run" --argjson artifact "$artifact" \
+                '. + [{workflow_name:$name, run:$run, artifact:$artifact}]' \
+                closure-entries.next.json > closure-entries.tmp.json
+              mv closure-entries.tmp.json closure-entries.next.json
+            done < required-evidence.tsv
+
+            if [ "$missing" -eq 0 ] && [ "$(jq 'length' closure-entries.next.json)" -eq 5 ]; then
+              mv closure-entries.next.json closure-entries.json
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo 'timed out waiting for complete exact-commit evidence set' >&2
+              exit 1
+            fi
+            sleep 3
+          done
+
+          jq -n --arg repo "$GITHUB_REPOSITORY" --arg sha "$TARGET_SHA" --slurpfile entries closure-entries.json '{
+            schema:"WS-SARA-CLOSURE-SNAPSHOT-V1",
+            repository:$repo,
+            target_commit_sha:$sha,
+            entries:$entries[0]
+          }' > "$CLOSURE_SNAPSHOT_FILE"
+
+      - name: Build exact-commit closure evidence manifest offline
         run: python deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
 
       - name: Validate closure manifest contract

--- a/.github/workflows/sara-commit-closure-evidence.yml
+++ b/.github/workflows/sara-commit-closure-evidence.yml
@@ -1,0 +1,156 @@
+name: SARA Commit Closure Evidence
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+      - SARA Verified Local v1 Gate
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact commit SHA to inventory
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  validate-pr-closure-manifest:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_SHA: ${{ github.event.pull_request.head.sha }}
+      CLOSURE_MANIFEST_DIR: closure_manifest
+      CLOSURE_WAIT_SECONDS: '420'
+    steps:
+      - name: Check out exact PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compile closure manifest builder
+        run: python -m py_compile deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+
+      - name: Build exact-commit closure evidence manifest
+        run: python deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+
+      - name: Validate closure manifest contract
+        run: |
+          python - <<'PY'
+          import json, pathlib
+          p = pathlib.Path('closure_manifest/commit-closure-evidence-manifest.json')
+          d = json.loads(p.read_text())
+          assert d['schema'] == 'WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1'
+          assert d['result'] == 'PASS'
+          assert len(d['entries']) == 5
+          assert all(d['checks'].values())
+          assert pathlib.Path('closure_manifest/commit-closure-evidence-manifest.sha256').is_file()
+          PY
+
+      - name: Upload PR closure manifest evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-commit-closure-evidence-pr
+          path: closure_manifest/
+          if-no-files-found: error
+          retention-days: 30
+
+  attest-main-closure-manifest:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+      CLOSURE_MANIFEST_DIR: closure_manifest
+      CLOSURE_WAIT_SECONDS: '420'
+    steps:
+      - name: Check out exact main commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Compile closure manifest builder
+        run: python -m py_compile deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+
+      - name: Build exact-commit closure evidence manifest
+        run: python deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+
+      - name: Validate closure manifest contract
+        run: |
+          python - <<'PY'
+          import json, os, pathlib
+          p = pathlib.Path('closure_manifest/commit-closure-evidence-manifest.json')
+          d = json.loads(p.read_text())
+          assert d['schema'] == 'WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1'
+          assert d['result'] == 'PASS'
+          assert d['target_commit_sha'] == os.environ['TARGET_SHA']
+          assert len(d['entries']) == 5
+          assert all(d['checks'].values())
+          PY
+
+      - name: Attest exact commit closure manifest
+        id: attest_closure
+        uses: actions/attest@v4
+        with:
+          subject-path: closure_manifest/commit-closure-evidence-manifest.json
+          create-storage-record: false
+
+      - name: Build closure custody receipt
+        env:
+          ATTESTATION_ID: ${{ steps.attest_closure.outputs.attestation-id }}
+          ATTESTATION_URL: ${{ steps.attest_closure.outputs.attestation-url }}
+          BUNDLE_PATH: ${{ steps.attest_closure.outputs.bundle-path }}
+        run: |
+          cp "$BUNDLE_PATH" closure_manifest/sigstore-closure-attestation-bundle.json
+          python - <<'PY'
+          import datetime, hashlib, json, os, pathlib
+          root = pathlib.Path('closure_manifest')
+          manifest = root / 'commit-closure-evidence-manifest.json'
+          bundle = root / 'sigstore-closure-attestation-bundle.json'
+          receipt = {
+              'schema': 'WS-SARA-COMMIT-CLOSURE-ATTESTATION-RECEIPT-V1',
+              'evidence_status': 'GITHUB_SIGSTORE_ATTESTED_COMMIT_CLOSURE_MANIFEST',
+              'executed_utc': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'repository': os.environ['GITHUB_REPOSITORY'],
+              'target_commit_sha': os.environ['TARGET_SHA'],
+              'manifest_sha256': 'sha256:' + hashlib.sha256(manifest.read_bytes()).hexdigest(),
+              'attestation_bundle_sha256': 'sha256:' + hashlib.sha256(bundle.read_bytes()).hexdigest(),
+              'attestation_id': os.environ['ATTESTATION_ID'],
+              'attestation_url': os.environ['ATTESTATION_URL'],
+              'signing_mechanism': 'GitHub OIDC with Sigstore-backed artifact attestation',
+              'claims_boundary': (
+                  'This receipt establishes cryptographic provenance for the commit-closure manifest inside GitHub-hosted custody. '
+                  'It does not establish off-provider or independent archival custody, legal-record retention, external audit, '
+                  'customer/government acceptance, certification, ATO, or third-party reproduction.'
+              ),
+          }
+          (root / 'commit-closure-attestation-receipt.json').write_text(json.dumps(receipt, sort_keys=True, indent=2)+'\n')
+          PY
+
+      - name: Upload attested commit closure evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-commit-closure-attestation-evidence
+          path: closure_manifest/
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/sara-commit-closure-evidence.yml
+++ b/.github/workflows/sara-commit-closure-evidence.yml
@@ -92,34 +92,19 @@ jobs:
           assert pathlib.Path('closure_manifest/commit-closure-evidence-manifest.sha256').is_file()
           PY
 
-  attest-main-closure-manifest:
+  collect-main-closure-manifest:
     if: >-
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 10
     permissions:
       actions: read
-      contents: read
-      id-token: write
-      attestations: write
-      artifact-metadata: write
     env:
       TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
-      CLOSURE_MANIFEST_DIR: closure_manifest
-      CLOSURE_SNAPSHOT_FILE: closure-snapshot.json
     steps:
-      - name: Check out exact trusted main commit without persisted credentials
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
-
-      - name: Compile offline closure manifest builder
-        run: python -m py_compile deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
-
       - name: Collect exact-main workflow and artifact metadata
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -141,12 +126,11 @@ jobs:
           SARA Operational Resilience Drill|sara-operational-resilience-evidence
           EOF
 
-          printf '[]\n' > closure-entries.json
           deadline=$((SECONDS + 420))
           while :; do
             gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
               -f head_sha="$TARGET_SHA" -f per_page=100 > closure-runs.json
-            printf '[]\n' > closure-entries.next.json
+            printf '[]\n' > closure-entries.json
             missing=0
 
             while IFS='|' read -r workflow_name artifact_name; do
@@ -173,12 +157,11 @@ jobs:
               fi
               jq --arg name "$workflow_name" --argjson run "$run" --argjson artifact "$artifact" \
                 '. + [{workflow_name:$name, run:$run, artifact:$artifact}]' \
-                closure-entries.next.json > closure-entries.tmp.json
-              mv closure-entries.tmp.json closure-entries.next.json
+                closure-entries.json > closure-entries.tmp.json
+              mv closure-entries.tmp.json closure-entries.json
             done < required-evidence.tsv
 
-            if [ "$missing" -eq 0 ] && [ "$(jq 'length' closure-entries.next.json)" -eq 5 ]; then
-              mv closure-entries.next.json closure-entries.json
+            if [ "$missing" -eq 0 ] && [ "$(jq 'length' closure-entries.json)" -eq 5 ]; then
               break
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
@@ -193,22 +176,131 @@ jobs:
             repository:$repo,
             target_commit_sha:$sha,
             entries:$entries[0]
-          }' > "$CLOSURE_SNAPSHOT_FILE"
+          }' > closure-snapshot.json
 
-      - name: Build exact-commit closure evidence manifest offline
-        run: python deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+      - name: Build and validate commit closure manifest from trusted metadata
+        env:
+          CLOSURE_SNAPSHOT_FILE: closure-snapshot.json
+          CLOSURE_MANIFEST_DIR: closure_manifest
+        run: |
+          python - <<'PY'
+          import datetime as dt, hashlib, json, os, pathlib, re
+          required = {
+              'SARA Verified Local v1 Gate': 'sara-release-evidence-index',
+              'SARA Rollback Drill': 'sara-rollback-drill-evidence',
+              'SARA Replacement Environment Restore': 'sara-replacement-environment-restore-evidence',
+              'SARA TLS Private Backend Architecture': 'sara-tls-private-backend-architecture-evidence',
+              'SARA Operational Resilience Drill': 'sara-operational-resilience-evidence',
+          }
+          sha = os.environ['TARGET_SHA']
+          digest_re = re.compile(r'^sha256:[0-9a-f]{64}$')
+          snapshot = json.loads(pathlib.Path(os.environ['CLOSURE_SNAPSHOT_FILE']).read_text())
+          assert snapshot['schema'] == 'WS-SARA-CLOSURE-SNAPSHOT-V1'
+          assert snapshot['repository'] == os.environ['GITHUB_REPOSITORY']
+          assert snapshot['target_commit_sha'] == sha
+          supplied = snapshot['entries']
+          assert isinstance(supplied, list) and len(supplied) == 5
+          by_name = {item['workflow_name']: item for item in supplied}
+          assert set(by_name) == set(required)
+          entries = []
+          for workflow_name, artifact_name in required.items():
+              item = by_name[workflow_name]
+              run, artifact = item['run'], item['artifact']
+              assert isinstance(run['id'], int) and run['id'] > 0
+              assert isinstance(artifact['id'], int) and artifact['id'] > 0
+              assert artifact['name'] == artifact_name
+              assert digest_re.fullmatch(artifact['digest'])
+              entries.append({
+                  'workflow_name': workflow_name,
+                  'workflow_run_id': run['id'],
+                  'workflow_run_attempt': run.get('run_attempt'),
+                  'workflow_event': run.get('event'),
+                  'workflow_head_branch': run.get('head_branch'),
+                  'workflow_head_sha': run.get('head_sha'),
+                  'workflow_conclusion': run.get('conclusion'),
+                  'workflow_html_url': run.get('html_url'),
+                  'artifact_name': artifact_name,
+                  'artifact_id': artifact['id'],
+                  'artifact_digest': artifact['digest'],
+                  'artifact_size_in_bytes': artifact.get('size_in_bytes'),
+                  'artifact_created_at': artifact.get('created_at'),
+                  'artifact_expires_at': artifact.get('expires_at'),
+                  'artifact_expired': artifact.get('expired'),
+              })
+          checks = {
+              'all_required_workflows_successful': all(e['workflow_conclusion'] == 'success' for e in entries),
+              'all_evidence_bound_to_target_commit': all(e['workflow_head_sha'] == sha for e in entries),
+              'all_required_artifacts_present': {e['artifact_name'] for e in entries} == set(required.values()),
+              'all_artifacts_have_sha256_digests': all(digest_re.fullmatch(e['artifact_digest']) for e in entries),
+              'all_artifacts_unexpired_at_manifest_time': all(e['artifact_expired'] is False for e in entries),
+          }
+          manifest = {
+              'schema': 'WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1',
+              'result': 'PASS' if all(checks.values()) else 'FAIL',
+              'evidence_status': 'GITHUB_HOSTED_COMMIT_BOUND_EVIDENCE_INVENTORY',
+              'generated_utc': dt.datetime.now(dt.timezone.utc).isoformat(),
+              'repository': os.environ['GITHUB_REPOSITORY'],
+              'target_commit_sha': sha,
+              'required_evidence_classes': list(required.values()),
+              'entries': entries,
+              'checks': checks,
+              'claims_boundary': (
+                  'This manifest binds named GitHub-hosted CI evidence artifacts and their provider-reported SHA-256 digests to one exact commit. '
+                  'It does not establish independent/off-provider custody, immutable legal-record retention, customer or government acceptance, '
+                  'external audit, certification, ATO, or third-party reproduction.'
+              ),
+          }
+          assert manifest['result'] == 'PASS'
+          root = pathlib.Path(os.environ['CLOSURE_MANIFEST_DIR'])
+          root.mkdir(parents=True, exist_ok=True)
+          path = root / 'commit-closure-evidence-manifest.json'
+          path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + '\n')
+          digest = hashlib.sha256(path.read_bytes()).hexdigest()
+          (root / 'commit-closure-evidence-manifest.sha256').write_text(f'{digest}  {path.name}\n')
+          print('CLOSURE_MANIFEST_PASS', sha, 'sha256:' + digest)
+          PY
 
-      - name: Validate closure manifest contract
+      - name: Upload closure manifest staging artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sara-commit-closure-manifest-staging
+          path: closure_manifest/
+          if-no-files-found: error
+          retention-days: 1
+
+  attest-main-closure-manifest:
+    needs: collect-main-closure-manifest
+    if: >-
+      github.event_name == 'workflow_run' &&
+      needs.collect-main-closure-manifest.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    env:
+      TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Download closure manifest from collector
+        uses: actions/download-artifact@v4
+        with:
+          name: sara-commit-closure-manifest-staging
+          path: closure_manifest
+
+      - name: Verify staged manifest identity
         run: |
           python - <<'PY'
           import json, os, pathlib
-          p = pathlib.Path('closure_manifest/commit-closure-evidence-manifest.json')
-          d = json.loads(p.read_text())
-          assert d['schema'] == 'WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1'
-          assert d['result'] == 'PASS'
-          assert d['target_commit_sha'] == os.environ['TARGET_SHA']
-          assert len(d['entries']) == 5
-          assert all(d['checks'].values())
+          path = pathlib.Path('closure_manifest/commit-closure-evidence-manifest.json')
+          data = json.loads(path.read_text())
+          assert data['schema'] == 'WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1'
+          assert data['result'] == 'PASS'
+          assert data['target_commit_sha'] == os.environ['TARGET_SHA']
+          assert len(data['entries']) == 5
+          assert all(data['checks'].values())
           PY
 
       - name: Attest exact commit closure manifest

--- a/deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+++ b/deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import time
+import urllib.error
+import urllib.request
+
+REQUIRED = {
+    "SARA Verified Local v1 Gate": "sara-release-evidence-index",
+    "SARA Rollback Drill": "sara-rollback-drill-evidence",
+    "SARA Replacement Environment Restore": "sara-replacement-environment-restore-evidence",
+    "SARA TLS Private Backend Architecture": "sara-tls-private-backend-architecture-evidence",
+    "SARA Operational Resilience Drill": "sara-operational-resilience-evidence",
+}
+
+
+def api(path: str) -> dict:
+    base = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    req = urllib.request.Request(
+        base + path,
+        headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "worldshepherd-sara-closure-manifest",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as response:
+        return json.load(response)
+
+
+def select_successful_run(runs: list[dict], workflow_name: str, sha: str) -> dict | None:
+    matches = [
+        run for run in runs
+        if run.get("name") == workflow_name
+        and run.get("head_sha") == sha
+        and run.get("status") == "completed"
+        and run.get("conclusion") == "success"
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda r: (r.get("run_attempt", 0), r.get("id", 0)))
+
+
+def main() -> None:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["TARGET_SHA"]
+    out_dir = pathlib.Path(os.environ.get("CLOSURE_MANIFEST_DIR", "closure_manifest"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    selected: dict[str, tuple[dict, dict]] = {}
+    deadline = time.monotonic() + int(os.environ.get("CLOSURE_WAIT_SECONDS", "420"))
+    last_missing: list[str] = []
+
+    while time.monotonic() < deadline:
+        run_payload = api(f"/repos/{repo}/actions/runs?head_sha={sha}&per_page=100")
+        runs = run_payload.get("workflow_runs", [])
+        selected.clear()
+        missing: list[str] = []
+        for workflow_name, artifact_name in REQUIRED.items():
+            run = select_successful_run(runs, workflow_name, sha)
+            if run is None:
+                missing.append(f"workflow:{workflow_name}")
+                continue
+            artifacts = api(f"/repos/{repo}/actions/runs/{run['id']}/artifacts?per_page=100").get("artifacts", [])
+            candidates = [a for a in artifacts if a.get("name") == artifact_name and not a.get("expired")]
+            if not candidates:
+                missing.append(f"artifact:{artifact_name}")
+                continue
+            artifact = max(candidates, key=lambda a: a.get("id", 0))
+            digest = artifact.get("digest") or ""
+            if not digest.startswith("sha256:"):
+                missing.append(f"artifact_digest:{artifact_name}")
+                continue
+            selected[workflow_name] = (run, artifact)
+        if not missing:
+            break
+        last_missing = missing
+        print("CLOSURE_MANIFEST_WAIT:", ", ".join(missing), flush=True)
+        time.sleep(3)
+    else:
+        raise SystemExit("CLOSURE_MANIFEST_TIMEOUT: " + ", ".join(last_missing))
+
+    entries = []
+    for workflow_name, artifact_name in REQUIRED.items():
+        run, artifact = selected[workflow_name]
+        entries.append({
+            "workflow_name": workflow_name,
+            "workflow_run_id": run["id"],
+            "workflow_run_attempt": run.get("run_attempt"),
+            "workflow_event": run.get("event"),
+            "workflow_head_branch": run.get("head_branch"),
+            "workflow_head_sha": run.get("head_sha"),
+            "workflow_conclusion": run.get("conclusion"),
+            "workflow_html_url": run.get("html_url"),
+            "artifact_name": artifact_name,
+            "artifact_id": artifact["id"],
+            "artifact_digest": artifact["digest"],
+            "artifact_size_in_bytes": artifact.get("size_in_bytes"),
+            "artifact_created_at": artifact.get("created_at"),
+            "artifact_expires_at": artifact.get("expires_at"),
+            "artifact_expired": artifact.get("expired"),
+        })
+
+    checks = {
+        "all_required_workflows_successful": len(entries) == len(REQUIRED) and all(e["workflow_conclusion"] == "success" for e in entries),
+        "all_evidence_bound_to_target_commit": all(e["workflow_head_sha"] == sha for e in entries),
+        "all_required_artifacts_present": {e["artifact_name"] for e in entries} == set(REQUIRED.values()),
+        "all_artifacts_have_sha256_digests": all(str(e["artifact_digest"]).startswith("sha256:") for e in entries),
+        "all_artifacts_unexpired_at_manifest_time": all(e["artifact_expired"] is False for e in entries),
+    }
+    manifest = {
+        "schema": "WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1",
+        "result": "PASS" if all(checks.values()) else "FAIL",
+        "evidence_status": "GITHUB_HOSTED_COMMIT_BOUND_EVIDENCE_INVENTORY",
+        "generated_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "repository": repo,
+        "target_commit_sha": sha,
+        "required_evidence_classes": list(REQUIRED.values()),
+        "entries": entries,
+        "checks": checks,
+        "claims_boundary": (
+            "This manifest binds named GitHub-hosted CI evidence artifacts and their provider-reported SHA-256 digests to one exact commit, "
+            "after successful execution of the required SARA, rollback, replacement-restore, TLS, and operational-resilience workflows. "
+            "It does not establish independent/off-provider custody, immutable legal-record retention, customer or government acceptance, "
+            "external audit, certification, ATO, or third-party reproduction."
+        ),
+    }
+    manifest_path = out_dir / "commit-closure-evidence-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    (out_dir / "commit-closure-evidence-manifest.sha256").write_text(f"{digest}  {manifest_path.name}\n", encoding="utf-8")
+    if manifest["result"] != "PASS":
+        raise SystemExit("CLOSURE_MANIFEST_FAIL: " + json.dumps(checks, sort_keys=True))
+    print("CLOSURE_MANIFEST_PASS", sha, "sha256:" + digest)
+
+
+if __name__ == "__main__":
+    main()

--- a/deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+++ b/deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
+import http.client
 import json
 import os
 import pathlib
+import re
+import ssl
 import time
-import urllib.error
-import urllib.request
+import urllib.parse
 
 REQUIRED = {
     "SARA Verified Local v1 Gate": "sara-release-evidence-index",
@@ -18,20 +20,76 @@ REQUIRED = {
     "SARA Operational Resilience Drill": "sara-operational-resilience-evidence",
 }
 
+API_HOST = "api.github.com"
+REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def validate_repo(value: str) -> str:
+    if not REPO_RE.fullmatch(value):
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_REPOSITORY")
+    return value
+
+
+def validate_sha(value: str) -> str:
+    value = value.lower()
+    if not SHA_RE.fullmatch(value):
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_SHA")
+    return value
+
+
+def validate_run_id(value: object) -> int:
+    if isinstance(value, bool):
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_ID")
+    try:
+        run_id = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_ID") from exc
+    if run_id <= 0:
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_ID")
+    return run_id
+
 
 def api(path: str) -> dict:
-    base = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
-    req = urllib.request.Request(
-        base + path,
-        headers={
-            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "worldshepherd-sara-closure-manifest",
-        },
+    if not path.startswith("/repos/") or "\r" in path or "\n" in path:
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_API_PATH")
+    token = os.environ["GITHUB_TOKEN"]
+    connection = http.client.HTTPSConnection(
+        API_HOST,
+        port=443,
+        timeout=30,
+        context=ssl.create_default_context(),
     )
-    with urllib.request.urlopen(req, timeout=30) as response:
-        return json.load(response)
+    try:
+        connection.request(
+            "GET",
+            path,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "worldshepherd-sara-closure-manifest",
+            },
+        )
+        response = connection.getresponse()
+        body = response.read()
+        if response.status != 200:
+            raise SystemExit(f"CLOSURE_MANIFEST_GITHUB_API_STATUS:{response.status}")
+        payload = json.loads(body.decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise SystemExit("CLOSURE_MANIFEST_INVALID_API_RESPONSE")
+        return payload
+    finally:
+        connection.close()
+
+
+def runs_path(repo: str, sha: str) -> str:
+    query = urllib.parse.urlencode({"head_sha": sha, "per_page": "100"})
+    return f"/repos/{repo}/actions/runs?{query}"
+
+
+def artifacts_path(repo: str, run_id: int) -> str:
+    return f"/repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100"
 
 
 def select_successful_run(runs: list[dict], workflow_name: str, sha: str) -> dict | None:
@@ -48,8 +106,8 @@ def select_successful_run(runs: list[dict], workflow_name: str, sha: str) -> dic
 
 
 def main() -> None:
-    repo = os.environ["GITHUB_REPOSITORY"]
-    sha = os.environ["TARGET_SHA"]
+    repo = validate_repo(os.environ["GITHUB_REPOSITORY"])
+    sha = validate_sha(os.environ["TARGET_SHA"])
     out_dir = pathlib.Path(os.environ.get("CLOSURE_MANIFEST_DIR", "closure_manifest"))
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -58,8 +116,10 @@ def main() -> None:
     last_missing: list[str] = []
 
     while time.monotonic() < deadline:
-        run_payload = api(f"/repos/{repo}/actions/runs?head_sha={sha}&per_page=100")
+        run_payload = api(runs_path(repo, sha))
         runs = run_payload.get("workflow_runs", [])
+        if not isinstance(runs, list):
+            raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_LIST")
         selected.clear()
         missing: list[str] = []
         for workflow_name, artifact_name in REQUIRED.items():
@@ -67,14 +127,17 @@ def main() -> None:
             if run is None:
                 missing.append(f"workflow:{workflow_name}")
                 continue
-            artifacts = api(f"/repos/{repo}/actions/runs/{run['id']}/artifacts?per_page=100").get("artifacts", [])
+            run_id = validate_run_id(run.get("id"))
+            artifacts = api(artifacts_path(repo, run_id)).get("artifacts", [])
+            if not isinstance(artifacts, list):
+                raise SystemExit("CLOSURE_MANIFEST_INVALID_ARTIFACT_LIST")
             candidates = [a for a in artifacts if a.get("name") == artifact_name and not a.get("expired")]
             if not candidates:
                 missing.append(f"artifact:{artifact_name}")
                 continue
-            artifact = max(candidates, key=lambda a: a.get("id", 0))
+            artifact = max(candidates, key=lambda a: validate_run_id(a.get("id")))
             digest = artifact.get("digest") or ""
-            if not digest.startswith("sha256:"):
+            if not isinstance(digest, str) or not digest.startswith("sha256:"):
                 missing.append(f"artifact_digest:{artifact_name}")
                 continue
             selected[workflow_name] = (run, artifact)
@@ -91,7 +154,7 @@ def main() -> None:
         run, artifact = selected[workflow_name]
         entries.append({
             "workflow_name": workflow_name,
-            "workflow_run_id": run["id"],
+            "workflow_run_id": validate_run_id(run["id"]),
             "workflow_run_attempt": run.get("run_attempt"),
             "workflow_event": run.get("event"),
             "workflow_head_branch": run.get("head_branch"),
@@ -99,7 +162,7 @@ def main() -> None:
             "workflow_conclusion": run.get("conclusion"),
             "workflow_html_url": run.get("html_url"),
             "artifact_name": artifact_name,
-            "artifact_id": artifact["id"],
+            "artifact_id": validate_run_id(artifact["id"]),
             "artifact_digest": artifact["digest"],
             "artifact_size_in_bytes": artifact.get("size_in_bytes"),
             "artifact_created_at": artifact.get("created_at"),

--- a/deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
+++ b/deployments/sara_verified_local_v1/scripts/build_commit_closure_manifest.py
@@ -3,14 +3,10 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
-import http.client
 import json
 import os
 import pathlib
 import re
-import ssl
-import time
-import urllib.parse
 
 REQUIRED = {
     "SARA Verified Local v1 Gate": "sara-release-evidence-index",
@@ -20,141 +16,72 @@ REQUIRED = {
     "SARA Operational Resilience Drill": "sara-operational-resilience-evidence",
 }
 
-API_HOST = "api.github.com"
 REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
-def validate_repo(value: str) -> str:
-    if not REPO_RE.fullmatch(value):
-        raise SystemExit("CLOSURE_MANIFEST_INVALID_REPOSITORY")
-    return value
-
-
-def validate_sha(value: str) -> str:
-    value = value.lower()
-    if not SHA_RE.fullmatch(value):
-        raise SystemExit("CLOSURE_MANIFEST_INVALID_SHA")
-    return value
-
-
-def validate_run_id(value: object) -> int:
+def positive_int(value: object, label: str) -> int:
     if isinstance(value, bool):
-        raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_ID")
+        raise SystemExit(f"CLOSURE_MANIFEST_INVALID_{label}")
     try:
-        run_id = int(value)
+        number = int(value)
     except (TypeError, ValueError) as exc:
-        raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_ID") from exc
-    if run_id <= 0:
-        raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_ID")
-    return run_id
-
-
-def api(path: str) -> dict:
-    if not path.startswith("/repos/") or "\r" in path or "\n" in path:
-        raise SystemExit("CLOSURE_MANIFEST_INVALID_API_PATH")
-    token = os.environ["GITHUB_TOKEN"]
-    connection = http.client.HTTPSConnection(
-        API_HOST,
-        port=443,
-        timeout=30,
-        context=ssl.create_default_context(),
-    )
-    try:
-        connection.request(
-            "GET",
-            path,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-                "User-Agent": "worldshepherd-sara-closure-manifest",
-            },
-        )
-        response = connection.getresponse()
-        body = response.read()
-        if response.status != 200:
-            raise SystemExit(f"CLOSURE_MANIFEST_GITHUB_API_STATUS:{response.status}")
-        payload = json.loads(body.decode("utf-8"))
-        if not isinstance(payload, dict):
-            raise SystemExit("CLOSURE_MANIFEST_INVALID_API_RESPONSE")
-        return payload
-    finally:
-        connection.close()
-
-
-def runs_path(repo: str, sha: str) -> str:
-    query = urllib.parse.urlencode({"head_sha": sha, "per_page": "100"})
-    return f"/repos/{repo}/actions/runs?{query}"
-
-
-def artifacts_path(repo: str, run_id: int) -> str:
-    return f"/repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100"
-
-
-def select_successful_run(runs: list[dict], workflow_name: str, sha: str) -> dict | None:
-    matches = [
-        run for run in runs
-        if run.get("name") == workflow_name
-        and run.get("head_sha") == sha
-        and run.get("status") == "completed"
-        and run.get("conclusion") == "success"
-    ]
-    if not matches:
-        return None
-    return max(matches, key=lambda r: (r.get("run_attempt", 0), r.get("id", 0)))
+        raise SystemExit(f"CLOSURE_MANIFEST_INVALID_{label}") from exc
+    if number <= 0:
+        raise SystemExit(f"CLOSURE_MANIFEST_INVALID_{label}")
+    return number
 
 
 def main() -> None:
-    repo = validate_repo(os.environ["GITHUB_REPOSITORY"])
-    sha = validate_sha(os.environ["TARGET_SHA"])
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["TARGET_SHA"].lower()
+    if not REPO_RE.fullmatch(repo):
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_REPOSITORY")
+    if not SHA_RE.fullmatch(sha):
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_SHA")
+
+    snapshot_path = pathlib.Path(os.environ["CLOSURE_SNAPSHOT_FILE"])
     out_dir = pathlib.Path(os.environ.get("CLOSURE_MANIFEST_DIR", "closure_manifest"))
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    selected: dict[str, tuple[dict, dict]] = {}
-    deadline = time.monotonic() + int(os.environ.get("CLOSURE_WAIT_SECONDS", "420"))
-    last_missing: list[str] = []
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    if snapshot.get("schema") != "WS-SARA-CLOSURE-SNAPSHOT-V1":
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_SNAPSHOT_SCHEMA")
+    if snapshot.get("repository") != repo or snapshot.get("target_commit_sha") != sha:
+        raise SystemExit("CLOSURE_MANIFEST_SNAPSHOT_IDENTITY_MISMATCH")
+    supplied = snapshot.get("entries")
+    if not isinstance(supplied, list):
+        raise SystemExit("CLOSURE_MANIFEST_INVALID_SNAPSHOT_ENTRIES")
 
-    while time.monotonic() < deadline:
-        run_payload = api(runs_path(repo, sha))
-        runs = run_payload.get("workflow_runs", [])
-        if not isinstance(runs, list):
-            raise SystemExit("CLOSURE_MANIFEST_INVALID_RUN_LIST")
-        selected.clear()
-        missing: list[str] = []
-        for workflow_name, artifact_name in REQUIRED.items():
-            run = select_successful_run(runs, workflow_name, sha)
-            if run is None:
-                missing.append(f"workflow:{workflow_name}")
-                continue
-            run_id = validate_run_id(run.get("id"))
-            artifacts = api(artifacts_path(repo, run_id)).get("artifacts", [])
-            if not isinstance(artifacts, list):
-                raise SystemExit("CLOSURE_MANIFEST_INVALID_ARTIFACT_LIST")
-            candidates = [a for a in artifacts if a.get("name") == artifact_name and not a.get("expired")]
-            if not candidates:
-                missing.append(f"artifact:{artifact_name}")
-                continue
-            artifact = max(candidates, key=lambda a: validate_run_id(a.get("id")))
-            digest = artifact.get("digest") or ""
-            if not isinstance(digest, str) or not digest.startswith("sha256:"):
-                missing.append(f"artifact_digest:{artifact_name}")
-                continue
-            selected[workflow_name] = (run, artifact)
-        if not missing:
-            break
-        last_missing = missing
-        print("CLOSURE_MANIFEST_WAIT:", ", ".join(missing), flush=True)
-        time.sleep(3)
-    else:
-        raise SystemExit("CLOSURE_MANIFEST_TIMEOUT: " + ", ".join(last_missing))
+    by_workflow: dict[str, dict] = {}
+    for item in supplied:
+        if not isinstance(item, dict):
+            raise SystemExit("CLOSURE_MANIFEST_INVALID_SNAPSHOT_ENTRY")
+        name = item.get("workflow_name")
+        if name not in REQUIRED or name in by_workflow:
+            raise SystemExit("CLOSURE_MANIFEST_UNEXPECTED_OR_DUPLICATE_WORKFLOW")
+        by_workflow[name] = item
 
     entries = []
     for workflow_name, artifact_name in REQUIRED.items():
-        run, artifact = selected[workflow_name]
+        item = by_workflow.get(workflow_name)
+        if item is None:
+            raise SystemExit(f"CLOSURE_MANIFEST_MISSING_WORKFLOW:{workflow_name}")
+        run = item.get("run")
+        artifact = item.get("artifact")
+        if not isinstance(run, dict) or not isinstance(artifact, dict):
+            raise SystemExit(f"CLOSURE_MANIFEST_INVALID_ENTRY:{workflow_name}")
+        run_id = positive_int(run.get("id"), "RUN_ID")
+        artifact_id = positive_int(artifact.get("id"), "ARTIFACT_ID")
+        digest = artifact.get("digest")
+        if not isinstance(digest, str) or not DIGEST_RE.fullmatch(digest):
+            raise SystemExit(f"CLOSURE_MANIFEST_INVALID_DIGEST:{artifact_name}")
+        if artifact.get("name") != artifact_name:
+            raise SystemExit(f"CLOSURE_MANIFEST_ARTIFACT_NAME_MISMATCH:{workflow_name}")
         entries.append({
             "workflow_name": workflow_name,
-            "workflow_run_id": validate_run_id(run["id"]),
+            "workflow_run_id": run_id,
             "workflow_run_attempt": run.get("run_attempt"),
             "workflow_event": run.get("event"),
             "workflow_head_branch": run.get("head_branch"),
@@ -162,8 +89,8 @@ def main() -> None:
             "workflow_conclusion": run.get("conclusion"),
             "workflow_html_url": run.get("html_url"),
             "artifact_name": artifact_name,
-            "artifact_id": validate_run_id(artifact["id"]),
-            "artifact_digest": artifact["digest"],
+            "artifact_id": artifact_id,
+            "artifact_digest": digest,
             "artifact_size_in_bytes": artifact.get("size_in_bytes"),
             "artifact_created_at": artifact.get("created_at"),
             "artifact_expires_at": artifact.get("expires_at"),
@@ -174,7 +101,7 @@ def main() -> None:
         "all_required_workflows_successful": len(entries) == len(REQUIRED) and all(e["workflow_conclusion"] == "success" for e in entries),
         "all_evidence_bound_to_target_commit": all(e["workflow_head_sha"] == sha for e in entries),
         "all_required_artifacts_present": {e["artifact_name"] for e in entries} == set(REQUIRED.values()),
-        "all_artifacts_have_sha256_digests": all(str(e["artifact_digest"]).startswith("sha256:") for e in entries),
+        "all_artifacts_have_sha256_digests": all(DIGEST_RE.fullmatch(e["artifact_digest"]) for e in entries),
         "all_artifacts_unexpired_at_manifest_time": all(e["artifact_expired"] is False for e in entries),
     }
     manifest = {
@@ -197,9 +124,11 @@ def main() -> None:
     manifest_path = out_dir / "commit-closure-evidence-manifest.json"
     manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
-    (out_dir / "commit-closure-evidence-manifest.sha256").write_text(f"{digest}  {manifest_path.name}\n", encoding="utf-8")
+    (out_dir / "commit-closure-evidence-manifest.sha256").write_text(
+        f"{digest}  {manifest_path.name}\n", encoding="utf-8"
+    )
     if manifest["result"] != "PASS":
-        raise SystemExit("CLOSURE_MANIFEST_FAIL: " + json.dumps(checks, sort_keys=True))
+        raise SystemExit("CLOSURE_MANIFEST_FAIL:" + json.dumps(checks, sort_keys=True))
     print("CLOSURE_MANIFEST_PASS", sha, "sha256:" + digest)
 
 

--- a/docs/operations/evidence-custody-policy.md
+++ b/docs/operations/evidence-custody-policy.md
@@ -8,7 +8,7 @@ Bind the critical internal engineering evidence for one exact SARA commit into a
 
 ## Required evidence classes
 
-A closure manifest must fail closed unless it finds a successful workflow run and an unexpired SHA-256-addressed artifact for the same target commit from each of these classes:
+A closure manifest must fail closed unless its trusted main-branch collector supplies a successful workflow run and an unexpired SHA-256-addressed artifact for the same target commit from each of these classes:
 
 - SARA release evidence index
 - rollback drill evidence
@@ -18,13 +18,17 @@ A closure manifest must fail closed unless it finds a successful workflow run an
 
 The manifest records workflow identity, run ID/attempt, event, branch, exact head SHA, conclusion, workflow URL, artifact name/ID, provider-reported digest, size, creation time, expiration time, and expiration state.
 
+## Trust separation
+
+The manifest builder is deliberately offline: it receives a local snapshot and never receives a GitHub token or performs network requests. GitHub workflow/artifact discovery occurs only in the trusted main-branch `workflow_run` path after the SARA main gate succeeds. That collector uses the bounded GitHub CLI API client and passes only resulting metadata into the offline validator.
+
 ## Signing
 
 For a successful `main` push, the closure manifest is attested through GitHub Actions OIDC using Sigstore-backed artifact attestation. The custody receipt records the target commit, manifest digest, attestation bundle digest, attestation identifier, attestation URL, and signing mechanism.
 
 ## Pull-request qualification
 
-Pull requests build the same exact-commit evidence inventory without making a production or external-custody claim. The PR gate therefore exercises workflow/artifact discovery and commit binding before merge.
+Pull requests receive no Actions-read credential for closure discovery. Instead, the PR job uses a synthetic five-class snapshot to compile and exercise the offline schema, validation, exact-SHA binding, digest validation, manifest generation, and fail-closed contract. Live workflow/artifact discovery and signing are reserved for trusted `main` execution.
 
 ## Claims boundary
 

--- a/docs/operations/evidence-custody-policy.md
+++ b/docs/operations/evidence-custody-policy.md
@@ -1,0 +1,31 @@
+# SARA Commit Closure Evidence Custody Policy
+
+Status: INTERNAL ENGINEERING CUSTODY PRECURSOR
+
+## Objective
+
+Bind the critical internal engineering evidence for one exact SARA commit into a single machine-verifiable manifest and cryptographically attest that manifest after successful main-branch execution.
+
+## Required evidence classes
+
+A closure manifest must fail closed unless it finds a successful workflow run and an unexpired SHA-256-addressed artifact for the same target commit from each of these classes:
+
+- SARA release evidence index
+- rollback drill evidence
+- replacement-environment restore evidence
+- TLS/private-backend architecture evidence
+- operational-resilience incident/recovery evidence
+
+The manifest records workflow identity, run ID/attempt, event, branch, exact head SHA, conclusion, workflow URL, artifact name/ID, provider-reported digest, size, creation time, expiration time, and expiration state.
+
+## Signing
+
+For a successful `main` push, the closure manifest is attested through GitHub Actions OIDC using Sigstore-backed artifact attestation. The custody receipt records the target commit, manifest digest, attestation bundle digest, attestation identifier, attestation URL, and signing mechanism.
+
+## Pull-request qualification
+
+Pull requests build the same exact-commit evidence inventory without making a production or external-custody claim. The PR gate therefore exercises workflow/artifact discovery and commit binding before merge.
+
+## Claims boundary
+
+This policy establishes a stronger same-provider cryptographic custody chain than separate unsigned CI artifacts. It is not off-provider or independent archival custody. It does not establish legal-record retention, WORM storage, customer/government acceptance, an external audit, certification, ATO, or independent third-party reproduction. A later external-custody implementation must export and verify the signed closure package in a separately administered failure and trust domain before the external ledger gate can be closed.


### PR DESCRIPTION
Adds a commit-bound evidence-custody precursor. For one exact trusted `main` SHA, a least-privilege collector requires successful SARA, rollback, replacement-restore, TLS, and operational-resilience workflows plus their named unexpired artifacts and provider-reported SHA-256 digests. It emits `WS-SARA-COMMIT-CLOSURE-EVIDENCE-MANIFEST-V1`. Pull requests receive no Actions-read custody credential; they exercise the offline manifest schema and fail-closed validation contract against a synthetic five-class fixture. After a successful main SARA gate, live metadata collection occurs without checking out repository code, then a separate OIDC/Sigstore attestation job receives only the staged manifest and retains a custody receipt.

Claims boundary: same-provider cryptographic custody only. This does not establish independent/off-provider archival custody, WORM/legal-record retention, external audit, customer/government acceptance, certification, ATO, or third-party reproduction.