### PR TITLE
WS-HMAA v0.3: replay, chronology, persistence, and read-only assurance API

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_3.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_3.md
@@ -1,0 +1,58 @@
+# WS-HMAA v0.3 — Replay, Chronology, and Persistent Evidence Controls
+
+Status: IMPLEMENTED IN SOFTWARE / LOCAL SYNTHETIC VALIDATION ONLY
+
+## Increment objective
+
+WS-HMAA v0.3 hardens the v0.2 synthetic assurance sidecar against replay ambiguity, source-clock disorder, and volatile evidence loss. The controls remain observational and non-flight-control.
+
+## Added controls
+
+### Replay-safe identity
+
+Each source event receives a stable SHA-256 identity key derived from:
+
+- mission identifier;
+- source-system identifier;
+- source event identifier.
+
+A separate source fingerprint excludes local ingest time and hash-chain placement. This lets WS-HMAA distinguish an exact replay from reuse of the same identity with conflicting source content.
+
+- exact replay -> `WARN`;
+- conflicting replay -> `REVIEW`.
+
+### Clock-skew-aware chronology
+
+Chronology is tracked per mission/source/subject scope. Source timestamps may arrive slightly out of order within an explicit tolerance. Events older than the latest source timestamp by more than the configured tolerance are escalated to `REVIEW`.
+
+The default synthetic tolerance is 2.0 seconds. This is a test parameter, not a production flight-system timing requirement.
+
+### Secured append-only evidence persistence
+
+`HMAAEvidenceStore` writes sealed assurance records to `hmaa_evidence.jsonl` under the existing SARA data directory conventions.
+
+The store:
+
+- requires a valid event seal;
+- requires mission-chain continuity;
+- writes append-only JSONL records;
+- fsyncs each accepted record;
+- enforces `0700` on the data directory and `0600` on the evidence file;
+- rejects malformed or oversized evidence lines instead of silently accepting them.
+
+No write API is exposed by this increment.
+
+### Read-only assurance API
+
+Two authenticated administrator endpoints expose the local assurance view:
+
+- `GET /v1/hmaa/status`
+- `GET /v1/hmaa/evidence?mission_id=<id>&limit=<n>`
+
+These endpoints do not ingest events, modify evidence, or issue vehicle-control commands.
+
+## Claims boundary
+
+v0.3 does not establish production interoperability with Anduril Lattice, Hermeus Quarterhorse, or any operational mission system. It demonstrates deterministic local assurance behavior with synthetic events and durable local evidence.
+
+The next external validation tier remains an authorized Lattice Sandbox or equivalent controlled interoperability environment.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_api.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from worldshepherd_sara.hmaa import (
+    HMAAEvent,
+    evaluate_event_assurance,
+    seal_event,
+)
+
+
+BASE = datetime(2026, 9, 4, 22, 0, tzinfo=timezone.utc)
+
+
+def auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _sealed_event() -> HMAAEvent:
+    return seal_event(
+        HMAAEvent(
+            event_id="API-E1",
+            mission_id="SIM-API-001",
+            source_system="synthetic-sil",
+            event_type="OBSERVATION",
+            source_timestamp=BASE,
+            ingest_timestamp=BASE,
+            payload={"status": "nominal"},
+        )
+    )
+
+
+def test_hmaa_read_endpoints_require_admin(client, tokens):
+    relay, admin = tokens
+
+    assert client.get("/v1/hmaa/status").status_code == 401
+    assert client.get("/v1/hmaa/status", headers=auth(relay)).status_code == 403
+    assert client.get("/v1/hmaa/evidence", headers=auth(relay)).status_code == 403
+    assert client.get("/v1/hmaa/status", headers=auth(admin)).status_code == 200
+
+
+def test_hmaa_status_and_evidence_are_read_only_views(client, tokens):
+    _, admin = tokens
+    event = _sealed_event()
+    client.app.state.hmaa_store.append(event, evaluate_event_assurance())
+
+    status = client.get("/v1/hmaa/status", headers=auth(admin))
+    assert status.status_code == 200
+    assert status.json()["ok"] is True
+    assert status.json()["status"]["latest_event_hash"] == event.event_hash
+    assert status.json()["status"]["latest_mission_id"] == "SIM-API-001"
+
+    evidence = client.get(
+        "/v1/hmaa/evidence?mission_id=SIM-API-001&limit=5",
+        headers=auth(admin),
+    )
+    assert evidence.status_code == 200
+    records = evidence.json()["records"]
+    assert len(records) == 1
+    assert records[0]["event"]["event_id"] == "API-E1"
+    assert records[0]["assessment"]["disposition"] == "ALLOW"
+
+
+def test_hmaa_evidence_filter_does_not_return_other_missions(client, tokens):
+    _, admin = tokens
+    event = _sealed_event()
+    client.app.state.hmaa_store.append(event, evaluate_event_assurance())
+
+    response = client.get(
+        "/v1/hmaa/evidence?mission_id=SIM-NOT-PRESENT",
+        headers=auth(admin),
+    )
+    assert response.status_code == 200
+    assert response.json()["records"] == []

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_state.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_state.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from worldshepherd_sara.hmaa import AssuranceDisposition, HMAAEvent
+from worldshepherd_sara.hmaa_state import HMAAAssuranceState
+
+
+BASE = datetime(2026, 9, 4, 20, 0, tzinfo=timezone.utc)
+
+
+def _event(
+    event_id: str,
+    *,
+    offset_seconds: int = 0,
+    payload: dict[str, object] | None = None,
+) -> HMAAEvent:
+    return HMAAEvent(
+        event_id=event_id,
+        mission_id="SIM-STATE-001",
+        source_system="synthetic-sil",
+        entity_id="AIRCRAFT-SIM-1",
+        event_type="ENTITY_UPDATE",
+        source_timestamp=BASE + timedelta(seconds=offset_seconds),
+        ingest_timestamp=BASE + timedelta(seconds=max(offset_seconds, 0)),
+        payload=payload or {"health": "nominal"},
+    )
+
+
+def test_replayed_source_event_is_deduplicated_and_warned():
+    state = HMAAAssuranceState()
+    first = _event("E-1")
+    _, first_assessment = state.assess(first)
+    observation, replay_assessment = state.assess(first)
+
+    assert first_assessment.disposition == AssuranceDisposition.ALLOW
+    assert observation.replay.duplicate_event is True
+    assert observation.replay.conflicting_replay is False
+    assert replay_assessment.disposition == AssuranceDisposition.WARN
+
+
+def test_conflicting_replay_requires_review():
+    state = HMAAAssuranceState()
+    state.assess(_event("E-1", payload={"health": "nominal"}))
+    observation, assessment = state.assess(
+        _event("E-1", payload={"health": "unexpected-change"})
+    )
+
+    assert observation.replay.duplicate_event is False
+    assert observation.replay.conflicting_replay is True
+    assert assessment.disposition == AssuranceDisposition.REVIEW
+    assert any("conflicting" in reason for reason in assessment.reasons)
+
+
+def test_clock_skew_tolerance_accepts_small_reordering_but_flags_large_reordering():
+    state = HMAAAssuranceState(clock_skew_tolerance_seconds=2.0)
+    state.assess(_event("E-10", offset_seconds=10))
+
+    within_tolerance, within_assessment = state.assess(
+        _event("E-9", offset_seconds=9)
+    )
+    outside_tolerance, outside_assessment = state.assess(
+        _event("E-6", offset_seconds=6)
+    )
+
+    assert within_tolerance.chronology.skew_seconds == 1.0
+    assert within_tolerance.chronology.out_of_order_event is False
+    assert within_assessment.disposition == AssuranceDisposition.ALLOW
+
+    assert outside_tolerance.chronology.skew_seconds == 4.0
+    assert outside_tolerance.chronology.out_of_order_event is True
+    assert outside_assessment.disposition == AssuranceDisposition.REVIEW
+
+
+def test_state_snapshot_exposes_counts_not_source_payloads():
+    state = HMAAAssuranceState()
+    state.assess(_event("E-1", payload={"sensitive": "not-for-snapshot"}))
+    snapshot = state.snapshot()
+
+    assert snapshot["deduplication_identities"] == 1
+    assert snapshot["chronology_scopes"] == 1
+    assert "sensitive" not in repr(snapshot)

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_storage.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_storage.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import stat
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from worldshepherd_sara.hmaa import (
+    HMAAEvent,
+    evaluate_event_assurance,
+    seal_event,
+)
+from worldshepherd_sara.hmaa_storage import HMAAEvidenceStore
+
+
+BASE = datetime(2026, 9, 4, 21, 0, tzinfo=timezone.utc)
+
+
+def _event(event_id: str, offset: int = 0) -> HMAAEvent:
+    return HMAAEvent(
+        event_id=event_id,
+        mission_id="SIM-PERSIST-001",
+        source_system="synthetic-sil",
+        event_type="OBSERVATION",
+        source_timestamp=BASE + timedelta(seconds=offset),
+        ingest_timestamp=BASE + timedelta(seconds=offset),
+        payload={"offset": offset},
+    )
+
+
+def test_append_only_store_preserves_chain_and_secure_permissions(tmp_path):
+    store = HMAAEvidenceStore(tmp_path / "data")
+    first = seal_event(_event("E1"))
+    second = seal_event(_event("E2", 1), first.event_hash)
+
+    store.append(first, evaluate_event_assurance())
+    store.append(second, evaluate_event_assurance())
+
+    records = store.read_recent(limit=10, mission_id="SIM-PERSIST-001")
+    assert [record.event.event_id for record in records] == ["E1", "E2"]
+    assert records[-1].event.previous_event_hash == first.event_hash
+    assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(store.root.stat().st_mode) == 0o700
+
+
+def test_store_rejects_unsealed_event(tmp_path):
+    store = HMAAEvidenceStore(tmp_path / "data")
+    with pytest.raises(ValueError, match="cryptographic seal"):
+        store.append(_event("E1"), evaluate_event_assurance())
+
+
+def test_store_rejects_non_contiguous_mission_chain(tmp_path):
+    store = HMAAEvidenceStore(tmp_path / "data")
+    first = seal_event(_event("E1"))
+    store.append(first, evaluate_event_assurance())
+
+    unrelated_head = "sha256:" + ("0" * 64)
+    discontinuous = seal_event(_event("E2", 1), unrelated_head)
+    with pytest.raises(ValueError, match="continue the persisted"):
+        store.append(discontinuous, evaluate_event_assurance())
+
+
+def test_status_does_not_expose_absolute_data_directory(tmp_path):
+    store = HMAAEvidenceStore(tmp_path / "private-data")
+    status = store.status()
+
+    assert status["append_only_file"] == "hmaa_evidence.jsonl"
+    assert str(tmp_path) not in repr(status)
+
+
+def test_hmaa_evidence_symlink_swap_is_rejected(tmp_path):
+    store = HMAAEvidenceStore(tmp_path / "data")
+    first = seal_event(_event("E1"))
+    store.append(first, evaluate_event_assurance())
+
+    outside = tmp_path / "outside-evidence.jsonl"
+    outside.write_text("{}\n", encoding="utf-8")
+    store.path.unlink()
+    store.path.symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="HMAA evidence file"):
+        store.read_recent(limit=1)
+
+    assert outside.read_text(encoding="utf-8") == "{}\n"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
@@ -12,6 +12,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from . import __version__
 from .auth import Role, require_admin, resolve_role, validate_runtime_secrets
