### PR TITLE
Add Worldshepherd Physical AI interface contract v0.1

### DIFF
--- a/deployments/sara_verified_local_v1/docs/PHYSICAL_AI_INTERFACE_CONTRACT_V0_1.md
+++ b/deployments/sara_verified_local_v1/docs/PHYSICAL_AI_INTERFACE_CONTRACT_V0_1.md
@@ -1,0 +1,161 @@
+# Worldshepherd Physical AI Interface Contract v0.1
+
+Status: **IMPLEMENTED IN SOFTWARE — E1 UNIT-CONTRACT LEVEL ONLY**
+
+This document defines the first bounded Physical AI interface layer for Worldshepherd SARA. It does not claim physical robot validation, flight validation, RF performance, materials qualification, or operational deployment.
+
+## 1. Purpose
+
+The contract provides a common governance and evidence boundary for heterogeneous physical systems while leaving flight control, motor control, robot servo control, PLC logic, and OEM safety loops inside their native controllers.
+
+Reference stack:
+
+```text
+Physical machine
+  -> native controller / OEM runtime
+  -> transport adapter (ROS 2 / PX4 / RMF / OPC UA / future adapters)
+  -> Worldshepherd Physical AI contract
+  -> PRIME policy decision
+  -> SARA orchestration
+  -> ECHO evidence
+  -> OVERWATCH observability
+```
+
+## 2. Asset identity
+
+Every physical asset receives a stable Worldshepherd URI:
+
+```text
+ws://physical-ai/<fleet_id>/<asset_id>
+```
+
+The asset record binds:
+
+- asset ID
+- fleet ID
+- asset class
+- hardware revision
+- software revision
+- configuration digest
+
+## 3. Action envelope
+
+A physical action request carries at minimum:
+
+- asset ID
+- mission ID
+- action ID
+- action type
+- confidence
+- requested authority
+- reversibility
+- battery state
+- telemetry age
+- degraded-state status
+- model digest
+- configuration digest
+- optional observation/evidence-parent digests
+
+No AI or planner output should be treated as actuator authority merely because it produced a candidate action.
+
+## 4. PRIME-style decision states
+
+The software contract exposes six dispositions:
+
+- `ALLOW`
+- `ALLOW_WITH_LIMITS`
+- `DEFER`
+- `HUMAN_APPROVAL`
+- `DENY`
+- `SAFE_HOLD`
+
+The initial evaluator is intentionally conservative. Missing custody evidence, stale telemetry, low confidence, excessive authority, or non-reversible automatic actions cannot silently pass.
+
+## 5. Degraded-state model
+
+The first state machine is:
+
+```text
+NORMAL -> DEGRADED -> SAFE_HOLD -> RECOVERY -> NORMAL
+   \          \           \          \
+    +----------+-----------+-----------+-> EMERGENCY_STOP
+```
+
+`EMERGENCY_STOP` is modeled as absorbing at this contract layer. Clearing a real emergency stop must be handled by an explicitly designed physical safety procedure and must not be inferred from software state alone.
+
+## 6. Evidence manifest
+
+For each authorization decision, the contract can create an evidence manifest containing:
+
+- mission ID
+- asset ID
+- action ID
+- UTC timestamp
+- policy ID
+- decision
+- configuration digest
+- model digest
+- observation digest
+- evidence parent
+- optional action/result digests
+
+This is the bridge into ECHO SENTINEL LINK provenance and future machine-passport work.
+
+## 7. E1 conformance set
+
+The initial unit-contract tests are labeled PA-001 through PA-012:
+
+| Test | Unit-contract behavior |
+|---|---|
+| PA-001 | Valid bounded action is allowed |
+| PA-002 | Explicitly denied action is rejected |
+| PA-003 | Stale telemetry defers execution |
+| PA-004 | Low battery enters safe hold |
+| PA-005 | Missing model digest defers execution |
+| PA-006 | Missing configuration digest defers execution |
+| PA-007 | Bounded local action can proceed with limits in degraded mode |
+| PA-008 | Unbounded degraded action enters safe hold |
+| PA-009 | Human-approval action is not automatically executed |
+| PA-010 | Emergency-stop state denies actions |
+| PA-011 | Recovery-state execution remains limited |
+| PA-012 | Degraded-state transitions obey bounded transition rules |
+
+These are **E1 unit tests**, not simulation, SIL, HIL, or physical-system evidence.
+
+## 8. Evidence ladder
+
+Worldshepherd Physical AI evidence is tracked as:
+
+- E0 — architecture only
+- E1 — unit test
+- E2 — software simulation
+- E3 — software in the loop
+- E4 — hardware in the loop
+- E5 — controlled physical test
+- E6 — operational partner demonstration
+
+A capability must not inherit a higher evidence level from adjacent software, simulations, publications, or partner systems.
+
+## 9. Adapter boundaries
+
+Planned adapters:
+
+- `WS-ROS` — ROS 2 semantic bridge
+- `WS-PX4` — high-level PX4 mission/governance bridge
+- `WS-RMF` — fleet-task/governance bridge
+- `WS-OPCUA` — industrial robot/factory semantic bridge
+- `WS-EMSKIN` — adaptive RF/metasurface control/evidence bridge
+
+Native real-time stabilization and safety-critical servo loops remain below the Worldshepherd governance layer unless separately validated for a specific platform.
+
+## 10. Next gate
+
+The next engineering gate is E2/E3:
+
+1. expose the contract through bounded SARA API endpoints;
+2. add a simulated UGV adapter;
+3. connect fault injection for telemetry staleness, battery depletion, navigation degradation, and network loss;
+4. persist authorization and transition evidence through the existing durable audit/evidence path;
+5. run PA-001..PA-012 in CI and then expand them into SIL scenarios.
+
+Only after those pass should the contract be connected to PX4, RMF, OPC UA, or physical hardware.

