### PR TITLE
WS-HMAA v0.5: authorized Sandbox read-only execution readiness

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_SANDBOX_ENV.example
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_SANDBOX_ENV.example
@@ -1,0 +1,6 @@
+# Copy the variable names into a local, ignored environment file or shell.
+# Never commit real credential values.
+
+LATTICE_ENDPOINT=
+ENVIRONMENT_TOKEN=
+SANDBOXES_TOKEN=

--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_5.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_5.md
@@ -1,0 +1,103 @@
+# WS-HMAA v0.5 — Authorized Sandbox Readiness
+
+Status: IMPLEMENTED IN SOFTWARE / NOT LIVE-VALIDATED
+
+## Objective
+
+WS-HMAA v0.5 turns the v0.4 public-contract harness into a bounded, credentials-aware **read-only** Sandbox execution path. This increment is designed so an authorized Lattice Sandbox can later be exercised without changing the assurance core or adding any operational write/control capability.
+
+No live Sandbox connection is performed as part of this increment, and `live_environment_validated` remains false.
+
+## Authentication basis
+
+Current public Lattice documentation states that Sandbox API requests require:
+
+- the Sandbox resource endpoint (`LATTICE_ENDPOINT`);
+- a Lattice bearer token (`ENVIRONMENT_TOKEN`), either a long-lived environment token or an OAuth-derived access token;
+- the account-level Sandbox bearer token (`SANDBOXES_TOKEN`) in the `Anduril-Sandbox-Authorization` header.
+
+For OAuth client credentials, public documentation states access tokens expire after approximately 30 minutes. v0.5 deliberately does **not** implement client-secret exchange or token refresh. It accepts a pre-provisioned bearer token only, keeping credential acquisition outside the assurance process.
+
+Official references:
+
+- https://developer.anduril.com/guides/developer-tools/sandboxes
+- https://developer.anduril.com/guides/getting-started/authenticate
+- https://developer.anduril.com/reference/rest/entities/stream-entities
+
+## Runtime environment contract
+
+Only these environment-variable names are consumed:
+
+```text
+LATTICE_ENDPOINT
+ENVIRONMENT_TOKEN
+SANDBOXES_TOKEN
+```
+
+Secret values are represented with Pydantic `SecretStr`, omitted from readiness reports, and never included in sanitized connection errors.
+
+## Transport controls
+
+`SandboxReadOnlySSETransport` implements the v0.4 `LatticeReadTransport` protocol and exposes only:
+
+- `stream_entities(...)`
+- `stream_tasks(...)`
+
+The concrete endpoint allowlist is exactly:
+
+```text
+/api/v1/entities/stream
+/api/v1/tasks/stream
+```
+
+The transport additionally enforces:
+
+- HTTPS-only endpoint configuration;
+- hostname-only base endpoint with no embedded credentials, path, query, fragment, or non-default port;
+- exact endpoint allowlisting;
+- blocked HTTP redirects to prevent bearer-header forwarding;
+- `Accept: text/event-stream` and content-type verification;
+- bounded SSE lines/events;
+- UTF-8 and JSON-object validation;
+- sanitized HTTP/network errors;
+- no arbitrary request method;
+- no entity publish, task creation/update, manual-control, or vehicle-control methods.
+
+## Finite evidence capture
+
+`capture_readonly_stream_evidence(...)` accepts a read-only transport plus a bounded capture plan. It samples at most the configured number of entity and task messages, closes the iterators, then passes those messages through the v0.4 public-contract parser and HMAA evidence chain.
+
+This allows a future authorized run to produce:
+
+1. public-contract validation;
+2. replay/chronology assessment;
+3. SHA-256 event-chain evidence;
+4. a fixture/capture digest and disposition counts;
+5. finite, reproducible evidence rather than an indefinitely open stream.
+
+The capture result still records `live_environment_validated=false`. A separate governed attestation step is required before that claim may change.
+
+## Acceptance boundary
+
+Passing v0.5 means Worldshepherd has an executable, CI-tested path prepared for an authorized Lattice Sandbox **read-only** trial. It does not establish:
+
+- that Sandbox credentials are currently available;
+- that authentication has succeeded against a live Sandbox;
+- that a live SSE stream has been received;
+- that Anduril or Hermeus has reviewed or approved this integration;
+- that Quarterhorse or any operational platform is integrated;
+- any flight-control, mission-command, weapons, or task-execution authority.
+
+## Authorized live-validation procedure
+
+When credentials are legitimately provisioned:
+
+1. Export the three runtime variables locally; never commit them.
+2. Run the redacted readiness check and confirm `live_environment_validated=false`.
+3. Exercise a finite read-only entity/task capture against the Sandbox.
+4. Preserve only governed evidence outputs; do not log bearer headers.
+5. Verify evidence-chain integrity and expected stream-envelope types.
+6. Repeat the read-only capture to establish reproducibility.
+7. Only after reproducible external evidence and review may a separate attestation record mark Sandbox read interoperability as validated.
+
+Production integration remains a later, independent gate.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_capture.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_capture.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from worldshepherd_sara.hmaa_lattice_capture import (
+    SandboxReadCapturePlan,
+    capture_readonly_stream_evidence,
+)
+from worldshepherd_sara.hmaa_lattice_contract import LatticeReadTransport
+
+
+class FakeReadTransport:
+    def __init__(self) -> None:
+        self.entity_closed = False
+        self.task_closed = False
+
+    def stream_entities(self, request):
+        try:
+            yield {
+                "heartbeat": {
+                    "timestamp": "2026-09-04T22:45:00Z",
+                    "sequence": 1,
+                }
+            }
+            yield {
+                "entity": {
+                    "eventType": "UPDATE",
+                    "entity": {
+                        "entityId": "AIRCRAFT-SIM-1",
+                        "timestamp": "2026-09-04T22:45:01Z",
+                    },
+                }
+            }
+            yield {
+                "entity": {
+                    "eventType": "UPDATE",
+                    "entity": {
+                        "entityId": "SHOULD-NOT-BE-CAPTURED",
+                        "timestamp": "2026-09-04T22:45:02Z",
+                    },
+                }
+            }
+        finally:
+            self.entity_closed = True
+
+    def stream_tasks(self, request):
+        try:
+            yield {
+                "heartbeat": {
+                    "timestamp": "2026-09-04T22:45:03Z",
+                    "sequence": 1,
+                }
+            }
+            yield {
+                "task_event": {
+                    "eventType": "UPDATE",
+                    "task": {
+                        "taskId": "TASK-SIM-1",
+                        "agentId": "AIRCRAFT-SIM-1",
+                        "status": "in_progress",
+                        "updateTime": "2026-09-04T22:45:04Z",
+                    },
+                }
+            }
+        finally:
+            self.task_closed = True
+
+
+def test_capture_runner_is_finite_closes_streams_and_builds_evidence():
+    transport = FakeReadTransport()
+    assert isinstance(transport, LatticeReadTransport)
+
+    result = capture_readonly_stream_evidence(
+        transport=transport,
+        mission_id="SIM-SANDBOX-CANDIDATE-001",
+        plan=SandboxReadCapturePlan(
+            entity_request={"heartbeatIntervalMS": 30000},
+            task_request={"heartbeatIntervalMs": 30000, "rateLimit": 250},
+            max_entity_messages=2,
+            max_task_messages=2,
+        ),
+    )
+
+    assert result.live_environment_validated is False
+    assert result.captured_entity_messages == 2
+    assert result.captured_task_messages == 2
+    assert result.interop.manifest.event_count == 4
+    assert result.interop.manifest.live_environment_validated is False
+    assert result.interop.manifest.disposition_counts == {"ALLOW": 4}
+    assert result.interop.evidence_bundle.final_chain_hash is not None
+    assert transport.entity_closed is True
+    assert transport.task_closed is True
+    assert all(
+        event.entity_id != "SHOULD-NOT-BE-CAPTURED"
+        for event in result.interop.evidence_bundle.events
+    )
+
+
+def test_capture_runner_can_sample_only_one_stream():
+    transport = FakeReadTransport()
+    result = capture_readonly_stream_evidence(
+        transport=transport,
+        mission_id="SIM-SANDBOX-CANDIDATE-002",
+        plan=SandboxReadCapturePlan(
+            max_entity_messages=1,
+            max_task_messages=0,
+        ),
+    )
+
+    assert result.captured_entity_messages == 1
+    assert result.captured_task_messages == 0
+    assert result.interop.manifest.event_count == 1
+
+
+def test_capture_runner_rejects_zero_message_plan():
+    transport = FakeReadTransport()
+    try:
+        capture_readonly_stream_evidence(
+            transport=transport,
+            mission_id="SIM-SANDBOX-CANDIDATE-003",
+            plan=SandboxReadCapturePlan(
+                max_entity_messages=0,
+                max_task_messages=0,
+            ),
+        )
+    except ValueError as exc:
+        assert "at least one" in str(exc)
+    else:
+        raise AssertionError("zero-message capture plan should fail")

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_sandbox.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_sandbox.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import io
+from urllib.error import HTTPError, URLError
+
+import pytest
+from pydantic import SecretStr
+
+from worldshepherd_sara.hmaa_lattice_contract import LatticeReadTransport
+from worldshepherd_sara.hmaa_lattice_sandbox import (
+    ENTITY_STREAM_PATH,
+    TASK_STREAM_PATH,
+    LatticeSandboxReadError,
+    SandboxReadConfig,
+    SandboxReadOnlySSETransport,
+    sandbox_readiness_report,
+)
+
+
+ENVIRONMENT_TOKEN = "environment-token-do-not-leak"
+SANDBOXES_TOKEN = "sandboxes-token-do-not-leak"
+
+
+def _config() -> SandboxReadConfig:
+    return SandboxReadConfig(
+        endpoint="sandbox-123.env.sandboxes.developer.anduril.com",
+        environment_token=SecretStr(ENVIRONMENT_TOKEN),
+        sandboxes_token=SecretStr(SANDBOXES_TOKEN),
+        timeout_seconds=5,
+        max_sse_event_bytes=4096,
+    )
+
+
+class FakeResponse:
+    def __init__(self, raw: bytes, content_type: str = "text/event-stream") -> None:
+        self._io = io.BytesIO(raw)
+        self.headers = {"Content-Type": content_type}
+        self.closed = False
+
+    def readline(self, limit: int = -1) -> bytes:
+        return self._io.readline(limit)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+        return False
+
+
+def test_config_normalizes_hostname_and_redacts_secrets():
+    config = _config()
+    assert config.endpoint == "https://sandbox-123.env.sandboxes.developer.anduril.com"
+    assert ENVIRONMENT_TOKEN not in repr(config)
+    assert SANDBOXES_TOKEN not in repr(config)
+
+    summary = config.redacted_summary()
+    assert summary["environment_token_present"] is True
+    assert summary["sandboxes_token_present"] is True
+    assert ENVIRONMENT_TOKEN not in repr(summary)
+    assert SANDBOXES_TOKEN not in repr(summary)
+    assert summary["live_environment_validated"] is False
+
+
+def test_config_from_env_uses_only_named_runtime_secrets(monkeypatch):
+    monkeypatch.setenv("LATTICE_ENDPOINT", "sandbox.env.sandboxes.developer.anduril.com")
+    monkeypatch.setenv("ENVIRONMENT_TOKEN", ENVIRONMENT_TOKEN)
+    monkeypatch.setenv("SANDBOXES_TOKEN", SANDBOXES_TOKEN)
+
+    config = SandboxReadConfig.from_env()
+    assert config.endpoint == "https://sandbox.env.sandboxes.developer.anduril.com"
+    assert config.environment_token.get_secret_value() == ENVIRONMENT_TOKEN
+    assert config.sandboxes_token.get_secret_value() == SANDBOXES_TOKEN
+
+
+def test_config_from_env_reports_missing_variable_names_only(monkeypatch):
+    monkeypatch.delenv("LATTICE_ENDPOINT", raising=False)
+    monkeypatch.delenv("ENVIRONMENT_TOKEN", raising=False)
+    monkeypatch.setenv("SANDBOXES_TOKEN", SANDBOXES_TOKEN)
+
+    with pytest.raises(ValueError) as exc_info:
+        SandboxReadConfig.from_env()
+
+    message = str(exc_info.value)
+    assert "LATTICE_ENDPOINT" in message
+    assert "ENVIRONMENT_TOKEN" in message
+    assert SANDBOXES_TOKEN not in message
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://sandbox.example",
+        "https://user:pass@sandbox.example",
+        "https://sandbox.example/api/v1/entities/stream",
+        "https://sandbox.example?token=bad",
+        "https://sandbox.example:8443",
+    ],
+)
+def test_endpoint_validation_rejects_unsafe_shapes(endpoint):
+    with pytest.raises(ValueError):
+        SandboxReadConfig(
+            endpoint=endpoint,
+            environment_token=SecretStr("x"),
+            sandboxes_token=SecretStr("y"),
+        )
+
+
+def test_readiness_report_never_claims_live_validation():
+    report = sandbox_readiness_report(_config())
+    assert report.ready_for_authorized_read_test is True
+    assert report.live_environment_validated is False
+    assert report.allowed_paths == [ENTITY_STREAM_PATH, TASK_STREAM_PATH]
+    assert "no_write_or_control_methods" in report.controls
+
+
+def test_transport_is_protocol_compatible_and_has_no_write_methods():
+    transport = SandboxReadOnlySSETransport(_config(), open_request=lambda r, t: None)
+    assert isinstance(transport, LatticeReadTransport)
+    assert not hasattr(transport, "publish_entity")
+    assert not hasattr(transport, "create_task")
+    assert not hasattr(transport, "update_task")
+    assert not hasattr(transport, "manual_control")
+
+
+def test_transport_builds_only_allowlisted_stream_requests_with_required_headers():
+    transport = SandboxReadOnlySSETransport(_config(), open_request=lambda r, t: None)
+    request = transport._build_stream_request(
+        ENTITY_STREAM_PATH,
+        {"preExistingOnly": True},
+    )
+    headers = {key.lower(): value for key, value in request.header_items()}
+
+    assert request.full_url.endswith(ENTITY_STREAM_PATH)
+    assert request.method == "POST"
+    assert headers["authorization"] == f"Bearer {ENVIRONMENT_TOKEN}"
+    assert headers["anduril-sandbox-authorization"] == f"Bearer {SANDBOXES_TOKEN}"
+    assert headers["accept"] == "text/event-stream"
+
+    with pytest.raises(ValueError, match="allowlist"):
+        transport._build_stream_request("/api/v1/entities", {})
+
+
+def test_entity_sse_stream_yields_json_objects_and_closes_response():
+    raw = (
+        b": keepalive\n"
+        b"data: {\"heartbeat\":{\"timestamp\":\"2026-09-04T22:40:00Z\"}}\n\n"
+        b"event: ignored-name\n"
+        b"data: {\"entity\":{\"eventType\":\"UPDATE\",\"entity\":{\"entityId\":\"E-1\",\"timestamp\":\"2026-09-04T22:40:01Z\"}}}\n\n"
+    )
+    response = FakeResponse(raw)
+    captured_request = {}
+
+    def open_request(request, timeout):
+        captured_request["request"] = request
+        captured_request["timeout"] = timeout
+        return response
+
+    transport = SandboxReadOnlySSETransport(_config(), open_request=open_request)
+    messages = list(transport.stream_entities({"heartbeatIntervalMS": 30000}))
+
+    assert len(messages) == 2
+    assert "heartbeat" in messages[0]
+    assert "entity" in messages[1]
+    assert response.closed is True
+    assert captured_request["timeout"] == 5
+
+
+def test_stream_rejects_unexpected_content_type_without_exposing_tokens():
+    response = FakeResponse(b"{}", content_type="application/json")
+    transport = SandboxReadOnlySSETransport(
+        _config(), open_request=lambda request, timeout: response
+    )
+
+    with pytest.raises(LatticeSandboxReadError) as exc_info:
+        list(transport.stream_tasks({"rateLimit": 250}))
+
+    message = str(exc_info.value)
+    assert "unexpected content type" in message
+    assert ENVIRONMENT_TOKEN not in message
+    assert SANDBOXES_TOKEN not in message
+
+
+def test_stream_sanitizes_network_errors_and_redirects():
+    def network_failure(request, timeout):
+        raise URLError(f"network problem containing {ENVIRONMENT_TOKEN}")
+
+    transport = SandboxReadOnlySSETransport(_config(), open_request=network_failure)
+    with pytest.raises(LatticeSandboxReadError) as exc_info:
+        list(transport.stream_entities({}))
+    assert ENVIRONMENT_TOKEN not in str(exc_info.value)
+
+    def redirect(request, timeout):
+        raise HTTPError(request.full_url, 302, "Found", {}, None)
+
+    redirect_transport = SandboxReadOnlySSETransport(_config(), open_request=redirect)
+    with pytest.raises(LatticeSandboxReadError, match="redirect blocked"):
+        list(redirect_transport.stream_entities({}))
+
+
+def test_stream_rejects_oversized_or_invalid_sse_data():
+    oversized = FakeResponse(b"data: " + (b"x" * 5000) + b"\n\n")
+    transport = SandboxReadOnlySSETransport(
+        _config(), open_request=lambda request, timeout: oversized
+    )
+    with pytest.raises(LatticeSandboxReadError, match="size limit"):
+        list(transport.stream_entities({}))
+
+    invalid = FakeResponse(b"data: not-json\n\n")
+    invalid_transport = SandboxReadOnlySSETransport(
+        _config(), open_request=lambda request, timeout: invalid
+    )
+    with pytest.raises(LatticeSandboxReadError, match="invalid JSON"):
+        list(invalid_transport.stream_entities({}))
+
+
+def test_transport_repr_is_secret_safe():
+    transport = SandboxReadOnlySSETransport(_config())
+    rendered = repr(transport)
+    assert "credentials=<redacted>" in rendered
+    assert ENVIRONMENT_TOKEN not in rendered
+    assert SANDBOXES_TOKEN not in rendered

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_capture.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_capture.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .hmaa_interop import InteropRunResult, run_public_contract_replay
+from .hmaa_lattice_contract import (
+    LatticeReadTransport,
+    validate_entity_stream_request,
+    validate_task_stream_request,
+)
+
+
+class SandboxReadCapturePlan(BaseModel):
+    entity_request: dict[str, Any] = Field(default_factory=dict)
+    task_request: dict[str, Any] = Field(default_factory=dict)
+    max_entity_messages: int = Field(default=4, ge=0, le=100)
+    max_task_messages: int = Field(default=4, ge=0, le=100)
+
+
+class SandboxReadCaptureResult(BaseModel):
+    live_environment_validated: bool = False
+    source_label: str = "authorized-sandbox-readonly-candidate"
+    captured_entity_messages: int
+    captured_task_messages: int
+    interop: InteropRunResult
+
+
+def _take_and_close(
+    values: Iterable[Mapping[str, Any]],
+    limit: int,
+) -> list[Mapping[str, Any]]:
+    if limit == 0:
+        return []
+    iterator: Iterator[Mapping[str, Any]] = iter(values)
+    captured: list[Mapping[str, Any]] = []
+    try:
+        for _ in range(limit):
+            try:
+                captured.append(next(iterator))
+            except StopIteration:
+                break
+    finally:
+        close = getattr(iterator, "close", None)
+        if callable(close):
+            close()
+    return captured
+
+
+def capture_readonly_stream_evidence(
+    *,
+    transport: LatticeReadTransport,
+    mission_id: str,
+    plan: SandboxReadCapturePlan,
+) -> SandboxReadCaptureResult:
+    if plan.max_entity_messages == 0 and plan.max_task_messages == 0:
+        raise ValueError("Sandbox read capture must request at least one stream message")
+
+    entity_request = validate_entity_stream_request(plan.entity_request)
+    task_request = validate_task_stream_request(plan.task_request)
+
+    entity_messages = _take_and_close(
+        transport.stream_entities(entity_request),
+        plan.max_entity_messages,
+    )
+    task_messages = _take_and_close(
+        transport.stream_tasks(task_request),
+        plan.max_task_messages,
+    )
+
+    items: list[dict[str, Any]] = []
+    items.extend(
+        {"stream": "entities", "message": dict(message)}
+        for message in entity_messages
+    )
+    items.extend(
+        {"stream": "tasks", "message": dict(message)}
+        for message in task_messages
+    )
+    if not items:
+        raise ValueError("Sandbox read capture produced no stream messages")
+
+    interop = run_public_contract_replay(
+        mission_id=mission_id,
+        items=items,
+        source_label="authorized-sandbox-readonly-candidate",
+    )
+    return SandboxReadCaptureResult(
+        live_environment_validated=False,
+        captured_entity_messages=len(entity_messages),
+        captured_task_messages=len(task_messages),
+        interop=interop,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_sandbox.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_sandbox.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, Field, SecretStr, field_validator
+
+from .hmaa_lattice_contract import (
+    LatticeReadTransport,
+    validate_entity_stream_request,
+    validate_task_stream_request,
+)
+
+
+ENTITY_STREAM_PATH = "/api/v1/entities/stream"
+TASK_STREAM_PATH = "/api/v1/tasks/stream"
+ALLOWED_READ_STREAM_PATHS = frozenset({ENTITY_STREAM_PATH, TASK_STREAM_PATH})
+SANDBOX_HOST_SUFFIX = ".env.sandboxes.developer.anduril.com"
+
+
+class LatticeSandboxReadError(RuntimeError):
+    """Sanitized read-only Sandbox transport error."""
+
+
+class SandboxReadConfig(BaseModel):
+    endpoint: str = Field(min_length=1)
+    environment_token: SecretStr
+    sandboxes_token: SecretStr
+    timeout_seconds: float = Field(default=30.0, gt=0, le=300)
+    max_sse_event_bytes: int = Field(default=1_048_576, ge=1024, le=8_388_608)
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, value: str) -> str:
+        raw = value.strip()
+        if not raw:
+            raise ValueError("LATTICE_ENDPOINT must not be empty")
+        candidate = raw if "://" in raw else f"https://{raw}"
+        parsed = urlsplit(candidate)
+        if parsed.scheme.lower() != "https":
+            raise ValueError("LATTICE_ENDPOINT must use HTTPS")
+        if not parsed.hostname:
+            raise ValueError("LATTICE_ENDPOINT must include a hostname")
+        if parsed.username or parsed.password:
+            raise ValueError("LATTICE_ENDPOINT must not contain user information")
+        if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+            raise ValueError("LATTICE_ENDPOINT must be a host endpoint without path/query/fragment")
+        if parsed.port not in (None, 443):
+            raise ValueError("LATTICE_ENDPOINT may only use the default HTTPS port")
+        hostname = parsed.hostname.lower()
+        if not hostname.endswith(SANDBOX_HOST_SUFFIX):
+            raise ValueError(
+                "LATTICE_ENDPOINT must be a documented Lattice Sandboxes environment host"
+            )
+        environment_id = hostname[: -len(SANDBOX_HOST_SUFFIX)]
+        if not environment_id or "." in environment_id:
+            raise ValueError("LATTICE_ENDPOINT Sandbox environment identifier is invalid")
+        return f"https://{hostname}"
+
+    @classmethod
+    def from_env(cls) -> "SandboxReadConfig":
+        required = {
+            "LATTICE_ENDPOINT": os.getenv("LATTICE_ENDPOINT"),
+            "ENVIRONMENT_TOKEN": os.getenv("ENVIRONMENT_TOKEN"),
+            "SANDBOXES_TOKEN": os.getenv("SANDBOXES_TOKEN"),
+        }
+        missing = sorted(name for name, value in required.items() if not value)
+        if missing:
+            raise ValueError(
+                "missing required Sandbox read environment variables: "
+                + ", ".join(missing)
+            )
+        return cls(
+            endpoint=required["LATTICE_ENDPOINT"],
+            environment_token=SecretStr(required["ENVIRONMENT_TOKEN"] or ""),
+            sandboxes_token=SecretStr(required["SANDBOXES_TOKEN"] or ""),
+        )
+
+    def redacted_summary(self) -> dict[str, Any]:
+        return {
+            "endpoint": self.endpoint,
+            "environment_token_present": bool(
+                self.environment_token.get_secret_value()
+            ),
+            "sandboxes_token_present": bool(self.sandboxes_token.get_secret_value()),
+            "timeout_seconds": self.timeout_seconds,
+            "max_sse_event_bytes": self.max_sse_event_bytes,
+            "allowed_paths": sorted(ALLOWED_READ_STREAM_PATHS),
+            "live_environment_validated": False,
+        }
+
+
+class SandboxReadinessReport(BaseModel):
+    ready_for_authorized_read_test: bool
+    live_environment_validated: bool = False
+    endpoint: str
+    allowed_paths: list[str]
+    credential_presence: dict[str, bool]
+    controls: list[str]
+
+
+def sandbox_readiness_report(config: SandboxReadConfig) -> SandboxReadinessReport:
+    summary = config.redacted_summary()
+    credential_presence = {
+        "environment_token": bool(summary["environment_token_present"]),
+        "sandboxes_token": bool(summary["sandboxes_token_present"]),
+    }
+    return SandboxReadinessReport(
+        ready_for_authorized_read_test=all(credential_presence.values()),
+        live_environment_validated=False,
+        endpoint=config.endpoint,
+        allowed_paths=sorted(ALLOWED_READ_STREAM_PATHS),
+        credential_presence=credential_presence,
+        controls=[
+            "https_only_endpoint",
+            "official_sandbox_host_suffix",
+            "exact_read_endpoint_allowlist",
+            "redirects_blocked",
+            "bounded_sse_event_size",
+            "secret_redacted_diagnostics",
+            "no_write_or_control_methods",
+        ],
+    )
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        raise HTTPError(req.full_url, code, "redirect blocked", headers, fp)
+
+
+OpenCallable = Callable[[Request, float], Any]
+
+
+def _default_open(request: Request, timeout: float) -> Any:
+    opener = build_opener(_NoRedirectHandler())
+    return opener.open(request, timeout=timeout)
+
+
+class SandboxReadOnlySSETransport(LatticeReadTransport):
+    """Read-only REST SSE transport for an authorized Lattice Sandbox.
+
+    Construction does not perform a network call. Only the two documented
+    stream endpoints are reachable through public methods.
+    """
+
+    def __init__(
+        self,
+        config: SandboxReadConfig,
+        *,
+        open_request: OpenCallable | None = None,
+    ) -> None:
+        self._config = config
+        self._open_request = open_request or _default_open
+
+    def __repr__(self) -> str:
+        return (
+            "SandboxReadOnlySSETransport("
+            f"endpoint={self._config.endpoint!r}, credentials=<redacted>)"
+        )
+
+    def _build_stream_request(
+        self,
+        path: str,
+        payload: Mapping[str, Any],
+    ) -> Request:
+        if path not in ALLOWED_READ_STREAM_PATHS:
+            raise ValueError("path is not in the WS-HMAA read-only endpoint allowlist")
+        body = json.dumps(
+            dict(payload),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return Request(
+            url=self._config.endpoint + path,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": (
+                    "Bearer " + self._config.environment_token.get_secret_value()
+                ),
+                "Anduril-Sandbox-Authorization": (
+                    "Bearer " + self._config.sandboxes_token.get_secret_value()
+                ),
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+            },
+        )
+
+    def _stream(
+        self,
+        path: str,
+        payload: Mapping[str, Any],
+    ) -> Iterator[Mapping[str, Any]]:
+        request = self._build_stream_request(path, payload)
+        try:
+            response = self._open_request(request, self._config.timeout_seconds)
+            with response:
+                content_type = str(response.headers.get("Content-Type", ""))
+                if "text/event-stream" not in content_type.lower():
+                    raise LatticeSandboxReadError(
+                        "Sandbox stream returned an unexpected content type"
+                    )
+                yield from self._iter_sse(response)
+        except LatticeSandboxReadError:
+            raise
+        except HTTPError as exc:
+            if 300 <= exc.code < 400:
+                raise LatticeSandboxReadError(
+                    f"Sandbox stream redirect blocked (HTTP {exc.code})"
+                ) from None
+            raise LatticeSandboxReadError(
+                f"Sandbox stream request failed (HTTP {exc.code})"
+            ) from None
+        except (URLError, TimeoutError, OSError) as exc:
+            raise LatticeSandboxReadError(
+                f"Sandbox stream connection failed ({type(exc).__name__})"
+            ) from None
+
+    def _iter_sse(self, response: Any) -> Iterator[Mapping[str, Any]]:
+        data_lines: list[str] = []
+        event_bytes = 0
+
+        def emit() -> Mapping[str, Any] | None:
+            nonlocal data_lines, event_bytes
+            if not data_lines:
+                event_bytes = 0
+                return None
+            raw_data = "\n".join(data_lines)
+            data_lines = []
+            event_bytes = 0
+            try:
+                value = json.loads(raw_data)
+            except json.JSONDecodeError as exc:
+                raise LatticeSandboxReadError(
+                    "Sandbox SSE event contained invalid JSON"
+                ) from exc
+            if not isinstance(value, Mapping):
+                raise LatticeSandboxReadError(
+                    "Sandbox SSE event JSON must be an object"
+                )
+            return value
+
+        while True:
+            raw = response.readline(self._config.max_sse_event_bytes + 1)
+            if not raw:
+                final = emit()
+                if final is not None:
+                    yield final
+                break
+            if len(raw) > self._config.max_sse_event_bytes:
+                raise LatticeSandboxReadError("Sandbox SSE line exceeded size limit")
+            event_bytes += len(raw)
+            if event_bytes > self._config.max_sse_event_bytes:
+                raise LatticeSandboxReadError("Sandbox SSE event exceeded size limit")
+            try:
+                line = raw.decode("utf-8").rstrip("\r\n")
+            except UnicodeDecodeError as exc:
+                raise LatticeSandboxReadError(
+                    "Sandbox SSE stream contained invalid UTF-8"
+                ) from exc
+
+            if line == "":
+                event = emit()
+                if event is not None:
+                    yield event
+                continue
+            if line.startswith(":"):
+                continue
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip(" "))
+
+    def stream_entities(
+        self, request: Mapping[str, Any]
+    ) -> Iterable[Mapping[str, Any]]:
+        validated = validate_entity_stream_request(request)
+        return self._stream(ENTITY_STREAM_PATH, validated)
+
+    def stream_tasks(
+        self, request: Mapping[str, Any]
+    ) -> Iterable[Mapping[str, Any]]:
+        validated = validate_task_stream_request(request)
+        return self._stream(TASK_STREAM_PATH, validated)