+from .hmaa_storage import HMAAEvidenceStore
 from .limits import MAX_REQUEST_BYTES
 from .models import AuditRecord, RegistryPatch, RelayRequest, RelayResponse
 from .storage import DurableStore
@@ -82,6 +83,7 @@ async def lifespan(app: FastAPI):
     os.umask(0o077)
     validate_runtime_secrets()
     app.state.store = DurableStore()
+    app.state.hmaa_store = HMAAEvidenceStore()
     app.state.store.append_audit(
         AuditRecord.create(
             event="service_started",
@@ -120,6 +122,10 @@ def store(request: Request) -> DurableStore:
     return request.app.state.store
 
 
+def hmaa_store(request: Request) -> HMAAEvidenceStore:
+    return request.app.state.hmaa_store
+
+
 @app.get("/health")
 def health() -> dict[str, object]:
     return {
@@ -132,6 +138,8 @@ def health() -> dict[str, object]:
             "liveness": "/livez",
             "readiness": "/readyz",
             "audit": "/v1/audit?limit=50",
+            "hmaa_status": "/v1/hmaa/status",
+            "hmaa_evidence": "/v1/hmaa/evidence?limit=50",
             "registry": "/admin/registry",
             "relay": "/v1/relay",
             "selftest": "/admin/selftest",
@@ -164,9 +172,41 @@ code{color:#9ad5ff} .ok{color:#96e6a1}
 </style></head><body><h1>Worldshepherd SARA</h1>
 <p class="ok">Local administration interface is online.</p>
 <div class="card"><strong>Authority separation</strong><p>CRE1AWS approves high-impact releases. SSPADAWANZZ operates the local service.</p></div>
-<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/admin/registry</code>, <code>/admin/selftest</code></p></div>
+<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/v1/hmaa/status</code>, <code>/v1/hmaa/evidence</code>, <code>/admin/registry</code>, <code>/admin/selftest</code></p></div>
 <div class="card"><strong>Security boundary</strong><p>Tokens are never stored in this page. Use Bearer authentication from an approved local client.</p></div>
 </body></html>"""
+
+
+@app.get("/v1/hmaa/status")
+def hmaa_status(
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, object]:
+    require_admin(role)
+    evidence_store = hmaa_store(request)
+    storage_ok, storage_detail = evidence_store.check_storage()
+    return {
+        "ok": storage_ok,
+        "storage": storage_detail,
+        "status": evidence_store.status(),
+    }
+
+
+@app.get("/v1/hmaa/evidence")
+def hmaa_evidence(
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    mission_id: Annotated[str | None, Query(min_length=1, max_length=128)] = None,
+) -> dict[str, object]:
+    require_admin(role)
+    records = hmaa_store(request).read_recent(
+        limit=limit,
+        mission_id=mission_id,
+    )
+    return {
+        "records": [record.model_dump(mode="json") for record in records]
+    }
 
 
 @app.post("/v1/relay", response_model=RelayResponse)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from datetime import datetime, timezone
 from enum import Enum
@@ -72,6 +73,35 @@ def seal_event(event: HMAAEvent, previous_event_hash: str | None = None) -> HMAA
     return candidate.model_copy(update={"event_hash": f"sha256:{digest}"})
 
 
+def verify_event_seal(event: HMAAEvent) -> bool:
+    if event.event_hash is None:
+        return False
+    candidate = event.model_copy(update={"event_hash": None})
+    expected_hash = "sha256:" + hashlib.sha256(canonical_event_bytes(candidate)).hexdigest()
+    return hmac.compare_digest(event.event_hash, expected_hash)
+
+
+def event_identity_key(event: HMAAEvent) -> str:
+    identity = "\x1f".join(
+        (event.mission_id, event.source_system, event.event_id)
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(identity).hexdigest()
+
+
+def event_source_fingerprint(event: HMAAEvent) -> str:
+    body = event.model_dump(
+        mode="json",
+        exclude={"ingest_timestamp", "previous_event_hash", "event_hash"},
+    )
+    encoded = json.dumps(
+        body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
 def verify_chain(events: list[HMAAEvent]) -> tuple[bool, list[str]]:
     errors: list[str] = []
     expected_previous: str | None = None
@@ -104,6 +134,7 @@ def evaluate_event_assurance(
     connection_healthy: bool = True,
     policy_engine_available: bool = True,
     duplicate_event: bool = False,
+    conflicting_replay: bool = False,
     out_of_order_event: bool = False,
     checksum_valid: bool = True,
 ) -> AssuranceAssessment:
@@ -118,6 +149,8 @@ def evaluate_event_assurance(
 
     if not checksum_valid:
         review_reasons.append("evidence checksum validation failed")
+    if conflicting_replay:
+        review_reasons.append("event identity replayed with conflicting source content")
     if out_of_order_event:
         review_reasons.append("event chronology is out of order")
     if duplicate_event:

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_state.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_state.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from .hmaa import (
+    AssuranceAssessment,
+    HMAAEvent,
+    event_identity_key,
+    event_source_fingerprint,
+    evaluate_event_assurance,
+)
+
+
+class ReplayObservation(BaseModel):
+    deduplication_key: str
+    source_fingerprint: str
+    duplicate_event: bool = False
+    conflicting_replay: bool = False
+
+
+class ChronologyObservation(BaseModel):
+    scope_key: str
+    previous_latest_source_timestamp: datetime | None = None
+    skew_seconds: float = 0.0
+    out_of_order_event: bool = False
+
+
+class HMAAStateObservation(BaseModel):
+    replay: ReplayObservation
+    chronology: ChronologyObservation
+
+
+class HMAAAssuranceState:
+    def __init__(self, clock_skew_tolerance_seconds: float = 2.0) -> None:
+        if clock_skew_tolerance_seconds < 0:
+            raise ValueError("clock skew tolerance must be non-negative")
+        self.clock_skew_tolerance_seconds = float(clock_skew_tolerance_seconds)
+        self._seen_fingerprints: dict[str, str] = {}
+        self._latest_source_timestamps: dict[str, datetime] = {}
+
+    @staticmethod
+    def _chronology_scope(event: HMAAEvent) -> str:
+        subject = event.entity_id or event.task_id or "mission"
+        return "\x1f".join((event.mission_id, event.source_system, subject))
+
+    def observe(self, event: HMAAEvent) -> HMAAStateObservation:
+        identity = event_identity_key(event)
+        fingerprint = event_source_fingerprint(event)
+        prior_fingerprint = self._seen_fingerprints.get(identity)
+
+        duplicate = prior_fingerprint == fingerprint if prior_fingerprint else False
+        conflicting = (
+            prior_fingerprint is not None and prior_fingerprint != fingerprint
+        )
+        if prior_fingerprint is None:
+            self._seen_fingerprints[identity] = fingerprint
+
+        scope = self._chronology_scope(event)
+        previous_latest = self._latest_source_timestamps.get(scope)
+        skew_seconds = 0.0
+        out_of_order = False
+
+        if previous_latest is not None:
+            skew_seconds = max(
+                0.0,
+                (previous_latest - event.source_timestamp).total_seconds(),
+            )
+            out_of_order = skew_seconds > self.clock_skew_tolerance_seconds
+
+        if previous_latest is None or event.source_timestamp > previous_latest:
+            self._latest_source_timestamps[scope] = event.source_timestamp
+
+        return HMAAStateObservation(
+            replay=ReplayObservation(
+                deduplication_key=identity,
+                source_fingerprint=fingerprint,
+                duplicate_event=duplicate,
+                conflicting_replay=conflicting,
+            ),
+            chronology=ChronologyObservation(
+                scope_key=scope,
+                previous_latest_source_timestamp=previous_latest,
+                skew_seconds=skew_seconds,
+                out_of_order_event=out_of_order,
+            ),
+        )
+
+    def assess(
+        self,
+        event: HMAAEvent,
+        *,
+        connection_healthy: bool = True,
+        policy_engine_available: bool = True,
+        checksum_valid: bool = True,
+    ) -> tuple[HMAAStateObservation, AssuranceAssessment]:
+        observation = self.observe(event)
+        assessment = evaluate_event_assurance(
+            connection_healthy=connection_healthy,
+            policy_engine_available=policy_engine_available,
+            duplicate_event=observation.replay.duplicate_event,
+            conflicting_replay=observation.replay.conflicting_replay,
+            out_of_order_event=observation.chronology.out_of_order_event,
+            checksum_valid=checksum_valid,
+        )
+        return observation, assessment
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "clock_skew_tolerance_seconds": self.clock_skew_tolerance_seconds,
+            "deduplication_identities": len(self._seen_fingerprints),
+            "chronology_scopes": len(self._latest_source_timestamps),
+        }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_storage.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_storage.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+from .hmaa import AssuranceAssessment, HMAAEvent, verify_event_seal
+from .storage import DurableStore
+
+
+MAX_HMAA_LINE_BYTES = 262_144
+
+
+class HMAAPersistedRecord(BaseModel):
+    recorded_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    event: HMAAEvent
+    assessment: AssuranceAssessment
+    state: dict[str, Any] | None = None
+
+
+class HMAAEvidenceStore:
+    def __init__(self, data_dir: str | Path | None = None) -> None:
+        root = Path(data_dir or os.getenv("SARA_DATA_DIR", "./data")).resolve()
+        root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        DurableStore._secure_mode(root, 0o700, "HMAA data directory")
+        self.root = root
+        self.path = root / "hmaa_evidence.jsonl"
+        self._lock = threading.RLock()
+        if self.path.exists():
+            DurableStore._secure_mode(self.path, 0o600, "HMAA evidence file")
+
+    def append(
+        self,
+        event: HMAAEvent,
+        assessment: AssuranceAssessment,
+        *,
+        state: dict[str, Any] | None = None,
+    ) -> HMAAPersistedRecord:
+        if not verify_event_seal(event):
+            raise ValueError("HMAA event must carry a valid cryptographic seal")
+
+        with self._lock:
+            prior = self.read_recent(limit=1, mission_id=event.mission_id)
+            expected_previous = prior[-1].event.event_hash if prior else None
+            if event.previous_event_hash != expected_previous:
+                raise ValueError(
+                    "HMAA event does not continue the persisted mission evidence chain"
+                )
+
+            record = HMAAPersistedRecord(
+                event=event,
+                assessment=assessment,
+                state=state,
+            )
+            encoded = record.model_dump_json(exclude_none=True).encode("utf-8")
+            if len(encoded) > MAX_HMAA_LINE_BYTES:
+                raise ValueError("HMAA evidence record exceeds the maximum line size")
+
+            descriptor = os.open(
+                self.path,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_APPEND
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+            )
+            try:
+                DurableStore._secure_descriptor(
+                    descriptor, 0o600, "HMAA evidence file"
+                )
+                with os.fdopen(descriptor, "ab") as handle:
+                    handle.write(encoded + b"\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            except Exception:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+                raise
+
+            DurableStore._secure_mode(
+                self.path, 0o600, "HMAA evidence file"
+            )
+            return record
+
+    def read_recent(
+        self,
+        limit: int,
+        mission_id: str | None = None,
+    ) -> list[HMAAPersistedRecord]:
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+
+        with self._lock:
+            try:
+                self.path.lstat()
+            except FileNotFoundError:
+                return []
+
+            descriptor = DurableStore._open_read_descriptor(
+                self.path, "HMAA evidence file"
+            )
+            matches: list[HMAAPersistedRecord] = []
+            with os.fdopen(descriptor, "rb") as handle:
+                while True:
+                    raw = handle.readline(MAX_HMAA_LINE_BYTES + 1)
+                    if not raw:
+                        break
+                    if len(raw) > MAX_HMAA_LINE_BYTES:
+                        if not raw.endswith(b"\n"):
+                            while raw and not raw.endswith(b"\n"):
+                                raw = handle.readline(MAX_HMAA_LINE_BYTES + 1)
+                        raise RuntimeError(
+                            "HMAA evidence corruption detected: line too long"
+                        )
+                    try:
+                        record = HMAAPersistedRecord.model_validate_json(raw)
+                    except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+                        raise RuntimeError(
+                            "HMAA evidence corruption detected: invalid record"
+                        ) from exc
+                    if mission_id is None or record.event.mission_id == mission_id:
+                        matches.append(record)
+                        if len(matches) > limit:
+                            del matches[0]
+            return matches
+
+    def status(self) -> dict[str, Any]:
+        latest = self.read_recent(limit=1)
+        return {
+            "configured": True,
+            "append_only_file": self.path.name,
+            "records_available": bool(latest),
+            "latest_event_hash": (
+                latest[-1].event.event_hash if latest else None
+            ),
+            "latest_mission_id": (
+                latest[-1].event.mission_id if latest else None
+            ),
+        }
+
+    def check_storage(self) -> tuple[bool, str]:
+        try:
+            DurableStore._secure_mode(
+                self.root, 0o700, "HMAA data directory"
+            )
+            if self.path.exists():
+                DurableStore._secure_mode(
+                    self.path, 0o600, "HMAA evidence file"
+                )
+                self.read_recent(limit=1)
+        except (OSError, RuntimeError, ValueError) as exc:
+            return False, str(exc)
+        return True, "HMAA evidence storage is readable and secured"


### PR DESCRIPTION
## Summary
Advances Worldshepherd High-Mach Autonomy Assurance from the merged v0.2 baseline with deterministic replay controls, clock-skew-aware chronology, secured local evidence persistence, and an authenticated read-only assurance API.

### Added
- stable SHA-256 replay identity and source fingerprinting
- exact replay detection -> WARN
- conflicting replay detection -> REVIEW
- per-mission/source/subject chronology tracking with explicit skew tolerance
- sealed append-only HMAA JSONL evidence store under SARA data-directory security conventions
- chain-continuity enforcement, fsync, 0700 directory / 0600 evidence file modes
- malformed/oversized evidence rejection and symlink-swap defense
- admin-only `GET /v1/hmaa/status`
- admin-only `GET /v1/hmaa/evidence`
- synthetic unit/API tests for replay, chronology, storage, authorization, filtering, and persistence

### Safety / claims boundary
This remains a non-flight-control assurance sidecar. No event-ingest or vehicle-control write API is exposed. No claim is made of production interoperability with Anduril Lattice, Hermeus Quarterhorse, or any operational government mission system. Tests use synthetic data only.

### Validation gate
Run the repository's protected SARA CI, resilience/recovery workflows, and CodeQL. Merge only after required gates are green.