### PR TITLE
WS-HMAA v0.2: autonomy assurance core and synthetic SIL harness

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_1.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_1.md
@@ -1,0 +1,104 @@
+# WS-HMAA v0.1 — High-Mach Autonomy Assurance
+
+Status: IMPLEMENTED IN SOFTWARE (synthetic-data assurance core only)
+
+## Purpose
+
+WS-HMAA is a non-flight-control assurance sidecar for autonomy integrations. It is designed to observe entity/task streams, preserve provenance, evaluate assurance exceptions, and generate verifiable evidence bundles without issuing safety-critical flight commands.
+
+The initial target is a Lattice-compatible software-in-the-loop demonstrator using simulated data. No Quarterhorse, Hermeus, Anduril proprietary, CUI, ITAR-controlled, or classified data is required for v0.1.
+
+## System boundary
+
+Data flow:
+
+1. External autonomy environment emits entity, task, heartbeat, and object-integrity events.
+2. `hmaa_adapter.py` normalizes external payloads into `HMAAEvent` records.
+3. `hmaa.py` seals each event into a SHA-256 hash chain.
+4. Assurance evaluation returns one of: `ALLOW`, `WARN`, `REVIEW`, or `INDETERMINATE`.
+5. Evidence bundles are emitted only after the event chain verifies.
+
+WS-HMAA MUST NOT:
+
+- command flight-control surfaces;
+- replace vehicle safety logic;
+- infer approval when the policy engine is unavailable;
+- treat a missing heartbeat as proof of vehicle failure;
+- silently accept checksum failures or chronology corruption;
+- publish ITAR, classified, or mission-sensitive schemas to public or non-rated registries.
+
+## Lattice-facing integration assumptions
+
+The public Lattice SDK documentation describes:
+
+- streaming entity events and heartbeat events through `StreamEntities`;
+- real-time task streaming through `StreamTasks`;
+- simulated-data development in Lattice Sandboxes;
+- SHA-256 checksums for Objects integrity;
+- custom Protobuf task definitions through the Lattice Schema Registry.
+
+WS-HMAA v0.1 intentionally avoids importing a proprietary SDK package. The adapter accepts mapping/dictionary payloads so the assurance core can be unit-tested independently and wired to REST, SSE, or gRPC clients in a later integration layer.
+
+## Evidence schema
+
+Primary schema identifier:
+
+`worldshepherd.hmaa.evidence.v0.1`
+
+Each sealed event includes:
+
+- event and mission identifiers;
+- optional entity/task identifiers;
+- source and ingest timestamps;
+- source payload;
+- previous event hash;
+- current SHA-256 event hash.
+
+A bundle is accepted only when every event hash and chain pointer verifies and all events match the bundle mission identifier.
+
+## Assurance semantics
+
+| Condition | Result |
+| --- | --- |
+| No detected exception | `ALLOW` |
+| Degraded heartbeat / duplicate requiring deduplication | `WARN` |
+| Checksum failure / chronology anomaly | `REVIEW` |
+| Policy engine unavailable | `INDETERMINATE` |
+
+`INDETERMINATE` is explicitly non-approval. This preserves the Worldshepherd doctrine that failure of an assurance service must not become implicit authorization.
+
+## SIL acceptance tests
+
+v0.1 includes automated tests for:
+
+1. valid chained evidence;
+2. tamper detection;
+3. policy-engine outage fail-closed behavior;
+4. checksum failure escalation;
+5. degraded-heartbeat warning;
+6. entity/task normalization;
+7. cross-mission evidence rejection;
+8. invalid reconnect-attempt rejection.
+
+## Next increment
+
+WS-HMAA v0.2 should add:
+
+- a sandbox client abstraction for entity/task streams;
+- persistent local evidence storage using the existing SARA durable-store conventions;
+- replay-safe deduplication keys;
+- monotonic chronology checks with explicit clock-skew tolerance;
+- object-checksum verification hooks;
+- `/v1/hmaa/*` read-only assurance endpoints;
+- fixture-driven link-loss and reconnect simulation;
+- CI evidence artifact generation.
+
+No claim of Hermeus/Anduril production integration is permitted until the sandbox integration is executed against an authorized environment and repeat-tested.
+
+## Public technical references
+
+- https://developer.anduril.com/guides/entities/watch
+- https://developer.anduril.com/guides/tasks/integrate-an-agent
+- https://developer.anduril.com/guides/developer-tools/sandboxes
+- https://developer.anduril.com/guides/objects/overview
+- https://developer.anduril.com/changelog/2026/7/23

