### PR TITLE
WS-HMAA v0.8: hash-bound partner validation request package

### DIFF
--- a/deployments/sara_verified_local_v1/WS_HMAA_V0_8_PARTNER_REQUEST_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/WS_HMAA_V0_8_PARTNER_REQUEST_BOUNDARY.md
@@ -1,0 +1,60 @@
+# WS-HMAA v0.8 — Partner Validation Request Boundary
+
+## Purpose
+
+v0.8 converts a v0.7 `EXTERNAL_ATTESTATION_REQUIRED` report into a canonical, secret-free validation request that can be reviewed by an authorized external partner. It does not perform external validation and cannot convert the request into a live-validation claim.
+
+## Preconditions
+
+A package can be built only when:
+
+- the v0.7 report state is `EXTERNAL_ATTESTATION_REQUIRED`;
+- repeatability is satisfied;
+- `live_environment_validated` is false;
+- external attestation remains required;
+- an aggregate attestation SHA-256 is present;
+- one mission ID is present; and
+- at least three distinct qualifying capture references remain internally consistent.
+
+## Exported evidence
+
+The request contains only:
+
+- mission ID;
+- attestation aggregate SHA-256;
+- distinct qualifying capture count;
+- capture SHA-256 references;
+- fixture SHA-256 references;
+- final evidence-chain hashes;
+- event counts;
+- requested partner validation checks;
+- current claim labels and prohibited claims; and
+- a canonical package SHA-256.
+
+Raw entity/task stream payloads and credentials are intentionally excluded.
+
+## Requested validation scope
+
+The fixed request scope is `read-only-sandbox-interoperability`.
+
+The external reviewer is asked to confirm authorization and environment provenance, verify that the cited evidence originated from the stated read-only environment, confirm that WS-HMAA did not request write/control actions, validate the referenced hashes, and return an independently attributable attestation bound to the package SHA-256.
+
+## Claims boundary
+
+The package status is `READY_FOR_PARTNER_VALIDATION_REQUEST`. It does not mean the request was sent, received, reviewed, approved, or validated.
+
+Allowed labels remain:
+
+- `IMPLEMENTED IN SOFTWARE`
+- `REQUIRES PARTNER VALIDATION`
+
+Explicitly prohibited claims include:
+
+- `LIVE_ENVIRONMENT_VALIDATED`
+- `PARTNER_VALIDATED`
+- `FLIGHT_VALIDATED`
+- `OPERATIONALLY_VALIDATED`
+
+## Control boundary
+
+v0.8 adds no network operation, OAuth behavior, partner communication, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP behavior. It only transforms an already-qualified v0.7 report into a hash-bound review package.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_partner_package.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_partner_package.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.hmaa_attestation import attest_candidate_captures
+from worldshepherd_sara.hmaa_interop import run_public_contract_replay
+from worldshepherd_sara.hmaa_lattice_capture import SandboxReadCaptureResult
+from worldshepherd_sara.hmaa_partner_package import (
+    PARTNER_VALIDATION_SCOPE,
+    build_partner_validation_request,
+    canonical_partner_request_bytes,
+)
+
+
+def _capture(sequence: int) -> SandboxReadCaptureResult:
+    interop = run_public_contract_replay(
+        mission_id="PARTNER-PACKAGE-001",
+        source_label="authorized-sandbox-readonly-candidate",
+        items=[
+            {
+                "stream": "entities",
+                "message": {
+                    "heartbeat": {
+                        "timestamp": f"2026-09-04T23:0{sequence}:00Z",
+                        "sequence": sequence,
+                    }
+                },
+            }
+        ],
+    )
+    return SandboxReadCaptureResult(
+        live_environment_validated=False,
+        source_label="authorized-sandbox-readonly-candidate",
+        captured_entity_messages=1,
+        captured_task_messages=0,
+        interop=interop,
+    )
+
+
+def _repeatable_report():
+    return attest_candidate_captures([_capture(1), _capture(2), _capture(3)])
+
+
+def test_repeatable_attestation_builds_partner_request_without_promoting_claims():
+    request = build_partner_validation_request(_repeatable_report())
+
+    assert request.request_status == "READY_FOR_PARTNER_VALIDATION_REQUEST"
+    assert request.requested_scope == PARTNER_VALIDATION_SCOPE
+    assert request.qualifying_capture_count == 3
+    assert request.live_environment_validated is False
+    assert "REQUIRES PARTNER VALIDATION" in request.claimable_labels
+    assert "PARTNER_VALIDATED" in request.prohibited_claims
+    assert "LIVE_ENVIRONMENT_VALIDATED" in request.prohibited_claims
+    assert request.package_sha256.startswith("sha256:")
+
+
+def test_candidate_only_evidence_cannot_build_partner_request():
+    candidate = attest_candidate_captures([_capture(1)])
+
+    with pytest.raises(ValueError, match="EXTERNAL_ATTESTATION_REQUIRED"):
+        build_partner_validation_request(candidate)
+
+
+def test_partner_request_is_deterministic_for_same_attestation():
+    report = _repeatable_report()
+    first = build_partner_validation_request(report)
+    second = build_partner_validation_request(report)
+
+    assert first.package_sha256 == second.package_sha256
+    assert canonical_partner_request_bytes(first) == canonical_partner_request_bytes(second)
+
+
+def test_partner_request_exports_references_not_raw_stream_payloads_or_credentials():
+    request = build_partner_validation_request(_repeatable_report())
+    encoded = canonical_partner_request_bytes(request)
+
+    assert b"heartbeat" not in encoded
+    assert b"access_token" not in encoded
+    assert b"client_secret" not in encoded
+    assert b"SANDBOXES_TOKEN" not in encoded
+    assert len(request.evidence_references) == 3
+    assert all(reference.capture_sha256.startswith("sha256:") for reference in request.evidence_references)
+
+
+def test_tampered_package_hash_is_rejected_on_canonical_export():
+    request = build_partner_validation_request(_repeatable_report())
+    tampered = request.model_copy(update={"package_sha256": "sha256:" + "0" * 64})
+
+    with pytest.raises(ValueError, match="hash verification failed"):
+        canonical_partner_request_bytes(tampered)
+
+
+def test_inconsistent_distinct_capture_count_is_rejected():
+    report = _repeatable_report().model_copy(update={"distinct_capture_count": 4})
+
+    with pytest.raises(ValueError, match="distinct-capture count is inconsistent"):
+        build_partner_validation_request(report)
+
+
+def test_preexisting_live_claim_is_rejected():
+    report = _repeatable_report().model_copy(update={"live_environment_validated": True})
+
+    with pytest.raises(ValueError, match="live-validation claim"):
+        build_partner_validation_request(report)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_partner_package.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_partner_package.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .hmaa_attestation import HMAAAttestationReport, HMAAAttestationState
+
+
+HMAA_PARTNER_REQUEST_VERSION = "worldshepherd.hmaa.partner-validation-request.v0.8"
+PARTNER_VALIDATION_SCOPE = "read-only-sandbox-interoperability"
+
+
+class HMAAPartnerEvidenceReference(BaseModel):
+    capture_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    fixture_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    final_chain_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    event_count: int = Field(gt=0)
+
+
+class HMAAPartnerValidationRequest(BaseModel):
+    package_version: str = HMAA_PARTNER_REQUEST_VERSION
+    request_status: str = "READY_FOR_PARTNER_VALIDATION_REQUEST"
+    mission_id: str = Field(min_length=1)
+    requested_scope: str = PARTNER_VALIDATION_SCOPE
+    attestation_aggregate_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    qualifying_capture_count: int = Field(ge=3)
+    evidence_references: list[HMAAPartnerEvidenceReference]
+    requested_checks: list[str]
+    claimable_labels: list[str]
+    prohibited_claims: list[str]
+    live_environment_validated: bool = False
+    package_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _request_body(report: HMAAAttestationReport) -> dict[str, Any]:
+    if report.live_environment_validated:
+        raise ValueError("partner request cannot be built from a live-validation claim")
+    if report.state is not HMAAAttestationState.EXTERNAL_ATTESTATION_REQUIRED:
+        raise ValueError(
+            "partner request requires an EXTERNAL_ATTESTATION_REQUIRED report"
+        )
+    if not report.repeatability_satisfied:
+        raise ValueError("partner request requires repeatability-qualified evidence")
+    if not report.external_attestation_required:
+        raise ValueError("partner request requires external attestation to remain pending")
+    if report.aggregate_sha256 is None:
+        raise ValueError("partner request requires an aggregate attestation digest")
+    if not report.mission_id:
+        raise ValueError("partner request requires a mission_id")
+
+    distinct = {capture.capture_sha256 for capture in report.captures}
+    if len(distinct) != report.distinct_capture_count:
+        raise ValueError("attestation distinct-capture count is inconsistent")
+    if report.distinct_capture_count < 3:
+        raise ValueError("partner request requires at least three distinct captures")
+
+    references = [
+        HMAAPartnerEvidenceReference(
+            capture_sha256=capture.capture_sha256,
+            fixture_sha256=capture.fixture_sha256,
+            final_chain_hash=capture.final_chain_hash,
+            event_count=capture.event_count,
+        )
+        for capture in report.captures
+    ]
+    references.sort(key=lambda item: item.capture_sha256)
+
+    return {
+        "package_version": HMAA_PARTNER_REQUEST_VERSION,
+        "request_status": "READY_FOR_PARTNER_VALIDATION_REQUEST",
+        "mission_id": report.mission_id,
+        "requested_scope": PARTNER_VALIDATION_SCOPE,
+        "attestation_aggregate_sha256": report.aggregate_sha256,
+        "qualifying_capture_count": report.distinct_capture_count,
+        "evidence_references": [
+            reference.model_dump(mode="json") for reference in references
+        ],
+        "requested_checks": [
+            "confirm the cited environment and access were authorized for read-only validation",
+            "confirm the cited entity/task stream evidence originated from the stated environment",
+            "confirm no publish, task mutation, manual-control, flight-control, or weapons action was requested by WS-HMAA",
+            "verify the supplied capture and aggregate SHA-256 references against the review evidence",
+            "return an independently attributable partner attestation bound to this package SHA-256",
+        ],
+        "claimable_labels": [
+            "IMPLEMENTED IN SOFTWARE",
+            "REQUIRES PARTNER VALIDATION",
+        ],
+        "prohibited_claims": [
+            "LIVE_ENVIRONMENT_VALIDATED",
+            "PARTNER_VALIDATED",
+            "FLIGHT_VALIDATED",
+            "OPERATIONALLY_VALIDATED",
+        ],
+        "live_environment_validated": False,
+    }
+
+
+def build_partner_validation_request(
+    report: HMAAAttestationReport,
+) -> HMAAPartnerValidationRequest:
+    body = _request_body(report)
+    return HMAAPartnerValidationRequest(
+        **body,
+        package_sha256=_sha256_json(body),
+    )
+
+
+def canonical_partner_request_bytes(request: HMAAPartnerValidationRequest) -> bytes:
+    body = request.model_dump(mode="json", exclude={"package_sha256"})
+    expected = _sha256_json(body)
+    if expected != request.package_sha256:
+        raise ValueError("partner validation request package hash verification failed")
+    return json.dumps(
+        request.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")


### PR DESCRIPTION
## Summary
Adds a canonical, secret-free partner validation request package derived only from repeatability-qualified v0.7 attestation reports.

### Added
- fixed validation scope: `read-only-sandbox-interoperability`
- partner evidence references containing capture SHA-256, fixture SHA-256, final chain hash, and event count only
- canonical package SHA-256 with verification on export
- explicit requested partner checks for authorization, environment provenance, read-only behavior, evidence hashes, and independently attributable return attestation
- explicit package status `READY_FOR_PARTNER_VALIDATION_REQUEST`
- explicit prohibited claims: live, partner, flight, and operational validation
- validation that at least three distinct qualifying captures remain consistent
- seven tests covering eligibility, deterministic hashing, secret/raw-payload exclusion, tamper detection, count inconsistency, and false live claims
- v0.8 partner-request boundary documentation

### Claims / safety boundary
This package is ready to be used in a future partner-validation request; it does not claim that a request was sent, received, reviewed, approved, or validated. `live_environment_validated` remains false.

No network, partner communication, OAuth behavior, credential handling, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP operation is added.

### Validation gate
Merge only after protected SARA CI/recovery/resilience gates and CodeQL are green.