--- a/deployments/sara_verified_local_v1/tests/test_physical_ai_contract.py
+++ b/deployments/sara_verified_local_v1/tests/test_physical_ai_contract.py
@@ -1,0 +1,129 @@
+from worldshepherd_sara.physical_ai_contract import (
+    DegradedState,
+    PhysicalActionDecision,
+    PhysicalActionPolicy,
+    PhysicalActionRequest,
+    evaluate_physical_action,
+    transition_allowed,
+)
+
+
+def policy() -> PhysicalActionPolicy:
+    return PhysicalActionPolicy(
+        policy_id="WS-PA-POLICY-001",
+        allowed_action_types=["navigate", "safe_hold", "recover", "dock"],
+        denied_action_types=["unsafe_override"],
+        human_approval_action_types=["dock"],
+        bounded_local_action_types=["navigate", "safe_hold"],
+        minimum_confidence=0.80,
+        minimum_battery_soc=0.25,
+        maximum_telemetry_age_s=2.0,
+        maximum_auto_authority=1,
+        require_reversible=True,
+        require_model_digest=True,
+        require_configuration_digest=True,
+    )
+
+
+def request(**overrides) -> PhysicalActionRequest:
+    values = {
+        "asset_id": "ugv-001",
+        "mission_id": "WS-PHYAI-DEMO-001",
+        "action_id": "ACT-001",
+        "action_type": "navigate",
+        "confidence": 0.95,
+        "requested_authority": 1,
+        "reversible": True,
+        "battery_soc": 0.80,
+        "telemetry_age_s": 0.10,
+        "degraded_state": DegradedState.NORMAL,
+        "bounded_local_mode": False,
+        "model_digest": "sha256:model",
+        "configuration_digest": "sha256:config",
+        "observation_digest": "sha256:obs",
+    }
+    values.update(overrides)
+    return PhysicalActionRequest(**values)
+
+
+def test_pa_001_valid_action_is_allowed():
+    result = evaluate_physical_action(request(), policy())
+    assert result.decision is PhysicalActionDecision.ALLOW
+
+
+def test_pa_002_explicitly_denied_action_is_rejected():
+    result = evaluate_physical_action(
+        request(action_type="unsafe_override"), policy()
+    )
+    assert result.decision is PhysicalActionDecision.DENY
+
+
+def test_pa_003_stale_telemetry_defers_execution():
+    result = evaluate_physical_action(request(telemetry_age_s=9.0), policy())
+    assert result.decision is PhysicalActionDecision.DEFER
+    assert "telemetry is stale" in result.reasons
+
+
+def test_pa_004_low_battery_enters_safe_hold():
+    result = evaluate_physical_action(request(battery_soc=0.10), policy())
+    assert result.decision is PhysicalActionDecision.SAFE_HOLD
+
+
+def test_pa_005_missing_model_digest_defers_execution():
+    result = evaluate_physical_action(request(model_digest=None), policy())
+    assert result.decision is PhysicalActionDecision.DEFER
+    assert "model digest is required" in result.reasons
+
+
+def test_pa_006_missing_configuration_digest_defers_execution():
+    result = evaluate_physical_action(request(configuration_digest=None), policy())
+    assert result.decision is PhysicalActionDecision.DEFER
+    assert "configuration digest is required" in result.reasons
+
+
+def test_pa_007_degraded_bounded_local_action_is_limited():
+    result = evaluate_physical_action(
+        request(
+            degraded_state=DegradedState.DEGRADED,
+            bounded_local_mode=True,
+        ),
+        policy(),
+    )
+    assert result.decision is PhysicalActionDecision.ALLOW_WITH_LIMITS
+    assert result.effective_limits["bounded_local_mode"] is True
+
+
+def test_pa_008_degraded_unbounded_action_enters_safe_hold():
+    result = evaluate_physical_action(
+        request(degraded_state=DegradedState.DEGRADED), policy()
+    )
+    assert result.decision is PhysicalActionDecision.SAFE_HOLD
+
+
+def test_pa_009_human_approval_action_is_not_auto_executed():
+    result = evaluate_physical_action(request(action_type="dock"), policy())
+    assert result.decision is PhysicalActionDecision.HUMAN_APPROVAL
+
+
+def test_pa_010_emergency_stop_is_absorbing_for_actions():
+    result = evaluate_physical_action(
+        request(degraded_state=DegradedState.EMERGENCY_STOP), policy()
+    )
+    assert result.decision is PhysicalActionDecision.DENY
+
+
+def test_pa_011_recovery_actions_remain_limited():
+    result = evaluate_physical_action(
+        request(degraded_state=DegradedState.RECOVERY), policy()
+    )
+    assert result.decision is PhysicalActionDecision.ALLOW_WITH_LIMITS
+    assert result.effective_limits["recovery_mode"] is True
+
+
+def test_pa_012_degraded_state_transition_rules_are_bounded():
+    assert transition_allowed(DegradedState.NORMAL, DegradedState.DEGRADED)
+    assert transition_allowed(DegradedState.DEGRADED, DegradedState.RECOVERY)
+    assert transition_allowed(DegradedState.RECOVERY, DegradedState.NORMAL)
+    assert not transition_allowed(
+        DegradedState.EMERGENCY_STOP, DegradedState.NORMAL
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/physical_ai_contract.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/physical_ai_contract.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AssetClass(str, Enum):
+    UAV = "UAV"
+    UGV = "UGV"
+    USV = "USV"
+    AMR = "AMR"
+    ROBOT_ARM = "ROBOT_ARM"
+    HUMANOID_SUBSYSTEM = "HUMANOID_SUBSYSTEM"
+    FACTORY_CELL = "FACTORY_CELL"
+    EMSKIN = "EMSKIN"
+
+
+class DegradedState(str, Enum):
+    NORMAL = "NORMAL"
+    DEGRADED = "DEGRADED"
+    SAFE_HOLD = "SAFE_HOLD"
+    RECOVERY = "RECOVERY"
+    EMERGENCY_STOP = "EMERGENCY_STOP"
+
+
+class PhysicalActionDecision(str, Enum):
+    ALLOW = "ALLOW"
+    ALLOW_WITH_LIMITS = "ALLOW_WITH_LIMITS"
+    DEFER = "DEFER"
+    HUMAN_APPROVAL = "HUMAN_APPROVAL"
+    DENY = "DENY"
+    SAFE_HOLD = "SAFE_HOLD"
+
+
+class AssetIdentity(BaseModel):
+    asset_id: str = Field(min_length=1, max_length=128)
+    fleet_id: str = Field(min_length=1, max_length=128)
+    asset_class: AssetClass
+    hardware_revision: str = Field(min_length=1, max_length=128)
+    software_revision: str = Field(min_length=1, max_length=128)
+    configuration_digest: str = Field(min_length=1, max_length=256)
+
+    @property
+    def ws_uri(self) -> str:
+        return f"ws://physical-ai/{self.fleet_id}/{self.asset_id}"
+
+
+class PhysicalActionRequest(BaseModel):
+    asset_id: str = Field(min_length=1, max_length=128)
+    mission_id: str = Field(min_length=1, max_length=128)
+    action_id: str = Field(min_length=1, max_length=128)
+    action_type: str = Field(min_length=1, max_length=128)
+    confidence: float = Field(ge=0.0, le=1.0)
+    requested_authority: int = Field(default=0, ge=0)
+    reversible: bool = True
+    battery_soc: float = Field(default=1.0, ge=0.0, le=1.0)
+    telemetry_age_s: float = Field(default=0.0, ge=0.0)
+    degraded_state: DegradedState = DegradedState.NORMAL
+    bounded_local_mode: bool = False
+    model_digest: str | None = Field(default=None, max_length=256)
+    configuration_digest: str | None = Field(default=None, max_length=256)
+    observation_digest: str | None = Field(default=None, max_length=256)
+    evidence_parent: str | None = Field(default=None, max_length=256)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class PhysicalActionPolicy(BaseModel):
+    policy_id: str = Field(min_length=1, max_length=128)
+    allowed_action_types: list[str] = Field(default_factory=list)
+    denied_action_types: list[str] = Field(default_factory=list)
+    human_approval_action_types: list[str] = Field(default_factory=list)
+    bounded_local_action_types: list[str] = Field(default_factory=list)
+    minimum_confidence: float = Field(default=0.8, ge=0.0, le=1.0)
+    minimum_battery_soc: float = Field(default=0.25, ge=0.0, le=1.0)
+    maximum_telemetry_age_s: float = Field(default=2.0, ge=0.0)
+    maximum_auto_authority: int = Field(default=0, ge=0)
+    require_reversible: bool = True
+    require_model_digest: bool = True
+    require_configuration_digest: bool = True
+
+
+class PhysicalActionAuthorization(BaseModel):
+    action_id: str
+    decision: PhysicalActionDecision
+    reasons: list[str] = Field(default_factory=list)
+    effective_limits: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceManifest(BaseModel):
+    mission_id: str = Field(min_length=1, max_length=128)
+    asset_id: str = Field(min_length=1, max_length=128)
+    action_id: str = Field(min_length=1, max_length=128)
+    timestamp_utc: str
+    action_digest: str | None = None
+    policy_id: str = Field(min_length=1, max_length=128)
+    decision: PhysicalActionDecision
+    configuration_digest: str | None = None
+    model_digest: str | None = None
+    observation_digest: str | None = None
+    evidence_parent: str | None = None
+    result_digest: str | None = None
+
+    @classmethod
+    def from_authorization(
+        cls,
+        request: PhysicalActionRequest,
+        policy: PhysicalActionPolicy,
+        authorization: PhysicalActionAuthorization,
+    ) -> "EvidenceManifest":
+        return cls(
+            mission_id=request.mission_id,
+            asset_id=request.asset_id,
+            action_id=request.action_id,
+            timestamp_utc=datetime.now(timezone.utc).isoformat(),
+            policy_id=policy.policy_id,
+            decision=authorization.decision,
+            configuration_digest=request.configuration_digest,
+            model_digest=request.model_digest,
+            observation_digest=request.observation_digest,
+            evidence_parent=request.evidence_parent,
+        )
+
+
+_ALLOWED_TRANSITIONS: dict[DegradedState, set[DegradedState]] = {
+    DegradedState.NORMAL: {
+        DegradedState.DEGRADED,
+        DegradedState.SAFE_HOLD,
+        DegradedState.EMERGENCY_STOP,
+    },
+    DegradedState.DEGRADED: {
+        DegradedState.SAFE_HOLD,
+        DegradedState.RECOVERY,
+        DegradedState.EMERGENCY_STOP,
+    },
+    DegradedState.SAFE_HOLD: {
+        DegradedState.RECOVERY,
+        DegradedState.EMERGENCY_STOP,
+    },
+    DegradedState.RECOVERY: {
+        DegradedState.NORMAL,
+        DegradedState.DEGRADED,
+        DegradedState.SAFE_HOLD,
+        DegradedState.EMERGENCY_STOP,
+    },
+    DegradedState.EMERGENCY_STOP: set(),
+}
+
+
+def transition_allowed(current: DegradedState, target: DegradedState) -> bool:
+    return target in _ALLOWED_TRANSITIONS[current]
+
+
+def evaluate_physical_action(
+    request: PhysicalActionRequest,
+    policy: PhysicalActionPolicy,
+) -> PhysicalActionAuthorization:
+    reasons: list[str] = []
+
+    if request.degraded_state is DegradedState.EMERGENCY_STOP:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.DENY,
+            reasons=["asset is in EMERGENCY_STOP"],
+        )
+
+    if request.action_type in policy.denied_action_types:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.DENY,
+            reasons=["action type explicitly denied by policy"],
+        )
+
+    if request.action_type not in policy.allowed_action_types:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.DENY,
+            reasons=["action type is not in physical-action allowlist"],
+        )
+
+    if request.action_type in policy.human_approval_action_types:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.HUMAN_APPROVAL,
+            reasons=["action type requires human approval"],
+        )
+
+    if policy.require_model_digest and not request.model_digest:
+        reasons.append("model digest is required")
+    if policy.require_configuration_digest and not request.configuration_digest:
+        reasons.append("configuration digest is required")
+    if request.telemetry_age_s > policy.maximum_telemetry_age_s:
+        reasons.append("telemetry is stale")
+    if request.confidence < policy.minimum_confidence:
+        reasons.append("confidence is below automatic-execution threshold")
+    if request.requested_authority > policy.maximum_auto_authority:
+        reasons.append("requested authority exceeds automatic-execution ceiling")
+    if policy.require_reversible and not request.reversible:
+        reasons.append("automatic execution requires reversible action")
+
+    if reasons:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.DEFER,
+            reasons=reasons,
+        )
+
+    if request.battery_soc < policy.minimum_battery_soc:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.SAFE_HOLD,
+            reasons=["battery state of charge is below policy minimum"],
+        )
+
+    if request.degraded_state is DegradedState.SAFE_HOLD:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.SAFE_HOLD,
+            reasons=["asset remains in SAFE_HOLD until recovery is authorized"],
+        )
+
+    if request.degraded_state is DegradedState.DEGRADED:
+        if request.bounded_local_mode and request.action_type in policy.bounded_local_action_types:
+            return PhysicalActionAuthorization(
+                action_id=request.action_id,
+                decision=PhysicalActionDecision.ALLOW_WITH_LIMITS,
+                reasons=["bounded local action allowed in DEGRADED state"],
+                effective_limits={"bounded_local_mode": True},
+            )
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.SAFE_HOLD,
+            reasons=["action is not approved for bounded local execution in DEGRADED state"],
+        )
+
+    if request.degraded_state is DegradedState.RECOVERY:
+        return PhysicalActionAuthorization(
+            action_id=request.action_id,
+            decision=PhysicalActionDecision.ALLOW_WITH_LIMITS,
+            reasons=["RECOVERY actions remain bounded until NORMAL state is restored"],
+            effective_limits={"recovery_mode": True},
+        )
+
+    return PhysicalActionAuthorization(
+        action_id=request.action_id,
+        decision=PhysicalActionDecision.ALLOW,
+        reasons=["request satisfies bounded physical-action policy gates"],
+    )


### PR DESCRIPTION
## Summary

Introduces the first bounded Worldshepherd Physical AI contract as an extension of the existing SARA verified-local deployment.

### Added
- `physical_ai_contract.py`
  - asset identity and Worldshepherd Physical-AI URI
  - physical action request/policy/authorization models
  - `ALLOW`, `ALLOW_WITH_LIMITS`, `DEFER`, `HUMAN_APPROVAL`, `DENY`, `SAFE_HOLD` dispositions
  - bounded degraded-state transition model
  - evidence-manifest bridge for ECHO-style provenance
- `test_physical_ai_contract.py`
  - PA-001 through PA-012 E1 conformance tests
- `PHYSICAL_AI_INTERFACE_CONTRACT_V0_1.md`
  - adapter-first architecture and evidence-level boundaries

## Claims boundary

This PR establishes **E1 unit-contract evidence only**. It does not claim SIL, HIL, flight, robot, RF, materials, or operational validation.

## Next gate after CI

1. expose bounded SARA API endpoints;
2. add simulated UGV adapter and fault injection;
3. persist authorization/transition evidence through the durable store;
4. expand PA-001..PA-012 into E2/E3 scenarios;
5. only then attach PX4/RMF/OPC-UA or physical hardware.
