### PR TITLE
WS-HMAA v0.7: governed repeatable-evidence attestation

### DIFF
--- a/deployments/sara_verified_local_v1/WS_HMAA_V0_7_ATTESTATION_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/WS_HMAA_V0_7_ATTESTATION_BOUNDARY.md
@@ -1,0 +1,50 @@
+# WS-HMAA v0.7 — Evidence Attestation Boundary
+
+## Purpose
+
+v0.7 adds a claims-control layer over the existing bounded read-only capture and HMAA evidence-chain implementation. It measures whether candidate evidence is internally coherent and repeatable without converting that evidence into a claim that an external Lattice Sandbox has been validated.
+
+## State model
+
+- `NO_EVIDENCE`: no qualifying capture has been supplied.
+- `CANDIDATE_EVIDENCE`: one or more qualifying captures exist, but the distinct-capture repeatability threshold has not been met.
+- `EXTERNAL_ATTESTATION_REQUIRED`: the configured repeatability threshold has been met. This is the highest state v0.7 can produce.
+
+There is deliberately no v0.7 transition to `LIVE_READ_VALIDATED`.
+
+## Qualification rules
+
+A candidate capture qualifies only when all of the following are true:
+
+1. Capture and interop manifest both retain `live_environment_validated=false`.
+2. Capture and manifest retain the bounded source label `authorized-sandbox-readonly-candidate`.
+3. The finite sample count is nonzero and matches the manifest event count.
+4. Evidence-bundle and manifest mission IDs match.
+5. Evidence-bundle and manifest final chain hashes are present and identical.
+6. Disposition totals match the event count.
+7. Every captured event is `ALLOW`; `WARN`, `REVIEW`, or `INDETERMINATE` evidence cannot promote repeatability readiness.
+8. Captures must use one mission ID for a single attestation package.
+9. Duplicate capture digests do not count toward repeatability.
+
+The default repeatability threshold is three distinct qualifying captures.
+
+## Integrity
+
+Each qualifying capture is reduced to a secret-free canonical reference and SHA-256 digest. The aggregate attestation digest is derived from the sorted set of distinct capture digests, making the aggregate deterministic and order-independent.
+
+No bearer token, OAuth client secret, Sandbox authorization token, response body outside the already-normalized evidence manifest, or credential metadata is accepted by the attestation model.
+
+## Claims boundary
+
+v0.7 may support only these labels:
+
+- `IMPLEMENTED IN SOFTWARE`
+- `REQUIRES PARTNER VALIDATION`
+
+v0.7 does **not** establish `PROVEN INTERNALLY`, partner validation, flight validation, operational validation, or live-environment validation.
+
+A future external-validation increment must ingest independently produced evidence/attestation through a separately governed mechanism before any live-validation state can be considered. That mechanism is intentionally absent from v0.7.
+
+## Control boundary
+
+v0.7 adds no network transport, credential acquisition, entity publication, task creation/update, manual-control, flight-control, weapons, or arbitrary HTTP operation. It operates only on already-produced finite read-only capture results.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_attestation.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_attestation.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.hmaa_attestation import (
+    HMAAAttestationState,
+    attest_candidate_captures,
+)
+from worldshepherd_sara.hmaa_interop import run_public_contract_replay
+from worldshepherd_sara.hmaa_lattice_capture import SandboxReadCaptureResult
+
+
+def _capture(sequence: int, *, mission_id: str = "ATTEST-MISSION-001") -> SandboxReadCaptureResult:
+    timestamp = f"2026-09-04T22:5{sequence}:00Z"
+    interop = run_public_contract_replay(
+        mission_id=mission_id,
+        source_label="authorized-sandbox-readonly-candidate",
+        items=[
+            {
+                "stream": "entities",
+                "message": {
+                    "heartbeat": {
+                        "timestamp": timestamp,
+                        "sequence": sequence,
+                    }
+                },
+            }
+        ],
+    )
+    return SandboxReadCaptureResult(
+        live_environment_validated=False,
+        source_label="authorized-sandbox-readonly-candidate",
+        captured_entity_messages=1,
+        captured_task_messages=0,
+        interop=interop,
+    )
+
+
+def test_empty_evidence_stays_unvalidated():
+    report = attest_candidate_captures([])
+
+    assert report.state is HMAAAttestationState.NO_EVIDENCE
+    assert report.live_environment_validated is False
+    assert report.external_attestation_required is True
+    assert report.repeatability_satisfied is False
+    assert report.aggregate_sha256 is None
+
+
+def test_single_capture_is_candidate_only():
+    report = attest_candidate_captures([_capture(1)])
+
+    assert report.state is HMAAAttestationState.CANDIDATE_EVIDENCE
+    assert report.capture_count == 1
+    assert report.distinct_capture_count == 1
+    assert report.repeatability_satisfied is False
+    assert report.live_environment_validated is False
+    assert "REQUIRES PARTNER VALIDATION" in report.claimable_labels
+    assert "PROVEN INTERNALLY" not in report.claimable_labels
+
+
+def test_three_distinct_captures_require_external_attestation_not_live_claim():
+    report = attest_candidate_captures([_capture(1), _capture(2), _capture(3)])
+
+    assert report.state is HMAAAttestationState.EXTERNAL_ATTESTATION_REQUIRED
+    assert report.capture_count == 3
+    assert report.distinct_capture_count == 3
+    assert report.repeatability_satisfied is True
+    assert report.live_environment_validated is False
+    assert report.external_attestation_required is True
+    assert report.aggregate_sha256 is not None
+    assert any("external/partner" in reason for reason in report.blocking_reasons)
+
+
+def test_duplicate_capture_does_not_satisfy_repeatability():
+    first = _capture(1)
+    report = attest_candidate_captures([first, first, _capture(2)])
+
+    assert report.capture_count == 3
+    assert report.distinct_capture_count == 2
+    assert report.repeatability_satisfied is False
+    assert report.state is HMAAAttestationState.CANDIDATE_EVIDENCE
+
+
+def test_aggregate_digest_is_order_independent():
+    captures = [_capture(1), _capture(2), _capture(3)]
+    forward = attest_candidate_captures(captures)
+    reverse = attest_candidate_captures(list(reversed(captures)))
+
+    assert forward.aggregate_sha256 == reverse.aggregate_sha256
+    assert [item.capture_sha256 for item in forward.captures] == [
+        item.capture_sha256 for item in reverse.captures
+    ]
+
+
+def test_mission_mismatch_is_rejected():
+    with pytest.raises(ValueError, match="same mission_id"):
+        attest_candidate_captures(
+            [_capture(1, mission_id="A"), _capture(2, mission_id="B")]
+        )
+
+
+def test_candidate_layer_rejects_any_preexisting_live_validation_claim():
+    candidate = _capture(1)
+    asserted_live = candidate.model_copy(update={"live_environment_validated": True})
+
+    with pytest.raises(ValueError, match="must not assert live-environment validation"):
+        attest_candidate_captures([asserted_live])
+
+
+def test_non_allow_capture_requires_review_and_cannot_qualify():
+    candidate = _capture(1)
+    manifest = candidate.interop.manifest.model_copy(
+        update={"disposition_counts": {"REVIEW": 1}}
+    )
+    interop = candidate.interop.model_copy(update={"manifest": manifest})
+    needs_review = candidate.model_copy(update={"interop": interop})
+
+    with pytest.raises(ValueError, match="non-ALLOW"):
+        attest_candidate_captures([needs_review])
+
+
+def test_manifest_count_must_match_finite_capture_count():
+    candidate = _capture(1)
+    manifest = candidate.interop.manifest.model_copy(update={"event_count": 2})
+    interop = candidate.interop.model_copy(update={"manifest": manifest})
+    inconsistent = candidate.model_copy(update={"interop": interop})
+
+    with pytest.raises(ValueError, match="does not match sampled message count"):
+        attest_candidate_captures([inconsistent])

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_attestation.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_attestation.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import Enum
+from typing import Any, Iterable
+
+from pydantic import BaseModel, Field
+
+from .hmaa_lattice_capture import SandboxReadCaptureResult
+
+
+HMAA_ATTESTATION_VERSION = "worldshepherd.hmaa.attestation.v0.7"
+CANDIDATE_SOURCE_LABEL = "authorized-sandbox-readonly-candidate"
+REPEATABLE_CAPTURE_THRESHOLD = 3
+
+
+class HMAAAttestationState(str, Enum):
+    NO_EVIDENCE = "NO_EVIDENCE"
+    CANDIDATE_EVIDENCE = "CANDIDATE_EVIDENCE"
+    EXTERNAL_ATTESTATION_REQUIRED = "EXTERNAL_ATTESTATION_REQUIRED"
+
+
+class HMAACaptureReference(BaseModel):
+    mission_id: str = Field(min_length=1)
+    source_label: str = Field(min_length=1)
+    fixture_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    final_chain_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    event_count: int = Field(gt=0)
+    captured_entity_messages: int = Field(ge=0)
+    captured_task_messages: int = Field(ge=0)
+    disposition_counts: dict[str, int]
+    capture_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+class HMAAAttestationReport(BaseModel):
+    attestation_version: str = HMAA_ATTESTATION_VERSION
+    mission_id: str | None = None
+    state: HMAAAttestationState
+    capture_count: int = 0
+    distinct_capture_count: int = 0
+    repeatability_satisfied: bool = False
+    aggregate_sha256: str | None = None
+    live_environment_validated: bool = False
+    external_attestation_required: bool = True
+    claimable_labels: list[str] = Field(default_factory=list)
+    blocking_reasons: list[str] = Field(default_factory=list)
+    captures: list[HMAACaptureReference] = Field(default_factory=list)
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _capture_reference(capture: SandboxReadCaptureResult) -> HMAACaptureReference:
+    manifest = capture.interop.manifest
+    bundle = capture.interop.evidence_bundle
+
+    if capture.live_environment_validated or manifest.live_environment_validated:
+        raise ValueError(
+            "candidate evidence must not assert live-environment validation"
+        )
+    if capture.source_label != CANDIDATE_SOURCE_LABEL:
+        raise ValueError("capture source label is not the authorized Sandbox candidate label")
+    if manifest.source_label != CANDIDATE_SOURCE_LABEL:
+        raise ValueError("interop manifest source label is not the authorized Sandbox candidate label")
+
+    sampled_count = capture.captured_entity_messages + capture.captured_task_messages
+    if sampled_count <= 0:
+        raise ValueError("capture must contain at least one sampled message")
+    if manifest.event_count != sampled_count:
+        raise ValueError("capture event count does not match sampled message count")
+    if bundle.mission_id != manifest.mission_id:
+        raise ValueError("capture bundle and manifest mission IDs do not match")
+    if bundle.final_chain_hash is None or manifest.final_chain_hash is None:
+        raise ValueError("capture is missing a final evidence-chain hash")
+    if bundle.final_chain_hash != manifest.final_chain_hash:
+        raise ValueError("capture bundle and manifest chain heads do not match")
+
+    disposition_total = sum(manifest.disposition_counts.values())
+    if disposition_total != manifest.event_count:
+        raise ValueError("capture disposition counts do not match event count")
+    non_allow = {
+        name: count
+        for name, count in manifest.disposition_counts.items()
+        if name != "ALLOW" and count > 0
+    }
+    if non_allow:
+        raise ValueError(
+            "capture contains non-ALLOW assurance dispositions and requires review"
+        )
+    if manifest.disposition_counts.get("ALLOW", 0) != manifest.event_count:
+        raise ValueError("capture is not fully ALLOW-qualified")
+
+    digest_body = {
+        "mission_id": manifest.mission_id,
+        "source_label": manifest.source_label,
+        "fixture_sha256": manifest.fixture_sha256,
+        "final_chain_hash": manifest.final_chain_hash,
+        "event_count": manifest.event_count,
+        "captured_entity_messages": capture.captured_entity_messages,
+        "captured_task_messages": capture.captured_task_messages,
+        "disposition_counts": dict(sorted(manifest.disposition_counts.items())),
+    }
+    return HMAACaptureReference(
+        **digest_body,
+        capture_sha256=_sha256_json(digest_body),
+    )
+
+
+def attest_candidate_captures(
+    captures: Iterable[SandboxReadCaptureResult],
+    *,
+    required_distinct_captures: int = REPEATABLE_CAPTURE_THRESHOLD,
+) -> HMAAAttestationReport:
+    if required_distinct_captures < 2:
+        raise ValueError("repeatability threshold must be at least 2 captures")
+
+    references = [_capture_reference(capture) for capture in captures]
+    if not references:
+        return HMAAAttestationReport(
+            state=HMAAAttestationState.NO_EVIDENCE,
+            blocking_reasons=["no qualifying capture evidence supplied"],
+            claimable_labels=["IMPLEMENTED IN SOFTWARE", "REQUIRES PARTNER VALIDATION"],
+        )
+
+    mission_ids = {reference.mission_id for reference in references}
+    if len(mission_ids) != 1:
+        raise ValueError("all attested captures must use the same mission_id")
+    mission_id = next(iter(mission_ids))
+
+    distinct_hashes = sorted({reference.capture_sha256 for reference in references})
+    repeatable = len(distinct_hashes) >= required_distinct_captures
+    state = (
+        HMAAAttestationState.EXTERNAL_ATTESTATION_REQUIRED
+        if repeatable
+        else HMAAAttestationState.CANDIDATE_EVIDENCE
+    )
+    blockers: list[str] = []
+    if not repeatable:
+        blockers.append(
+            f"requires {required_distinct_captures} distinct qualifying captures; "
+            f"found {len(distinct_hashes)}"
+        )
+    blockers.append(
+        "independent external/partner attestation is required before any live-validation claim"
+    )
+
+    aggregate = _sha256_json(
+        {
+            "attestation_version": HMAA_ATTESTATION_VERSION,
+            "mission_id": mission_id,
+            "distinct_capture_sha256": distinct_hashes,
+        }
+    )
+    ordered = sorted(references, key=lambda item: item.capture_sha256)
+    return HMAAAttestationReport(
+        mission_id=mission_id,
+        state=state,
+        capture_count=len(references),
+        distinct_capture_count=len(distinct_hashes),
+        repeatability_satisfied=repeatable,
+        aggregate_sha256=aggregate,
+        live_environment_validated=False,
+        external_attestation_required=True,
+        claimable_labels=["IMPLEMENTED IN SOFTWARE", "REQUIRES PARTNER VALIDATION"],
+        blocking_reasons=blockers,
+        captures=ordered,
+    )