--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_2.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_2.md
@@ -1,0 +1,58 @@
+# WS-HMAA v0.2 — Synthetic SIL Scenario Runner
+
+Status: IMPLEMENTED IN SOFTWARE / SYNTHETIC VALIDATION ONLY
+
+## Increment objective
+
+WS-HMAA v0.2 adds an executable software-in-the-loop scenario runner on top of the v0.1 assurance core. It exercises nominal autonomy observations, link degradation, reconnection, evidence-integrity failure, and policy-service failure without commanding an aircraft or importing proprietary vehicle/autonomy software.
+
+## Added behavior
+
+`hmaa_simulation.py` accepts typed scenario steps and converts them into the same hash-chained HMAA evidence model introduced in v0.1. Each step receives an assurance disposition:
+
+- `ALLOW` — no assurance exception detected;
+- `WARN` — degraded link or duplicate condition requiring attention;
+- `REVIEW` — integrity or chronology exception requiring human review;
+- `INDETERMINATE` — assurance/policy service unavailable; approval is never inferred.
+
+The runner then verifies the complete evidence chain before emitting a scenario result.
+
+## First scenario fixture
+
+`fixtures/hmaa_link_loss_scenario.json` contains seven synthetic events:
+
+1. nominal aircraft entity update;
+2. task enters progress;
+3. healthy entity-stream heartbeat;
+4. degraded/missed-link heartbeat condition;
+5. stream reconnect attempt;
+6. evidence-object checksum failure;
+7. policy-service outage.
+
+Expected assurance distribution:
+
+- 4 `ALLOW`
+- 1 `WARN`
+- 1 `REVIEW`
+- 1 `INDETERMINATE`
+
+## Acceptance criteria
+
+Automated tests require that:
+
+- the seven-event chain verifies end to end;
+- the degraded heartbeat is surfaced as `WARN`;
+- reconnection is recorded as a separate provenance event;
+- checksum failure is escalated to `REVIEW`;
+- policy-service failure remains `INDETERMINATE`;
+- an empty SIL scenario is rejected.
+
+## Claims boundary
+
+This increment is evidence that the Worldshepherd assurance logic can execute against synthetic autonomy-like event sequences. It is not evidence of production integration with Anduril Lattice, Hermeus Quarterhorse, any government mission system, or any flight-control stack.
+
+The next validation tier requires an authorized Lattice Sandbox or equivalent controlled interoperability environment. Until then, the appropriate claims labels remain `IMPLEMENTED IN SOFTWARE` and `SIMULATED ONLY`.
+
+## Next increment
+
+WS-HMAA v0.3 should add replay-safe deduplication, clock-skew-aware chronology validation, persistent evidence storage using SARA's secured data-directory conventions, and read-only assurance status/evidence endpoints. A live Lattice client should remain a separate adapter package so the assurance core stays testable without external credentials or proprietary dependencies.

