### PR TITLE
WS-HMAA v0.4: public Lattice contract and interoperability evidence harness

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_4.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_4.md
@@ -1,0 +1,72 @@
+# WS-HMAA v0.4 — Public Lattice Contract Harness
+
+Status: IMPLEMENTED IN SOFTWARE / PUBLIC-CONTRACT SYNTHETIC VALIDATION ONLY
+
+## Objective
+
+WS-HMAA v0.4 creates a credentials-free interoperability preparation layer around the public Lattice REST streaming contract. It does not connect to a Lattice deployment and does not add publish, task-create, task-status, manual-control, or vehicle-control operations.
+
+The purpose is to make external sandbox validation a narrow evidence exercise instead of a first-time integration effort.
+
+## Public contract basis
+
+The implementation is based on public Lattice documentation current as of 2026-09-04:
+
+- `POST /api/v1/entities/stream` is a one-way SSE stream that returns entity or heartbeat messages and supports `heartbeatIntervalMS`, `preExistingOnly`, `componentsToInclude`, and optional filtering.
+- `POST /api/v1/tasks/stream` is an SSE task-update stream that returns task-event or heartbeat messages. Its public request contract includes `heartbeatIntervalMs`, `rateLimit`, `excludePreexistingTasks`, and optional filters.
+- A nonzero task `rateLimit` must be at least 250 ms.
+- `parentTaskId` is mutually exclusive with `updateStartTime`, `assignee`, `statusFilter`, and `taskType`.
+- Lattice Sandboxes is documented as a secure isolated simulated-data environment for development and testing.
+
+References:
+
+- https://developer.anduril.com/reference/rest/entities/stream-entities
+- https://developer.anduril.com/reference/rest/tasks/stream-tasks
+- https://developer.anduril.com/guides/developer-tools/sandboxes
+
+## Added software boundary
+
+`hmaa_lattice_contract.py` adds:
+
+- request-contract validation for the public entity and task stream fields used by WS-HMAA;
+- one-of envelope validation for heartbeat/entity and heartbeat/task-event responses;
+- deterministic SHA-256 source-event identities so replay detection survives reconnects;
+- normalization into the existing `HMAAEvent` evidence model;
+- a runtime-checkable `LatticeReadTransport` protocol containing only `stream_entities` and `stream_tasks`.
+
+There is deliberately no concrete HTTP client and no credential handling in v0.4.
+
+## Interoperability evidence replay
+
+`hmaa_interop.py` replays public-contract-shaped synthetic messages through:
+
+1. contract parsing;
+2. HMAA replay/chronology assurance state;
+3. SHA-256 event sealing;
+4. evidence-bundle verification;
+5. an interoperability manifest.
+
+The manifest records:
+
+- the public contract version;
+- a source label;
+- fixture SHA-256;
+- event/disposition counts;
+- final evidence-chain hash;
+- `live_environment_validated=false`.
+
+That last field is intentional and must remain false until an authorized external environment is actually exercised.
+
+## Acceptance boundary
+
+Passing v0.4 demonstrates that Worldshepherd can validate and normalize synthetic messages shaped to the documented public stream contract. It does **not** demonstrate:
+
+- possession of Lattice credentials;
+- access to Lattice Sandboxes;
+- successful authentication;
+- live SSE/gRPC connectivity;
+- production Lattice interoperability;
+- Hermeus Quarterhorse integration;
+- flight-control, task-execution, or weapons authority.
+
+The next evidence tier is an authorized Lattice Sandbox read-only connection using separately provisioned credentials and captured interoperability evidence. No production claim is permitted before that test is repeatable.