### PR DESCRIPTION
## Summary
Adds a claims-control attestation layer over the existing finite read-only Sandbox capture and HMAA evidence-chain outputs.

### Added
- deterministic, secret-free `HMAACaptureReference` records
- canonical SHA-256 capture digests and order-independent aggregate attestation digest
- qualification checks for candidate source labels, finite event/message count consistency, mission consistency, matching evidence-chain heads, disposition totals, and fully `ALLOW` evidence
- duplicate capture digests excluded from repeatability credit
- default repeatability threshold of three distinct qualifying captures
- explicit attestation states: `NO_EVIDENCE`, `CANDIDATE_EVIDENCE`, and `EXTERNAL_ATTESTATION_REQUIRED`
- hard rejection of any candidate input that already asserts live-environment validation
- nine tests covering empty/single/repeatable evidence, duplicate captures, deterministic aggregation, mission mismatch, false live claims, non-ALLOW evidence, and count inconsistency
- v0.7 claims/control boundary documentation

### Claims / safety boundary
`EXTERNAL_ATTESTATION_REQUIRED` is the highest state this PR can produce. `live_environment_validated` remains false in all outputs. No mechanism for self-promoting to a live/partner-validated claim is added.

This PR adds no network transport, credential acquisition, entity publication, task create/update, manual-control, flight-control, weapons, or arbitrary HTTP operation.

### Validation gate
Merge only after the protected SARA CI/recovery/resilience suite and CodeQL are green.