--- a/deployments/sara_verified_local_v1/fixtures/hmaa_link_loss_scenario.json
+++ b/deployments/sara_verified_local_v1/fixtures/hmaa_link_loss_scenario.json
@@ -1,0 +1,43 @@
+[
+  {
+    "kind": "entity",
+    "payload": {
+      "entityId": "AIRCRAFT-SIM-1",
+      "eventType": "update",
+      "timestamp": "2026-09-04T20:00:00Z",
+      "health": "nominal"
+    }
+  },
+  {
+    "kind": "task",
+    "payload": {
+      "taskId": "TASK-SIM-1",
+      "agentId": "AIRCRAFT-SIM-1",
+      "status": "in_progress",
+      "timestamp": "2026-09-04T20:00:01Z"
+    }
+  },
+  {
+    "kind": "heartbeat",
+    "payload": {"stream": "entities"}
+  },
+  {
+    "kind": "heartbeat",
+    "payload": {"stream": "entities"},
+    "connection_healthy": false
+  },
+  {
+    "kind": "reconnect",
+    "payload": {"stream": "entities", "attempt": 1}
+  },
+  {
+    "kind": "observation",
+    "payload": {"object_id": "evidence-object-sim-1"},
+    "checksum_valid": false
+  },
+  {
+    "kind": "observation",
+    "payload": {"reason": "policy-service-outage"},
+    "policy_engine_available": false
+  }
+]