--- a/deployments/sara_verified_local_v1/fixtures/hmaa_lattice_public_contract.json
+++ b/deployments/sara_verified_local_v1/fixtures/hmaa_lattice_public_contract.json
@@ -1,0 +1,59 @@
+{
+  "entity_request": {
+    "heartbeatIntervalMS": 30000,
+    "preExistingOnly": false,
+    "componentsToInclude": ["aliases", "locationUncertainty"]
+  },
+  "task_request": {
+    "heartbeatIntervalMs": 30000,
+    "rateLimit": 250,
+    "excludePreexistingTasks": true
+  },
+  "stream_items": [
+    {
+      "stream": "entities",
+      "message": {
+        "heartbeat": {
+          "timestamp": "2026-09-04T22:30:00Z",
+          "sequence": 1
+        }
+      }
+    },
+    {
+      "stream": "entities",
+      "message": {
+        "entity": {
+          "eventType": "UPDATE",
+          "entity": {
+            "entityId": "AIRCRAFT-SIM-1",
+            "timestamp": "2026-09-04T22:30:01Z",
+            "aliases": {"name": "Synthetic Contract Entity"}
+          }
+        }
+      }
+    },
+    {
+      "stream": "tasks",
+      "message": {
+        "heartbeat": {
+          "timestamp": "2026-09-04T22:30:02Z",
+          "sequence": 1
+        }
+      }
+    },
+    {
+      "stream": "tasks",
+      "message": {
+        "task_event": {
+          "eventType": "UPDATE",
+          "task": {
+            "taskId": "TASK-SIM-1",
+            "agentId": "AIRCRAFT-SIM-1",
+            "status": "in_progress",
+            "updateTime": "2026-09-04T22:30:03Z"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_contract.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_contract.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worldshepherd_sara.hmaa_lattice_contract import (
+    LATTICE_PUBLIC_CONTRACT_VERSION,
+    LatticeEnvelopeKind,
+    LatticeReadTransport,
+    LatticeStream,
+    parse_entity_stream_message,
+    parse_task_stream_message,
+    validate_entity_stream_request,
+    validate_task_stream_request,
+)
+from worldshepherd_sara.hmaa_interop import run_public_contract_replay
+
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "hmaa_lattice_public_contract.json"
+
+
+def _fixture() -> dict[str, object]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_public_contract_fixture_requests_validate():
+    fixture = _fixture()
+    assert validate_entity_stream_request(fixture["entity_request"])[
+        "heartbeatIntervalMS"
+    ] == 30000
+    assert validate_task_stream_request(fixture["task_request"])["rateLimit"] == 250
+
+
+def test_task_rate_limit_contract_is_enforced():
+    with pytest.raises(ValueError, match="at least 250"):
+        validate_task_stream_request({"rateLimit": 249})
+    assert validate_task_stream_request({"rateLimit": 0})["rateLimit"] == 0
+
+
+def test_parent_task_id_contract_rejects_mutually_exclusive_filters():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        validate_task_stream_request(
+            {"parentTaskId": "PARENT-1", "statusFilter": {"include": ["open"]}}
+        )
+
+
+def test_entity_request_contract_rejects_bad_heartbeat_and_components():
+    with pytest.raises(ValueError, match="positive integer"):
+        validate_entity_stream_request({"heartbeatIntervalMS": 0})
+    with pytest.raises(ValueError, match="non-empty strings"):
+        validate_entity_stream_request({"componentsToInclude": [""]})
+
+
+def test_entity_envelope_requires_exactly_one_variant():
+    with pytest.raises(ValueError, match="exactly one"):
+        parse_entity_stream_message({}, mission_id="SIM-CONTRACT")
+    with pytest.raises(ValueError, match="exactly one"):
+        parse_entity_stream_message(
+            {
+                "heartbeat": {"timestamp": "2026-09-04T22:30:00Z"},
+                "entity": {"entity": {"entityId": "E-1"}},
+            },
+            mission_id="SIM-CONTRACT",
+        )
+
+
+def test_task_envelope_requires_exactly_one_variant():
+    with pytest.raises(ValueError, match="exactly one"):
+        parse_task_stream_message({}, mission_id="SIM-CONTRACT")
+
+
+def test_identical_public_stream_envelope_gets_stable_source_event_identity():
+    message = {
+        "entity": {
+            "eventType": "UPDATE",
+            "entity": {
+                "entityId": "AIRCRAFT-SIM-1",
+                "timestamp": "2026-09-04T22:30:01Z",
+            },
+        }
+    }
+    first = parse_entity_stream_message(message, mission_id="SIM-CONTRACT")
+    second = parse_entity_stream_message(message, mission_id="SIM-CONTRACT")
+
+    assert first.source_event_id == second.source_event_id
+    assert first.hmaa_event.event_id == second.hmaa_event.event_id
+    assert first.kind == LatticeEnvelopeKind.ENTITY
+    assert first.stream == LatticeStream.ENTITIES
+
+
+def test_fixture_messages_normalize_into_expected_contract_kinds():
+    fixture = _fixture()
+    items = fixture["stream_items"]
+    entity_heartbeat = parse_entity_stream_message(
+        items[0]["message"], mission_id="SIM-CONTRACT"
+    )
+    entity = parse_entity_stream_message(
+        items[1]["message"], mission_id="SIM-CONTRACT"
+    )
+    task_heartbeat = parse_task_stream_message(
+        items[2]["message"], mission_id="SIM-CONTRACT"
+    )
+    task = parse_task_stream_message(
+        items[3]["message"], mission_id="SIM-CONTRACT"
+    )
+
+    assert entity_heartbeat.kind == LatticeEnvelopeKind.HEARTBEAT
+    assert entity.kind == LatticeEnvelopeKind.ENTITY
+    assert entity.hmaa_event.entity_id == "AIRCRAFT-SIM-1"
+    assert task_heartbeat.kind == LatticeEnvelopeKind.HEARTBEAT
+    assert task.kind == LatticeEnvelopeKind.TASK
+    assert task.hmaa_event.task_id == "TASK-SIM-1"
+
+
+def test_public_contract_replay_emits_verifiable_non_live_manifest():
+    fixture = _fixture()
+    result = run_public_contract_replay(
+        mission_id="SIM-LATTICE-CONTRACT-001",
+        items=fixture["stream_items"],
+    )
+
+    assert result.manifest.contract_version == LATTICE_PUBLIC_CONTRACT_VERSION
+    assert result.manifest.live_environment_validated is False
+    assert result.manifest.event_count == 4
+    assert result.manifest.fixture_sha256.startswith("sha256:")
+    assert result.manifest.final_chain_hash == result.evidence_bundle.final_chain_hash
+    assert len(result.evidence_bundle.events) == 4
+    assert result.manifest.disposition_counts == {"ALLOW": 4}
+
+
+def test_read_transport_protocol_contains_only_read_stream_methods():
+    class FakeReadTransport:
+        def stream_entities(self, request):
+            return []
+
+        def stream_tasks(self, request):
+            return []
+
+    fake = FakeReadTransport()
+    assert isinstance(fake, LatticeReadTransport)
+    assert not hasattr(fake, "publish_entity")
+    assert not hasattr(fake, "create_task")

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_interop.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_interop.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+from pydantic import BaseModel, Field
+
+from .hmaa import (
+    AssuranceAssessment,
+    HMAAEvidenceBundle,
+    build_evidence_bundle,
+    seal_event,
+)
+from .hmaa_lattice_contract import (
+    LATTICE_PUBLIC_CONTRACT_VERSION,
+    LatticeContractEvent,
+    LatticeStream,
+    parse_entity_stream_message,
+    parse_task_stream_message,
+)
+from .hmaa_state import HMAAAssuranceState, HMAAStateObservation
+
+
+class InteropStep(BaseModel):
+    contract_event: LatticeContractEvent
+    state: HMAAStateObservation
+    assessment: AssuranceAssessment
+
+
+class InteropEvidenceManifest(BaseModel):
+    contract_version: str = LATTICE_PUBLIC_CONTRACT_VERSION
+    source_label: str
+    mission_id: str
+    live_environment_validated: bool = False
+    fixture_sha256: str
+    event_count: int
+    disposition_counts: dict[str, int] = Field(default_factory=dict)
+    final_chain_hash: str | None = None
+
+
+class InteropRunResult(BaseModel):
+    manifest: InteropEvidenceManifest
+    evidence_bundle: HMAAEvidenceBundle
+    steps: list[InteropStep]
+
+
+def _fixture_digest(items: Sequence[Mapping[str, Any]]) -> str:
+    encoded = json.dumps(
+        list(items),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def run_public_contract_replay(
+    *,
+    mission_id: str,
+    items: Sequence[Mapping[str, Any]],
+    source_label: str = "synthetic-public-contract-fixture",
+    clock_skew_tolerance_seconds: float = 2.0,
+) -> InteropRunResult:
+    if not items:
+        raise ValueError("interop replay requires at least one stream item")
+
+    state = HMAAAssuranceState(
+        clock_skew_tolerance_seconds=clock_skew_tolerance_seconds
+    )
+    previous_hash: str | None = None
+    sealed_events = []
+    steps: list[InteropStep] = []
+    counts: Counter[str] = Counter()
+
+    for index, item in enumerate(items):
+        stream_value = item.get("stream")
+        message = item.get("message")
+        if not isinstance(message, Mapping):
+            raise ValueError(f"interop item[{index}] message must be an object")
+
+        try:
+            stream = LatticeStream(str(stream_value))
+        except ValueError as exc:
+            raise ValueError(
+                f"interop item[{index}] has unsupported stream {stream_value!r}"
+            ) from exc
+
+        if stream is LatticeStream.ENTITIES:
+            contract_event = parse_entity_stream_message(
+                message, mission_id=mission_id
+            )
+        else:
+            contract_event = parse_task_stream_message(
+                message, mission_id=mission_id
+            )
+
+        observation, assessment = state.assess(contract_event.hmaa_event)
+        sealed = seal_event(contract_event.hmaa_event, previous_hash)
+        previous_hash = sealed.event_hash
+        sealed_events.append(sealed)
+        counts[assessment.disposition.value] += 1
+        steps.append(
+            InteropStep(
+                contract_event=contract_event.model_copy(
+                    update={"hmaa_event": sealed}
+                ),
+                state=observation,
+                assessment=assessment,
+            )
+        )
+
+    bundle = build_evidence_bundle(mission_id, sealed_events)
+    manifest = InteropEvidenceManifest(
+        source_label=source_label,
+        mission_id=mission_id,
+        live_environment_validated=False,
+        fixture_sha256="sha256:" + _fixture_digest(items),
+        event_count=len(sealed_events),
+        disposition_counts=dict(sorted(counts.items())),
+        final_chain_hash=bundle.final_chain_hash,
+    )
+    return InteropRunResult(
+        manifest=manifest,
+        evidence_bundle=bundle,
+        steps=steps,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_contract.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_contract.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+from .hmaa import HMAAEvent
+from .hmaa_adapter import normalize_entity_event, normalize_task_event
+
+
+LATTICE_PUBLIC_CONTRACT_VERSION = "lattice-public-rest-contract-2026-09-04"
+
+
+class LatticeStream(StrEnum):
+    ENTITIES = "entities"
+    TASKS = "tasks"
+
+
+class LatticeEnvelopeKind(StrEnum):
+    HEARTBEAT = "heartbeat"
+    ENTITY = "entity"
+    TASK = "task"
+
+
+class LatticeContractEvent(BaseModel):
+    contract_version: str = LATTICE_PUBLIC_CONTRACT_VERSION
+    stream: LatticeStream
+    kind: LatticeEnvelopeKind
+    source_event_id: str
+    hmaa_event: HMAAEvent
+
+
+@runtime_checkable
+class LatticeReadTransport(Protocol):
+    """Credentials-agnostic, read-only transport boundary for future adapters."""
+
+    def stream_entities(
+        self, request: Mapping[str, Any]
+    ) -> Iterable[Mapping[str, Any]]: ...
+
+    def stream_tasks(
+        self, request: Mapping[str, Any]
+    ) -> Iterable[Mapping[str, Any]]: ...
+
+
+def _canonical_sha256(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _source_event_id(stream: LatticeStream, message: Mapping[str, Any]) -> str:
+    return f"lattice:{stream.value}:sha256:{_canonical_sha256(message)}"
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value.strip():
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    raise ValueError("stream heartbeat is missing a usable timestamp")
+
+
+def _heartbeat_timestamp(payload: Mapping[str, Any]) -> datetime:
+    for key in ("timestamp", "time", "sourceTimestamp", "source_timestamp"):
+        if key in payload:
+            return _parse_timestamp(payload[key])
+    raise ValueError("stream heartbeat is missing a timestamp")
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def validate_entity_stream_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(request)
+
+    if "heartbeatIntervalMS" in result:
+        value = result["heartbeatIntervalMS"]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError("heartbeatIntervalMS must be a positive integer")
+
+    if "preExistingOnly" in result and not isinstance(result["preExistingOnly"], bool):
+        raise ValueError("preExistingOnly must be boolean")
+
+    if "componentsToInclude" in result:
+        components = result["componentsToInclude"]
+        if not isinstance(components, list) or any(
+            not isinstance(item, str) or not item.strip() for item in components
+        ):
+            raise ValueError("componentsToInclude must be a list of non-empty strings")
+
+    if "filter" in result:
+        _require_mapping(result["filter"], "filter")
+
+    return result
+
+
+def validate_task_stream_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(request)
+
+    if "heartbeatIntervalMs" in result:
+        value = result["heartbeatIntervalMs"]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError("heartbeatIntervalMs must be a positive integer")
+
+    if "rateLimit" in result:
+        rate_limit = result["rateLimit"]
+        if isinstance(rate_limit, bool) or not isinstance(rate_limit, int):
+            raise ValueError("rateLimit must be an integer")
+        if rate_limit < 0 or (rate_limit != 0 and rate_limit < 250):
+            raise ValueError("rateLimit must be 0 or at least 250 milliseconds")
+
+    if "excludePreexistingTasks" in result and not isinstance(
+        result["excludePreexistingTasks"], bool
+    ):
+        raise ValueError("excludePreexistingTasks must be boolean")
+
+    parent_task_id = result.get("parentTaskId")
+    if parent_task_id is not None:
+        if not isinstance(parent_task_id, str) or not parent_task_id.strip():
+            raise ValueError("parentTaskId must be a non-empty string")
+        mutually_exclusive = {
+            "updateStartTime",
+            "assignee",
+            "statusFilter",
+            "taskType",
+        }
+        conflict = sorted(mutually_exclusive.intersection(result))
+        if conflict:
+            raise ValueError(
+                "parentTaskId is mutually exclusive with: " + ", ".join(conflict)
+            )
+
+    for field in ("assignee", "statusFilter", "taskType"):
+        if field in result:
+            _require_mapping(result[field], field)
+
+    if "updateStartTime" in result and (
+        not isinstance(result["updateStartTime"], str)
+        or not result["updateStartTime"].strip()
+    ):
+        raise ValueError("updateStartTime must be a non-empty timestamp string")
+
+    return result
+
+
+def parse_entity_stream_message(
+    message: Mapping[str, Any], *, mission_id: str
+) -> LatticeContractEvent:
+    heartbeat = message.get("heartbeat")
+    entity_wrapper = message.get("entity")
+    present = int(heartbeat is not None) + int(entity_wrapper is not None)
+    if present != 1:
+        raise ValueError("entity stream message must contain exactly one heartbeat or entity")
+
+    source_event_id = _source_event_id(LatticeStream.ENTITIES, message)
+    if heartbeat is not None:
+        heartbeat_payload = _require_mapping(heartbeat, "heartbeat")
+        event = HMAAEvent(
+            event_id=source_event_id,
+            mission_id=mission_id,
+            source_system="lattice-public-contract",
+            event_type="HEARTBEAT",
+            source_timestamp=_heartbeat_timestamp(heartbeat_payload),
+            payload={"stream": LatticeStream.ENTITIES.value, **dict(heartbeat_payload)},
+        )
+        return LatticeContractEvent(
+            stream=LatticeStream.ENTITIES,
+            kind=LatticeEnvelopeKind.HEARTBEAT,
+            source_event_id=source_event_id,
+            hmaa_event=event,
+        )
+
+    wrapper = _require_mapping(entity_wrapper, "entity")
+    entity_payload = _require_mapping(wrapper.get("entity", wrapper), "entity payload")
+    normalized_payload = dict(entity_payload)
+    stream_event_type = wrapper.get("eventType", wrapper.get("event_type"))
+    if stream_event_type is not None:
+        normalized_payload.setdefault("eventType", stream_event_type)
+    event = normalize_entity_event(normalized_payload, mission_id=mission_id).model_copy(
+        update={
+            "event_id": source_event_id,
+            "source_system": "lattice-public-contract",
+        }
+    )
+    return LatticeContractEvent(
+        stream=LatticeStream.ENTITIES,
+        kind=LatticeEnvelopeKind.ENTITY,
+        source_event_id=source_event_id,
+        hmaa_event=event,
+    )
+
+
+def parse_task_stream_message(
+    message: Mapping[str, Any], *, mission_id: str
+) -> LatticeContractEvent:
+    heartbeat = message.get("heartbeat")
+    task_wrapper = message.get("task_event", message.get("taskEvent"))
+    present = int(heartbeat is not None) + int(task_wrapper is not None)
+    if present != 1:
+        raise ValueError("task stream message must contain exactly one heartbeat or task_event")
+
+    source_event_id = _source_event_id(LatticeStream.TASKS, message)
+    if heartbeat is not None:
+        heartbeat_payload = _require_mapping(heartbeat, "heartbeat")
+        event = HMAAEvent(
+            event_id=source_event_id,
+            mission_id=mission_id,
+            source_system="lattice-public-contract",
+            event_type="HEARTBEAT",
+            source_timestamp=_heartbeat_timestamp(heartbeat_payload),
+            payload={"stream": LatticeStream.TASKS.value, **dict(heartbeat_payload)},
+        )
+        return LatticeContractEvent(
+            stream=LatticeStream.TASKS,
+            kind=LatticeEnvelopeKind.HEARTBEAT,
+            source_event_id=source_event_id,
+            hmaa_event=event,
+        )
+
+    wrapper = _require_mapping(task_wrapper, "task_event")
+    task_payload = _require_mapping(wrapper.get("task", wrapper), "task payload")
+    normalized_payload = dict(task_payload)
+    event_type = wrapper.get("eventType", wrapper.get("event_type"))
+    if event_type is not None and "status" not in normalized_payload:
+        normalized_payload["status"] = str(event_type)
+    event = normalize_task_event(normalized_payload, mission_id=mission_id).model_copy(
+        update={
+            "event_id": source_event_id,
+            "source_system": "lattice-public-contract",
+        }
+    )
+    return LatticeContractEvent(
+        stream=LatticeStream.TASKS,
+        kind=LatticeEnvelopeKind.TASK,
+        source_event_id=source_event_id,
+        hmaa_event=event,
+    )


### PR DESCRIPTION
## Summary
Adds a credentials-free interoperability-preparation layer based only on the documented public Lattice read-stream contract.

### Added
- read-only `LatticeReadTransport` protocol with entity/task stream methods only
- public entity-stream request validation (`heartbeatIntervalMS`, `preExistingOnly`, `componentsToInclude`, filter)
- public task-stream request validation including nonzero `rateLimit >= 250 ms` and `parentTaskId` mutual-exclusion rules
- one-of heartbeat/entity and heartbeat/task-event envelope validation
- deterministic SHA-256 source-event identities so HMAA replay detection remains stable across reconnect/replay
- normalization into the existing HMAA evidence model
- synthetic public-contract fixture for entity/task heartbeats and updates
- interoperability replay runner producing a sealed evidence chain and fixture hash
- evidence manifest explicitly recording `live_environment_validated=false`
- tests for contract constraints, envelope shape, stable identities, normalization, read-only boundary, and evidence replay

### Safety / claims boundary
No network client, credential handling, entity publish, task creation/status update, manual-control, vehicle-control, or other write/control operation is added. This PR does not claim access to Lattice Sandboxes, live Lattice interoperability, Hermeus Quarterhorse integration, or any operational mission-system integration.

### Public contract basis
Current public Anduril Lattice documentation for REST Stream Entities, REST Stream Tasks, and Lattice Sandboxes as reviewed 2026-09-04.

### Validation gate
Merge only after protected SARA CI/recovery/resilience gates and CodeQL are green.