### PR DESCRIPTION
## Summary
Advances the merged v0.4 public-contract harness into a bounded, credentials-aware read-only execution path for a future authorized Lattice Sandbox trial.

### Added
- `SandboxReadConfig` consuming only `LATTICE_ENDPOINT`, `ENVIRONMENT_TOKEN`, and `SANDBOXES_TOKEN`
- secret-safe Pydantic `SecretStr` handling and redacted readiness reporting
- HTTPS-only endpoint validation restricted to documented `*.env.sandboxes.developer.anduril.com` hosts
- exact read-only endpoint allowlist:
  - `/api/v1/entities/stream`
  - `/api/v1/tasks/stream`
- bearer headers required by current Sandbox/Lattice public documentation
- blocked redirects to prevent credential forwarding
- bounded UTF-8/JSON SSE parsing with content-type validation
- sanitized HTTP/network errors that do not echo tokens or response bodies
- finite entity/task capture plan with explicit iterator closure
- capture output routed into the existing v0.4 public-contract replay/evidence chain
- environment-variable-name-only example file; no credentials committed
- unit tests for configuration, secret redaction, endpoint restrictions, headers, SSE parsing, redirect/network failure handling, size bounds, no-write boundary, and finite capture behavior

### Claims / safety boundary
No live Sandbox call is made by this PR. `live_environment_validated` remains false. No OAuth client-secret exchange or refresh is implemented, and no entity publish, task create/update, manual-control, flight-control, weapons, or arbitrary HTTP request path is exposed.

### Public documentation basis
Current Anduril Lattice Sandbox/authentication and Stream Entities documentation reviewed 2026-09-04.

### Validation gate
Merge only after the protected SARA CI/recovery/resilience suite and CodeQL are green.