--- a/deployments/sara_verified_local_v1/tests/test_hmaa.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from worldshepherd_sara.hmaa import (
+    AssuranceDisposition,
+    HMAAEvent,
+    build_evidence_bundle,
+    evaluate_event_assurance,
+    seal_event,
+    verify_chain,
+)
+from worldshepherd_sara.hmaa_adapter import (
+    normalize_entity_event,
+    normalize_task_event,
+    reconnect_event,
+)
+
+
+def _event(event_id: str, mission_id: str = "SIM-001") -> HMAAEvent:
+    return HMAAEvent(
+        event_id=event_id,
+        mission_id=mission_id,
+        event_type="TASK_STATUS_CHANGE",
+        source_timestamp=datetime(2026, 9, 4, 20, 0, tzinfo=timezone.utc),
+        payload={"status": "IN_PROGRESS"},
+    )
+
+
+def test_hash_chain_verifies_and_bundle_carries_final_hash():
+    first = seal_event(_event("E1"))
+    second = seal_event(_event("E2"), first.event_hash)
+
+    ok, errors = verify_chain([first, second])
+    assert ok is True
+    assert errors == []
+
+    bundle = build_evidence_bundle("SIM-001", [first, second])
+    assert bundle.final_chain_hash == second.event_hash
+
+
+def test_hash_chain_detects_payload_tampering():
+    event = seal_event(_event("E1"))
+    tampered = event.model_copy(update={"payload": {"status": "COMPLETE"}})
+
+    ok, errors = verify_chain([tampered])
+    assert ok is False
+    assert any("event_hash" in error for error in errors)
+
+
+def test_policy_engine_outage_never_implies_approval():
+    assessment = evaluate_event_assurance(policy_engine_available=False)
+    assert assessment.disposition == AssuranceDisposition.INDETERMINATE
+    assert any("must not be inferred" in reason for reason in assessment.reasons)
+
+
+def test_checksum_failure_requires_review():
+    assessment = evaluate_event_assurance(checksum_valid=False)
+    assert assessment.disposition == AssuranceDisposition.REVIEW
+
+
+def test_degraded_heartbeat_warns_without_becoming_flight_control():
+    assessment = evaluate_event_assurance(connection_healthy=False)
+    assert assessment.disposition == AssuranceDisposition.WARN
+    assert any("heartbeat" in reason for reason in assessment.reasons)
+
+
+def test_adapter_normalizes_entity_and_task_payloads():
+    entity = normalize_entity_event(
+        {
+            "entityId": "AIRCRAFT-SIM-1",
+            "eventType": "update",
+            "timestamp": "2026-09-04T20:00:00Z",
+        },
+        mission_id="SIM-001",
+    )
+    task = normalize_task_event(
+        {
+            "taskId": "TASK-1",
+            "agentId": "AIRCRAFT-SIM-1",
+            "status": "in_progress",
+            "timestamp": "2026-09-04T20:00:01Z",
+        },
+        mission_id="SIM-001",
+    )
+
+    assert entity.entity_id == "AIRCRAFT-SIM-1"
+    assert entity.event_type == "ENTITY_UPDATE"
+    assert task.task_id == "TASK-1"
+    assert task.entity_id == "AIRCRAFT-SIM-1"
+    assert task.event_type == "TASK_IN_PROGRESS"
+
+
+def test_bundle_rejects_cross_mission_evidence():
+    first = seal_event(_event("E1", mission_id="SIM-001"))
+    second = seal_event(_event("E2", mission_id="SIM-002"), first.event_hash)
+
+    with pytest.raises(ValueError, match="mission_id"):
+        build_evidence_bundle("SIM-001", [first, second])
+
+
+def test_reconnect_attempt_must_be_positive():
+    with pytest.raises(ValueError, match="at least 1"):
+        reconnect_event(mission_id="SIM-001", stream="entities", attempt=0)

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_simulation.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_simulation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldshepherd_sara.hmaa import AssuranceDisposition, verify_chain
+from worldshepherd_sara.hmaa_simulation import load_sil_steps, run_sil_scenario
+
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "hmaa_link_loss_scenario.json"
+
+
+def test_link_loss_scenario_produces_verifiable_evidence_and_expected_dispositions():
+    steps = load_sil_steps(json.loads(FIXTURE.read_text(encoding="utf-8")))
+    result = run_sil_scenario(mission_id="SIM-LINK-LOSS-001", steps=steps)
+
+    ok, errors = verify_chain(result.evidence_bundle.events)
+    assert ok is True
+    assert errors == []
+    assert result.evidence_bundle.final_chain_hash
+    assert len(result.steps) == 7
+    assert result.disposition_counts[AssuranceDisposition.ALLOW.value] == 4
+    assert result.disposition_counts[AssuranceDisposition.WARN.value] == 1
+    assert result.disposition_counts[AssuranceDisposition.REVIEW.value] == 1
+    assert result.disposition_counts[AssuranceDisposition.INDETERMINATE.value] == 1
+
+
+def test_link_loss_scenario_records_reconnect_after_degraded_heartbeat():
+    steps = load_sil_steps(json.loads(FIXTURE.read_text(encoding="utf-8")))
+    result = run_sil_scenario(mission_id="SIM-LINK-LOSS-002", steps=steps)
+
+    assert result.steps[3].event.event_type == "HEARTBEAT"
+    assert result.steps[3].assessment.disposition == AssuranceDisposition.WARN
+    assert result.steps[4].event.event_type == "STREAM_RECONNECT"
+    assert result.steps[4].event.payload["attempt"] == 1
+
+
+def test_scenario_rejects_empty_step_set():
+    try:
+        run_sil_scenario(mission_id="SIM-EMPTY", steps=[])
+    except ValueError as exc:
+        assert "at least one step" in str(exc)
+    else:
+        raise AssertionError("empty SIL scenario must be rejected")

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+HMAA_SCHEMA_VERSION = "worldshepherd.hmaa.evidence.v0.1"
+
+
+class AssuranceDisposition(str, Enum):
+    ALLOW = "ALLOW"
+    WARN = "WARN"
+    REVIEW = "REVIEW"
+    INDETERMINATE = "INDETERMINATE"
+
+
+class HMAAEvent(BaseModel):
+    schema_version: str = HMAA_SCHEMA_VERSION
+    event_id: str = Field(min_length=1)
+    mission_id: str = Field(min_length=1)
+    source_system: str = Field(default="lattice", min_length=1)
+    entity_id: str | None = None
+    task_id: str | None = None
+    event_type: str = Field(min_length=1)
+    source_timestamp: datetime
+    ingest_timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    payload: dict[str, Any] = Field(default_factory=dict)
+    previous_event_hash: str | None = None
+    event_hash: str | None = None
+
+
+class AssuranceAssessment(BaseModel):
+    disposition: AssuranceDisposition
+    reasons: list[str] = Field(default_factory=list)
+
+
+class HMAAEvidenceBundle(BaseModel):
+    schema_version: str = HMAA_SCHEMA_VERSION
+    mission_id: str = Field(min_length=1)
+    generated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    events: list[HMAAEvent] = Field(default_factory=list)
+    final_chain_hash: str | None = None
+
+
+def canonical_event_bytes(event: HMAAEvent) -> bytes:
+    body = event.model_dump(mode="json", exclude={"event_hash"})
+    return json.dumps(
+        body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def seal_event(event: HMAAEvent, previous_event_hash: str | None = None) -> HMAAEvent:
+    candidate = event.model_copy(
+        update={
+            "previous_event_hash": previous_event_hash,
+            "event_hash": None,
+        }
+    )
+    digest = hashlib.sha256(canonical_event_bytes(candidate)).hexdigest()
+    return candidate.model_copy(update={"event_hash": f"sha256:{digest}"})
+
+
+def verify_chain(events: list[HMAAEvent]) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+    expected_previous: str | None = None
+
+    for index, event in enumerate(events):
+        if event.previous_event_hash != expected_previous:
+            errors.append(
+                f"event[{index}] previous_event_hash does not match chain head"
+            )
+
+        candidate = event.model_copy(
+            update={
+                "previous_event_hash": expected_previous,
+                "event_hash": None,
+            }
+        )
+        expected_hash = (
+            "sha256:" + hashlib.sha256(canonical_event_bytes(candidate)).hexdigest()
+        )
+        if event.event_hash != expected_hash:
+            errors.append(f"event[{index}] event_hash verification failed")
+
+        expected_previous = event.event_hash
+
+    return not errors, errors
+
+
+def evaluate_event_assurance(
+    *,
+    connection_healthy: bool = True,
+    policy_engine_available: bool = True,
+    duplicate_event: bool = False,
+    out_of_order_event: bool = False,
+    checksum_valid: bool = True,
+) -> AssuranceAssessment:
+    if not policy_engine_available:
+        return AssuranceAssessment(
+            disposition=AssuranceDisposition.INDETERMINATE,
+            reasons=["policy engine unavailable; approval must not be inferred"],
+        )
+
+    review_reasons: list[str] = []
+    warning_reasons: list[str] = []
+
+    if not checksum_valid:
+        review_reasons.append("evidence checksum validation failed")
+    if out_of_order_event:
+        review_reasons.append("event chronology is out of order")
+    if duplicate_event:
+        warning_reasons.append("duplicate event detected; deduplication required")
+    if not connection_healthy:
+        warning_reasons.append("source connection heartbeat is degraded")
+
+    if review_reasons:
+        return AssuranceAssessment(
+            disposition=AssuranceDisposition.REVIEW,
+            reasons=review_reasons + warning_reasons,
+        )
+    if warning_reasons:
+        return AssuranceAssessment(
+            disposition=AssuranceDisposition.WARN,
+            reasons=warning_reasons,
+        )
+    return AssuranceAssessment(
+        disposition=AssuranceDisposition.ALLOW,
+        reasons=["no assurance exception detected"],
+    )
+
+
+def build_evidence_bundle(
+    mission_id: str, events: list[HMAAEvent]
+) -> HMAAEvidenceBundle:
+    ok, errors = verify_chain(events)
+    if not ok:
+        raise ValueError("invalid HMAA evidence chain: " + "; ".join(errors))
+    if any(event.mission_id != mission_id for event in events):
+        raise ValueError("all HMAA events must match the evidence-bundle mission_id")
+    return HMAAEvidenceBundle(
+        mission_id=mission_id,
+        events=events,
+        final_chain_hash=events[-1].event_hash if events else None,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_adapter.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_adapter.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from uuid import uuid4
+
+from .hmaa import HMAAEvent
+
+
+def _first(payload: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = payload.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _timestamp(payload: Mapping[str, Any]) -> datetime:
+    value = _first(
+        payload,
+        "source_timestamp",
+        "timestamp",
+        "last_updated_at",
+        "lastUpdatedAt",
+        "update_time",
+        "updateTime",
+    )
+    if value is None:
+        return datetime.now(timezone.utc)
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    raise ValueError("unsupported source timestamp type")
+
+
+def normalize_entity_event(
+    payload: Mapping[str, Any], *, mission_id: str
+) -> HMAAEvent:
+    entity_id = _first(payload, "entity_id", "entityId", "id")
+    if not entity_id:
+        raise ValueError("entity update is missing an entity identifier")
+
+    stream_event_type = _first(payload, "event_type", "eventType", "type")
+    return HMAAEvent(
+        event_id=str(uuid4()),
+        mission_id=mission_id,
+        entity_id=str(entity_id),
+        event_type=f"ENTITY_{str(stream_event_type or 'UPDATE').upper()}",
+        source_timestamp=_timestamp(payload),
+        payload=dict(payload),
+    )
+
+
+def normalize_task_event(
+    payload: Mapping[str, Any], *, mission_id: str
+) -> HMAAEvent:
+    task_id = _first(payload, "task_id", "taskId", "id")
+    if not task_id:
+        raise ValueError("task update is missing a task identifier")
+
+    status = _first(payload, "status", "task_status", "taskStatus")
+    return HMAAEvent(
+        event_id=str(uuid4()),
+        mission_id=mission_id,
+        task_id=str(task_id),
+        entity_id=(
+            str(_first(payload, "entity_id", "entityId", "agent_id", "agentId"))
+            if _first(payload, "entity_id", "entityId", "agent_id", "agentId")
+            is not None
+            else None
+        ),
+        event_type=f"TASK_{str(status or 'UPDATE').upper()}",
+        source_timestamp=_timestamp(payload),
+        payload=dict(payload),
+    )
+
+
+def heartbeat_event(*, mission_id: str, stream: str) -> HMAAEvent:
+    now = datetime.now(timezone.utc)
+    return HMAAEvent(
+        event_id=str(uuid4()),
+        mission_id=mission_id,
+        event_type="HEARTBEAT",
+        source_timestamp=now,
+        payload={"stream": stream},
+    )
+
+
+def reconnect_event(
+    *, mission_id: str, stream: str, attempt: int
+) -> HMAAEvent:
+    if attempt < 1:
+        raise ValueError("reconnect attempt must be at least 1")
+    now = datetime.now(timezone.utc)
+    return HMAAEvent(
+        event_id=str(uuid4()),
+        mission_id=mission_id,
+        event_type="STREAM_RECONNECT",
+        source_timestamp=now,
+        payload={"stream": stream, "attempt": attempt},
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_simulation.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_simulation.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from .hmaa import (
+    AssuranceAssessment,
+    AssuranceDisposition,
+    HMAAEvidenceBundle,
+    HMAAEvent,
+    build_evidence_bundle,
+    evaluate_event_assurance,
+    seal_event,
+)
+from .hmaa_adapter import (
+    heartbeat_event,
+    normalize_entity_event,
+    normalize_task_event,
+    reconnect_event,
+)
+
+
+class SILStep(BaseModel):
+    kind: Literal["entity", "task", "heartbeat", "reconnect", "observation"]
+    payload: dict[str, Any] = Field(default_factory=dict)
+    connection_healthy: bool = True
+    policy_engine_available: bool = True
+    duplicate_event: bool = False
+    out_of_order_event: bool = False
+    checksum_valid: bool = True
+
+
+class SILStepResult(BaseModel):
+    index: int = Field(ge=0)
+    event: HMAAEvent
+    assessment: AssuranceAssessment
+
+
+class SILScenarioResult(BaseModel):
+    mission_id: str = Field(min_length=1)
+    steps: list[SILStepResult]
+    evidence_bundle: HMAAEvidenceBundle
+    disposition_counts: dict[str, int]
+
+
+def _observation_event(payload: dict[str, Any], mission_id: str) -> HMAAEvent:
+    return HMAAEvent(
+        event_id=str(uuid4()),
+        mission_id=mission_id,
+        event_type="ASSURANCE_OBSERVATION",
+        source_timestamp=datetime.now(timezone.utc),
+        payload=payload,
+    )
+
+
+def _event_from_step(step: SILStep, mission_id: str) -> HMAAEvent:
+    if step.kind == "entity":
+        return normalize_entity_event(step.payload, mission_id=mission_id)
+    if step.kind == "task":
+        return normalize_task_event(step.payload, mission_id=mission_id)
+    if step.kind == "heartbeat":
+        stream = str(step.payload.get("stream", "entities"))
+        return heartbeat_event(mission_id=mission_id, stream=stream)
+    if step.kind == "reconnect":
+        stream = str(step.payload.get("stream", "entities"))
+        attempt = int(step.payload.get("attempt", 1))
+        return reconnect_event(
+            mission_id=mission_id,
+            stream=stream,
+            attempt=attempt,
+        )
+    return _observation_event(step.payload, mission_id)
+
+
+def run_sil_scenario(
+    *, mission_id: str, steps: list[SILStep]
+) -> SILScenarioResult:
+    if not mission_id:
+        raise ValueError("mission_id must not be empty")
+    if not steps:
+        raise ValueError("SIL scenario must contain at least one step")
+
+    results: list[SILStepResult] = []
+    sealed_events: list[HMAAEvent] = []
+    previous_hash: str | None = None
+
+    for index, step in enumerate(steps):
+        event = _event_from_step(step, mission_id)
+        sealed = seal_event(event, previous_hash)
+        assessment = evaluate_event_assurance(
+            connection_healthy=step.connection_healthy,
+            policy_engine_available=step.policy_engine_available,
+            duplicate_event=step.duplicate_event,
+            out_of_order_event=step.out_of_order_event,
+            checksum_valid=step.checksum_valid,
+        )
+        results.append(
+            SILStepResult(index=index, event=sealed, assessment=assessment)
+        )
+        sealed_events.append(sealed)
+        previous_hash = sealed.event_hash
+
+    bundle = build_evidence_bundle(mission_id, sealed_events)
+    counts = Counter(result.assessment.disposition.value for result in results)
+    normalized_counts = {
+        disposition.value: counts.get(disposition.value, 0)
+        for disposition in AssuranceDisposition
+    }
+    return SILScenarioResult(
+        mission_id=mission_id,
+        steps=results,
+        evidence_bundle=bundle,
+        disposition_counts=normalized_counts,
+    )
+
+
+def load_sil_steps(value: list[dict[str, Any]]) -> list[SILStep]:
+    return [SILStep.model_validate(item) for item in value]


### PR DESCRIPTION
## Summary
Implements Worldshepherd High-Mach Autonomy Assurance (WS-HMAA) as a non-flight-control assurance sidecar and advances it through a synthetic software-in-the-loop link-loss/reconnect scenario.

### v0.1 foundation
- SHA-256 chained mission evidence records
- ALLOW / WARN / REVIEW / INDETERMINATE assurance dispositions
- fail-closed behavior when policy evaluation is unavailable
- generic entity/task/heartbeat/reconnect normalization layer
- tamper, checksum, heartbeat, cross-mission, and adapter tests

### v0.2 increment
- typed synthetic SIL scenario runner
- seven-step entity/task/heartbeat/link-loss/reconnect/checksum/policy-outage fixture
- end-to-end evidence-chain verification
- explicit expected assurance disposition counts
- automated tests confirming reconnect provenance and fail-conservative behavior

### Safety / claims boundary
This PR does **not** claim Hermeus or Anduril production integration and does not issue vehicle-control commands. It remains a synthetic-data assurance sidecar. No CUI, ITAR-controlled, classified, proprietary Quarterhorse, or proprietary Lattice data is required.

### Public integration basis
The design is aligned to current public Lattice documentation for StreamEntities, StreamTasks/heartbeats, Sandboxes, Objects integrity checks, and Schema Registry capabilities, while keeping the core independent of proprietary SDK dependencies.

### Validation gates
The first commit cleared package compilation and unit/API tests and supporting resilience/compliance workflows. The v0.2 commit intentionally retriggers the protected CI/security gates.

### Next gate
After the v0.2 head clears required CI and CodeQL, the next increment is replay-safe deduplication, clock-skew-aware chronology validation, secured persistent evidence storage, read-only `/v1/hmaa/*` assurance endpoints, and then an authorized Lattice Sandbox adapter/validation step.