### PR TITLE
WS-HMAA v0.6: short-lived Sandbox OAuth credential lifecycle

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_SANDBOX_ENV.example
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_SANDBOX_ENV.example
@@ -1,6 +1,13 @@
-# Copy the variable names into a local, ignored environment file or shell.
+# Copy only the variable names/mode you need into a local, ignored environment file or shell.
 # Never commit real credential values.
 
+# Common Sandbox endpoint and account-level Sandbox token.
 LATTICE_ENDPOINT=
-ENVIRONMENT_TOKEN=
 SANDBOXES_TOKEN=
+
+# Option A — pre-provisioned environment bearer token.
+ENVIRONMENT_TOKEN=
+
+# Option B — OAuth 2.0 client credentials for short-lived environment bearer tokens.
+LATTICE_CLIENT_ID=
+LATTICE_CLIENT_SECRET=

--- a/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_6.md
+++ b/deployments/sara_verified_local_v1/docs/WS_HMAA_V0_6.md
@@ -1,0 +1,110 @@
+# WS-HMAA v0.6 — Short-Lived Sandbox OAuth Credential Lifecycle
+
+Status: IMPLEMENTED IN SOFTWARE / NOT LIVE-VALIDATED
+
+## Objective
+
+WS-HMAA v0.6 adds a bounded OAuth 2.0 client-credentials lifecycle for the read-only Lattice Sandbox transport introduced in v0.5. It does not perform a live Sandbox call and does not add any entity publish, task create/update, manual-control, flight-control, weapons, or arbitrary HTTP operation.
+
+`live_environment_validated` remains false.
+
+## Public authentication basis
+
+Current public Anduril documentation reviewed 2026-09-04 describes the Sandbox machine-to-machine flow as:
+
+- `POST /api/v1/oauth/token` on the Sandbox environment endpoint;
+- `Content-Type: application/x-www-form-urlencoded`;
+- `Anduril-Sandbox-Authorization: Bearer <SANDBOXES_TOKEN>`;
+- form fields `grant_type=client_credentials`, `client_id`, and `client_secret`;
+- response fields including `access_token`, `token_type`, and `expires_in`;
+- cached short-lived access tokens refreshed before expiry rather than reacquired for every API request.
+
+Official references:
+
+- https://developer.anduril.com/guides/getting-started/authenticate
+- https://developer.anduril.com/guides/getting-started/quickstart
+- https://developer.anduril.com/reference/rest/oauth/create-token
+- https://developer.anduril.com/guides/developer-tools/sandboxes
+
+## Runtime environment contract
+
+OAuth mode consumes only:
+
+```text
+LATTICE_ENDPOINT
+LATTICE_CLIENT_ID
+LATTICE_CLIENT_SECRET
+SANDBOXES_TOKEN
+```
+
+The existing static-token mode remains supported with:
+
+```text
+LATTICE_ENDPOINT
+ENVIRONMENT_TOKEN
+SANDBOXES_TOKEN
+```
+
+Real credential values must remain outside the repository.
+
+## OAuth controls
+
+`SandboxClientCredentialsTokenProvider` adds:
+
+- exact token path `/api/v1/oauth/token`;
+- HTTPS-only, official `*.env.sandboxes.developer.anduril.com` endpoint restriction;
+- blocked redirects;
+- form-urlencoded client-credentials request body;
+- account-level Sandbox authorization header;
+- bounded token response size;
+- JSON-object response validation;
+- required non-empty `access_token`;
+- required Bearer `token_type`;
+- required positive integer `expires_in`;
+- fail-closed behavior when expiry metadata is absent or invalid;
+- in-memory token cache only;
+- monotonic-clock expiry tracking;
+- configurable pre-expiry refresh skew;
+- explicit cache clearing;
+- secret-redacted diagnostics and errors;
+- no refresh-token persistence or support.
+
+The provider does not make a network call on construction.
+
+## Read-only transport integration
+
+`SandboxReadOnlySSETransport` remains backward compatible with the v0.5 static bearer-token mode. It now also accepts an `EnvironmentTokenProvider`.
+
+When a provider is configured, each stream request asks the provider for a currently valid short-lived bearer token. The transport itself does not persist or cache that token. All v0.5 restrictions remain in force:
+
+- exact entity/task stream endpoint allowlist only;
+- Sandbox host restriction;
+- redirects blocked;
+- bounded SSE parsing;
+- sanitized errors;
+- no write/control methods.
+
+## Claims boundary
+
+Passing v0.6 demonstrates that the repository contains a CI-testable, secret-safe implementation of the documented Sandbox client-credentials lifecycle. It does not establish:
+
+- possession of valid Anduril credentials;
+- successful live OAuth authentication;
+- successful live SSE connectivity;
+- Anduril or Hermeus review/approval;
+- Quarterhorse or operational mission-system integration;
+- flight-control, mission-command, task-execution, weapons, or other control authority.
+
+## Next external evidence gate
+
+Once legitimate Sandbox credentials are provisioned, the next governed step is a finite read-only trial:
+
+1. load the credential variables outside the repository;
+2. acquire a short-lived token through the v0.6 provider;
+3. run the v0.5 finite entity/task capture;
+4. preserve only secret-free HMAA evidence and diagnostics;
+5. repeat the capture to demonstrate reproducibility;
+6. independently review the resulting evidence chain;
+7. only then create a separate attestation capable of changing Sandbox read interoperability from `live_environment_validated=false`.
+
+Production integration remains a later and independent gate.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_oauth.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_lattice_oauth.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import io
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs
+
+import pytest
+from pydantic import SecretStr
+
+from worldshepherd_sara.hmaa_lattice_oauth import (
+    LatticeOAuthError,
+    OAUTH_TOKEN_PATH,
+    SandboxClientCredentialsTokenProvider,
+    SandboxOAuthConfig,
+)
+from worldshepherd_sara.hmaa_lattice_sandbox import (
+    ENTITY_STREAM_PATH,
+    EnvironmentTokenProvider,
+    SandboxReadConfig,
+    SandboxReadOnlySSETransport,
+)
+
+
+CLIENT_ID = "client-id-example"
+CLIENT_SECRET = "client&secret=must+encode"
+SANDBOXES_TOKEN = "sandbox-token-do-not-leak"
+ACCESS_TOKEN = "short-lived-access-token-do-not-leak"
+ENDPOINT = "sandbox-123.env.sandboxes.developer.anduril.com"
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        raw: bytes,
+        content_type: str = "application/json",
+    ) -> None:
+        self._io = io.BytesIO(raw)
+        self.headers = {"Content-Type": content_type}
+        self.closed = False
+
+    def read(self, limit: int = -1) -> bytes:
+        return self._io.read(limit)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+        return False
+
+
+class FakeClock:
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _config(**overrides) -> SandboxOAuthConfig:
+    values = {
+        "endpoint": ENDPOINT,
+        "client_id": CLIENT_ID,
+        "client_secret": SecretStr(CLIENT_SECRET),
+        "sandboxes_token": SecretStr(SANDBOXES_TOKEN),
+        "timeout_seconds": 5,
+        "max_token_response_bytes": 4096,
+        "refresh_skew_seconds": 60,
+    }
+    values.update(overrides)
+    return SandboxOAuthConfig(**values)
+
+
+def _token_response(
+    token: str = ACCESS_TOKEN,
+    *,
+    token_type: str = "Bearer",
+    expires_in: object = 1800,
+) -> FakeResponse:
+    import json
+
+    return FakeResponse(
+        json.dumps(
+            {
+                "access_token": token,
+                "token_type": token_type,
+                "expires_in": expires_in,
+            }
+        ).encode("utf-8")
+    )
+
+
+def test_oauth_config_from_env_and_redacted_summary(monkeypatch):
+    monkeypatch.setenv("LATTICE_ENDPOINT", ENDPOINT)
+    monkeypatch.setenv("LATTICE_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("LATTICE_CLIENT_SECRET", CLIENT_SECRET)
+    monkeypatch.setenv("SANDBOXES_TOKEN", SANDBOXES_TOKEN)
+
+    config = SandboxOAuthConfig.from_env()
+    summary = config.redacted_summary()
+
+    assert config.endpoint == f"https://{ENDPOINT}"
+    assert config.client_secret.get_secret_value() == CLIENT_SECRET
+    assert summary["client_id_present"] is True
+    assert summary["client_secret_present"] is True
+    assert summary["sandboxes_token_present"] is True
+    assert summary["persistent_token_storage"] is False
+    assert summary["live_environment_validated"] is False
+    assert CLIENT_SECRET not in repr(config)
+    assert CLIENT_SECRET not in repr(summary)
+    assert SANDBOXES_TOKEN not in repr(summary)
+
+
+def test_oauth_config_from_env_reports_missing_names_not_values(monkeypatch):
+    monkeypatch.setenv("LATTICE_ENDPOINT", ENDPOINT)
+    monkeypatch.delenv("LATTICE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("LATTICE_CLIENT_SECRET", raising=False)
+    monkeypatch.setenv("SANDBOXES_TOKEN", SANDBOXES_TOKEN)
+
+    with pytest.raises(ValueError) as exc_info:
+        SandboxOAuthConfig.from_env()
+
+    message = str(exc_info.value)
+    assert "LATTICE_CLIENT_ID" in message
+    assert "LATTICE_CLIENT_SECRET" in message
+    assert SANDBOXES_TOKEN not in message
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://sandbox-123.env.sandboxes.developer.anduril.com",
+        "https://example.com",
+        "https://user:pass@sandbox-123.env.sandboxes.developer.anduril.com",
+        "https://sandbox-123.env.sandboxes.developer.anduril.com/api/v1/oauth/token",
+        "https://sandbox-123.env.sandboxes.developer.anduril.com?x=1",
+        "https://nested.sandbox-123.env.sandboxes.developer.anduril.com",
+    ],
+)
+def test_oauth_endpoint_rejects_unsafe_or_non_sandbox_hosts(endpoint):
+    with pytest.raises(ValueError):
+        _config(endpoint=endpoint)
+
+
+def test_token_request_matches_public_client_credentials_contract_and_url_encodes_secret():
+    captured = {}
+
+    def open_request(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _token_response()
+
+    provider = SandboxClientCredentialsTokenProvider(
+        _config(), open_request=open_request, clock=FakeClock()
+    )
+    token = provider.get_token()
+
+    request = captured["request"]
+    headers = {key.lower(): value for key, value in request.header_items()}
+    form = parse_qs(request.data.decode("utf-8"), keep_blank_values=True)
+
+    assert request.full_url == f"https://{ENDPOINT}{OAUTH_TOKEN_PATH}"
+    assert request.method == "POST"
+    assert captured["timeout"] == 5
+    assert headers["content-type"] == "application/x-www-form-urlencoded"
+    assert headers["accept"] == "application/json"
+    assert headers["anduril-sandbox-authorization"] == f"Bearer {SANDBOXES_TOKEN}"
+    assert form == {
+        "grant_type": ["client_credentials"],
+        "client_id": [CLIENT_ID],
+        "client_secret": [CLIENT_SECRET],
+    }
+    assert token.get_secret_value() == ACCESS_TOKEN
+
+
+def test_token_provider_is_protocol_compatible_and_secret_safe():
+    provider = SandboxClientCredentialsTokenProvider(
+        _config(), open_request=lambda request, timeout: _token_response()
+    )
+    assert isinstance(provider, EnvironmentTokenProvider)
+    rendered = repr(provider)
+    assert "storage=memory-only" in rendered
+    assert CLIENT_SECRET not in rendered
+    assert SANDBOXES_TOKEN not in rendered
+    assert ACCESS_TOKEN not in rendered
+
+
+def test_token_is_cached_and_refreshed_before_expiry():
+    clock = FakeClock()
+    calls = []
+
+    def open_request(request, timeout):
+        calls.append(len(calls) + 1)
+        return _token_response(token=f"token-{len(calls)}", expires_in=1800)
+
+    provider = SandboxClientCredentialsTokenProvider(
+        _config(refresh_skew_seconds=60),
+        open_request=open_request,
+        clock=clock,
+    )
+
+    assert provider.get_token().get_secret_value() == "token-1"
+    assert provider.get_token().get_secret_value() == "token-1"
+    assert len(calls) == 1
+
+    clock.now += 1739
+    assert provider.get_token().get_secret_value() == "token-1"
+    assert len(calls) == 1
+
+    clock.now += 2
+    assert provider.get_token().get_secret_value() == "token-2"
+    assert len(calls) == 2
+
+    diagnostics = provider.diagnostics()
+    assert diagnostics.cached_token_present is True
+    assert diagnostics.persistent_token_storage is False
+    assert ACCESS_TOKEN not in repr(diagnostics)
+
+
+def test_clear_forces_fresh_acquisition():
+    calls = []
+
+    def open_request(request, timeout):
+        calls.append(1)
+        return _token_response(token=f"token-{len(calls)}")
+
+    provider = SandboxClientCredentialsTokenProvider(
+        _config(), open_request=open_request, clock=FakeClock()
+    )
+    assert provider.get_token().get_secret_value() == "token-1"
+    provider.clear()
+    assert provider.diagnostics().cached_token_present is False
+    assert provider.get_token().get_secret_value() == "token-2"
+    assert len(calls) == 2
+
+
+def test_missing_or_invalid_expiry_fails_closed():
+    import json
+
+    invalid_payloads = [
+        {"access_token": ACCESS_TOKEN, "token_type": "Bearer"},
+        {"access_token": ACCESS_TOKEN, "token_type": "Bearer", "expires_in": 0},
+        {"access_token": ACCESS_TOKEN, "token_type": "Bearer", "expires_in": -1},
+        {"access_token": ACCESS_TOKEN, "token_type": "Bearer", "expires_in": True},
+        {"access_token": ACCESS_TOKEN, "token_type": "Bearer", "expires_in": "1800"},
+    ]
+
+    for payload in invalid_payloads:
+        provider = SandboxClientCredentialsTokenProvider(
+            _config(),
+            open_request=lambda request, timeout, payload=payload: FakeResponse(
+                json.dumps(payload).encode("utf-8")
+            ),
+        )
+        with pytest.raises(LatticeOAuthError, match="expires_in"):
+            provider.get_token()
+
+
+def test_missing_access_token_and_non_bearer_type_are_rejected_without_leakage():
+    import json
+
+    missing = SandboxClientCredentialsTokenProvider(
+        _config(),
+        open_request=lambda request, timeout: FakeResponse(
+            json.dumps({"token_type": "Bearer", "expires_in": 1800}).encode()
+        ),
+    )
+    with pytest.raises(LatticeOAuthError, match="access_token"):
+        missing.get_token()
+
+    wrong_type = SandboxClientCredentialsTokenProvider(
+        _config(),
+        open_request=lambda request, timeout: _token_response(token_type="MAC"),
+    )
+    with pytest.raises(LatticeOAuthError, match="Bearer") as exc_info:
+        wrong_type.get_token()
+    assert ACCESS_TOKEN not in str(exc_info.value)
+
+
+def test_malformed_oversized_and_wrong_content_type_responses_are_rejected():
+    malformed = SandboxClientCredentialsTokenProvider(
+        _config(),
+        open_request=lambda request, timeout: FakeResponse(b"not-json"),
+    )
+    with pytest.raises(LatticeOAuthError, match="UTF-8 JSON"):
+        malformed.get_token()
+
+    oversized = SandboxClientCredentialsTokenProvider(
+        _config(max_token_response_bytes=1024),
+        open_request=lambda request, timeout: FakeResponse(b"x" * 1025),
+    )
+    with pytest.raises(LatticeOAuthError, match="size limit"):
+        oversized.get_token()
+
+    wrong_content = SandboxClientCredentialsTokenProvider(
+        _config(),
+        open_request=lambda request, timeout: FakeResponse(
+            b"{}", content_type="text/plain"
+        ),
+    )
+    with pytest.raises(LatticeOAuthError, match="content type"):
+        wrong_content.get_token()
+
+
+def test_network_http_and_redirect_errors_are_sanitized():
+    def network_failure(request, timeout):
+        raise URLError(f"failure containing {CLIENT_SECRET} {SANDBOXES_TOKEN}")
+
+    network = SandboxClientCredentialsTokenProvider(
+        _config(), open_request=network_failure
+    )
+    with pytest.raises(LatticeOAuthError) as exc_info:
+        network.get_token()
+    message = str(exc_info.value)
+    assert CLIENT_SECRET not in message
+    assert SANDBOXES_TOKEN not in message
+
+    def redirect(request, timeout):
+        raise HTTPError(request.full_url, 302, "Found", {}, None)
+
+    redirected = SandboxClientCredentialsTokenProvider(
+        _config(), open_request=redirect
+    )
+    with pytest.raises(LatticeOAuthError, match="redirect blocked"):
+        redirected.get_token()
+
+    def unauthorized(request, timeout):
+        raise HTTPError(request.full_url, 401, ACCESS_TOKEN, {}, None)
+
+    unauthorized_provider = SandboxClientCredentialsTokenProvider(
+        _config(), open_request=unauthorized
+    )
+    with pytest.raises(LatticeOAuthError, match="HTTP 401") as exc_info:
+        unauthorized_provider.get_token()
+    assert ACCESS_TOKEN not in str(exc_info.value)
+
+
+def test_oauth_provider_writes_no_token_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    provider = SandboxClientCredentialsTokenProvider(
+        _config(),
+        open_request=lambda request, timeout: _token_response(),
+        clock=FakeClock(),
+    )
+    assert provider.get_token().get_secret_value() == ACCESS_TOKEN
+    assert provider.diagnostics().cached_token_present is True
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_read_transport_uses_provider_token_without_persisting_it():
+    provider = SandboxClientCredentialsTokenProvider(
+        _config(),
+        open_request=lambda request, timeout: _token_response(),
+        clock=FakeClock(),
+    )
+    read_config = SandboxReadConfig(
+        endpoint=ENDPOINT,
+        environment_token=None,
+        sandboxes_token=SecretStr(SANDBOXES_TOKEN),
+    )
+    transport = SandboxReadOnlySSETransport(
+        read_config,
+        environment_token_provider=provider,
+        open_request=lambda request, timeout: None,
+    )
+
+    request = transport._build_stream_request(ENTITY_STREAM_PATH, {})
+    headers = {key.lower(): value for key, value in request.header_items()}
+    assert headers["authorization"] == f"Bearer {ACCESS_TOKEN}"
+    assert headers["anduril-sandbox-authorization"] == f"Bearer {SANDBOXES_TOKEN}"
+    assert ACCESS_TOKEN not in repr(transport)
+    assert CLIENT_SECRET not in repr(transport)
+
+
+def test_transport_requires_static_token_or_provider():
+    read_config = SandboxReadConfig(
+        endpoint=ENDPOINT,
+        environment_token=None,
+        sandboxes_token=SecretStr(SANDBOXES_TOKEN),
+    )
+    with pytest.raises(ValueError, match="static environment token or token provider"):
+        SandboxReadOnlySSETransport(read_config)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_oauth.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_oauth.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, Field, SecretStr, field_validator
+
+
+OAUTH_TOKEN_PATH = "/api/v1/oauth/token"
+SANDBOX_HOST_SUFFIX = ".env.sandboxes.developer.anduril.com"
+
+
+class LatticeOAuthError(RuntimeError):
+    """Sanitized OAuth client-credentials error."""
+
+
+class SandboxOAuthConfig(BaseModel):
+    endpoint: str = Field(min_length=1)
+    client_id: str = Field(min_length=1)
+    client_secret: SecretStr
+    sandboxes_token: SecretStr
+    timeout_seconds: float = Field(default=15.0, gt=0, le=120)
+    max_token_response_bytes: int = Field(default=65_536, ge=1024, le=1_048_576)
+    refresh_skew_seconds: float = Field(default=60.0, ge=0, le=600)
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, value: str) -> str:
+        raw = value.strip()
+        if not raw:
+            raise ValueError("LATTICE_ENDPOINT must not be empty")
+        candidate = raw if "://" in raw else f"https://{raw}"
+        parsed = urlsplit(candidate)
+        if parsed.scheme.lower() != "https":
+            raise ValueError("LATTICE_ENDPOINT must use HTTPS")
+        if not parsed.hostname:
+            raise ValueError("LATTICE_ENDPOINT must include a hostname")
+        if parsed.username or parsed.password:
+            raise ValueError("LATTICE_ENDPOINT must not contain user information")
+        if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+            raise ValueError("LATTICE_ENDPOINT must be a host endpoint without path/query/fragment")
+        if parsed.port not in (None, 443):
+            raise ValueError("LATTICE_ENDPOINT may only use the default HTTPS port")
+        hostname = parsed.hostname.lower()
+        if not hostname.endswith(SANDBOX_HOST_SUFFIX):
+            raise ValueError(
+                "LATTICE_ENDPOINT must be a documented Lattice Sandboxes environment host"
+            )
+        environment_id = hostname[: -len(SANDBOX_HOST_SUFFIX)]
+        if not environment_id or "." in environment_id:
+            raise ValueError("LATTICE_ENDPOINT Sandbox environment identifier is invalid")
+        return f"https://{hostname}"
+
+    @field_validator("client_id")
+    @classmethod
+    def validate_client_id(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("LATTICE_CLIENT_ID must not be empty")
+        return normalized
+
+    @classmethod
+    def from_env(cls) -> "SandboxOAuthConfig":
+        required = {
+            "LATTICE_ENDPOINT": os.getenv("LATTICE_ENDPOINT"),
+            "LATTICE_CLIENT_ID": os.getenv("LATTICE_CLIENT_ID"),
+            "LATTICE_CLIENT_SECRET": os.getenv("LATTICE_CLIENT_SECRET"),
+            "SANDBOXES_TOKEN": os.getenv("SANDBOXES_TOKEN"),
+        }
+        missing = sorted(name for name, value in required.items() if not value)
+        if missing:
+            raise ValueError(
+                "missing required Sandbox OAuth environment variables: "
+                + ", ".join(missing)
+            )
+        return cls(
+            endpoint=required["LATTICE_ENDPOINT"] or "",
+            client_id=required["LATTICE_CLIENT_ID"] or "",
+            client_secret=SecretStr(required["LATTICE_CLIENT_SECRET"] or ""),
+            sandboxes_token=SecretStr(required["SANDBOXES_TOKEN"] or ""),
+        )
+
+    def redacted_summary(self) -> dict[str, Any]:
+        return {
+            "endpoint": self.endpoint,
+            "client_id_present": bool(self.client_id),
+            "client_secret_present": bool(self.client_secret.get_secret_value()),
+            "sandboxes_token_present": bool(self.sandboxes_token.get_secret_value()),
+            "token_path": OAUTH_TOKEN_PATH,
+            "timeout_seconds": self.timeout_seconds,
+            "max_token_response_bytes": self.max_token_response_bytes,
+            "refresh_skew_seconds": self.refresh_skew_seconds,
+            "persistent_token_storage": False,
+            "live_environment_validated": False,
+        }
+
+
+class OAuthTokenResponse(BaseModel):
+    access_token: SecretStr
+    token_type: str = "Bearer"
+    expires_in: int = Field(gt=0)
+
+
+class OAuthTokenDiagnostics(BaseModel):
+    cached_token_present: bool
+    token_type: str | None = None
+    seconds_until_expiry: float | None = None
+    refresh_due: bool = True
+    persistent_token_storage: bool = False
+    live_environment_validated: bool = False
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        raise HTTPError(req.full_url, code, "redirect blocked", headers, fp)
+
+
+OpenCallable = Callable[[Request, float], Any]
+ClockCallable = Callable[[], float]
+
+
+def _default_open(request: Request, timeout: float) -> Any:
+    opener = build_opener(_NoRedirectHandler())
+    return opener.open(request, timeout=timeout)
+
+
+class SandboxClientCredentialsTokenProvider:
+    """Acquire and cache short-lived Lattice bearer tokens in memory only."""
+
+    def __init__(
+        self,
+        config: SandboxOAuthConfig,
+        *,
+        open_request: OpenCallable | None = None,
+        clock: ClockCallable | None = None,
+    ) -> None:
+        self._config = config
+        self._open_request = open_request or _default_open
+        self._clock = clock or time.monotonic
+        self._lock = threading.RLock()
+        self._cached: OAuthTokenResponse | None = None
+        self._refresh_at: float | None = None
+        self._expires_at: float | None = None
+
+    def __repr__(self) -> str:
+        return (
+            "SandboxClientCredentialsTokenProvider("
+            f"endpoint={self._config.endpoint!r}, credentials=<redacted>, "
+            "storage=memory-only)"
+        )
+
+    def _build_token_request(self) -> Request:
+        body = urlencode(
+            {
+                "grant_type": "client_credentials",
+                "client_id": self._config.client_id,
+                "client_secret": self._config.client_secret.get_secret_value(),
+            }
+        ).encode("utf-8")
+        return Request(
+            url=self._config.endpoint + OAUTH_TOKEN_PATH,
+            data=body,
+            method="POST",
+            headers={
+                "Anduril-Sandbox-Authorization": (
+                    "Bearer " + self._config.sandboxes_token.get_secret_value()
+                ),
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+        )
+
+    def _acquire(self) -> OAuthTokenResponse:
+        request = self._build_token_request()
+        try:
+            response = self._open_request(request, self._config.timeout_seconds)
+            with response:
+                content_type = str(response.headers.get("Content-Type", ""))
+                if "application/json" not in content_type.lower():
+                    raise LatticeOAuthError(
+                        "Sandbox OAuth endpoint returned an unexpected content type"
+                    )
+                raw = response.read(self._config.max_token_response_bytes + 1)
+                if len(raw) > self._config.max_token_response_bytes:
+                    raise LatticeOAuthError(
+                        "Sandbox OAuth response exceeded the configured size limit"
+                    )
+        except LatticeOAuthError:
+            raise
+        except HTTPError as exc:
+            if 300 <= exc.code < 400:
+                raise LatticeOAuthError(
+                    f"Sandbox OAuth redirect blocked (HTTP {exc.code})"
+                ) from None
+            raise LatticeOAuthError(
+                f"Sandbox OAuth request failed (HTTP {exc.code})"
+            ) from None
+        except (URLError, TimeoutError, OSError) as exc:
+            raise LatticeOAuthError(
+                f"Sandbox OAuth connection failed ({type(exc).__name__})"
+            ) from None
+
+        try:
+            decoded = raw.decode("utf-8")
+            payload = json.loads(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise LatticeOAuthError(
+                "Sandbox OAuth response was not valid UTF-8 JSON"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise LatticeOAuthError("Sandbox OAuth response JSON must be an object")
+
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise LatticeOAuthError(
+                "Sandbox OAuth response did not contain a usable access_token"
+            )
+
+        token_type = payload.get("token_type")
+        if not isinstance(token_type, str) or token_type.lower() != "bearer":
+            raise LatticeOAuthError(
+                "Sandbox OAuth response token_type must be Bearer"
+            )
+
+        expires_in = payload.get("expires_in")
+        if isinstance(expires_in, bool) or not isinstance(expires_in, int) or expires_in <= 0:
+            raise LatticeOAuthError(
+                "Sandbox OAuth response expires_in must be a positive integer"
+            )
+
+        return OAuthTokenResponse(
+            access_token=SecretStr(access_token),
+            token_type="Bearer",
+            expires_in=expires_in,
+        )
+
+    def get_token(self) -> SecretStr:
+        with self._lock:
+            now = self._clock()
+            if (
+                self._cached is not None
+                and self._refresh_at is not None
+                and now < self._refresh_at
+            ):
+                return self._cached.access_token
+
+            token = self._acquire()
+            acquired_at = self._clock()
+            self._cached = token
+            self._expires_at = acquired_at + float(token.expires_in)
+            refresh_delay = max(
+                0.0,
+                float(token.expires_in) - self._config.refresh_skew_seconds,
+            )
+            self._refresh_at = acquired_at + refresh_delay
+            return token.access_token
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cached = None
+            self._refresh_at = None
+            self._expires_at = None
+
+    def diagnostics(self) -> OAuthTokenDiagnostics:
+        with self._lock:
+            now = self._clock()
+            seconds_until_expiry = None
+            if self._expires_at is not None:
+                seconds_until_expiry = max(0.0, self._expires_at - now)
+            refresh_due = (
+                self._cached is None
+                or self._refresh_at is None
+                or now >= self._refresh_at
+            )
+            return OAuthTokenDiagnostics(
+                cached_token_present=self._cached is not None,
+                token_type=self._cached.token_type if self._cached else None,
+                seconds_until_expiry=seconds_until_expiry,
+                refresh_due=refresh_due,
+            )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_sandbox.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_lattice_sandbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener
@@ -27,9 +27,14 @@ class LatticeSandboxReadError(RuntimeError):
     """Sanitized read-only Sandbox transport error."""
 
 
+@runtime_checkable
+class EnvironmentTokenProvider(Protocol):
+    def get_token(self) -> SecretStr: ...
+
+
 class SandboxReadConfig(BaseModel):
     endpoint: str = Field(min_length=1)
-    environment_token: SecretStr
+    environment_token: SecretStr | None = None
     sandboxes_token: SecretStr
     timeout_seconds: float = Field(default=30.0, gt=0, le=300)
     max_sse_event_bytes: int = Field(default=1_048_576, ge=1024, le=8_388_608)
@@ -85,7 +90,8 @@ class SandboxReadConfig(BaseModel):
         return {
             "endpoint": self.endpoint,
             "environment_token_present": bool(
-                self.environment_token.get_secret_value()
+                self.environment_token
+                and self.environment_token.get_secret_value()
             ),
             "sandboxes_token_present": bool(self.sandboxes_token.get_secret_value()),
             "timeout_seconds": self.timeout_seconds,
@@ -145,23 +151,51 @@ class SandboxReadOnlySSETransport(LatticeReadTransport):
     """Read-only REST SSE transport for an authorized Lattice Sandbox.
 
     Construction does not perform a network call. Only the two documented
-    stream endpoints are reachable through public methods.
+    stream endpoints are reachable through public methods. The environment
+    bearer can be static or supplied on demand by an in-memory token provider.
     """
 
     def __init__(
         self,
         config: SandboxReadConfig,
         *,
+        environment_token_provider: EnvironmentTokenProvider | None = None,
         open_request: OpenCallable | None = None,
     ) -> None:
+        if environment_token_provider is None and not (
+            config.environment_token
+            and config.environment_token.get_secret_value()
+        ):
+            raise ValueError(
+                "Sandbox read transport requires a static environment token or token provider"
+            )
         self._config = config
+        self._environment_token_provider = environment_token_provider
         self._open_request = open_request or _default_open
 
     def __repr__(self) -> str:
+        mode = "provider" if self._environment_token_provider else "static"
         return (
             "SandboxReadOnlySSETransport("
-            f"endpoint={self._config.endpoint!r}, credentials=<redacted>)"
+            f"endpoint={self._config.endpoint!r}, token_mode={mode!r}, "
+            "credentials=<redacted>)"
         )
+
+    def _environment_token_value(self) -> str:
+        if self._environment_token_provider is not None:
+            token = self._environment_token_provider.get_token()
+            value = token.get_secret_value()
+            if not value:
+                raise LatticeSandboxReadError(
+                    "environment token provider returned an unusable token"
+                )
+            return value
+        if self._config.environment_token is None:
+            raise LatticeSandboxReadError("environment token is unavailable")
+        value = self._config.environment_token.get_secret_value()
+        if not value:
+            raise LatticeSandboxReadError("environment token is unavailable")
+        return value
 
     def _build_stream_request(
         self,
@@ -180,9 +214,7 @@ class SandboxReadOnlySSETransport(LatticeReadTransport):
             data=body,
             method="POST",
             headers={
-                "Authorization": (
-                    "Bearer " + self._config.environment_token.get_secret_value()
-                ),
+                "Authorization": "Bearer " + self._environment_token_value(),
                 "Anduril-Sandbox-Authorization": (
                     "Bearer " + self._config.sandboxes_token.get_secret_value()
                 ),


### PR DESCRIPTION
## Summary
Adds a bounded OAuth 2.0 client-credentials lifecycle for the validated read-only Lattice Sandbox transport.

### Added
- `SandboxOAuthConfig` consuming only `LATTICE_ENDPOINT`, `LATTICE_CLIENT_ID`, `LATTICE_CLIENT_SECRET`, and `SANDBOXES_TOKEN`
- exact `POST /api/v1/oauth/token` client-credentials request with form-urlencoded body
- account-level `Anduril-Sandbox-Authorization` header
- official Sandbox-host restriction and blocked redirects
- bounded JSON token response handling
- required non-empty `access_token`, Bearer `token_type`, and positive integer `expires_in`
- fail-closed behavior if expiry metadata is absent or invalid
- in-memory token caching only, tracked with a monotonic clock
- configurable pre-expiry refresh skew and explicit cache clearing
- secret-redacted diagnostics and sanitized HTTP/network errors
- backward-compatible optional `EnvironmentTokenProvider` integration with `SandboxReadOnlySSETransport`
- static `ENVIRONMENT_TOKEN` mode remains supported
- tests for environment handling, URL encoding, request contract, caching, refresh, clearing, malformed responses, expiry failures, redirect/network sanitization, zero disk persistence, and provider-to-read-transport integration
- updated environment-variable template and v0.6 claims-boundary documentation

### Claims / safety boundary
No live OAuth or Sandbox connection is made by this PR. `live_environment_validated` remains false. No token is written to disk. No refresh-token storage is implemented. No entity publish, task create/update, manual-control, flight-control, weapons, or arbitrary HTTP operation is added.

### Public documentation basis
Current Anduril Lattice authentication, OAuth token, quickstart, and Sandbox documentation reviewed 2026-09-04.

### Validation gate
Merge only after protected SARA CI/recovery/resilience gates and CodeQL are green.