### PR TITLE
WS-HMAA v0.9: fail-closed external attestation return contract

### DIFF
--- a/deployments/sara_verified_local_v1/WS_HMAA_V0_9_EXTERNAL_RESPONSE_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/WS_HMAA_V0_9_EXTERNAL_RESPONSE_BOUNDARY.md
@@ -1,0 +1,52 @@
+# WS-HMAA v0.9 — External Attestation Return Boundary
+
+## Purpose
+
+v0.9 defines how an independently produced partner-attestation response can be represented and assessed against a v0.8 partner-validation request. It separates structural integrity, signature authenticity, and human acceptance so that no single software step can manufacture a partner- or live-validation claim.
+
+## Binding requirements
+
+A response must bind exactly to the v0.8 request through:
+
+- `request_package_sha256`;
+- mission ID; and
+- requested scope.
+
+The response also carries an organization identifier, reviewer identifier, UTC-capable attestation timestamp, outcome, confirmed requested-check digests, evidence references, external-signature metadata, and a response SHA-256.
+
+## Integrity vs. authenticity
+
+The response SHA-256 detects alteration of the response container. It does **not** authenticate the external organization or reviewer.
+
+Authenticity is delegated to the `PartnerAttestationVerifier` protocol. The production default is fail-closed and returns an unverified result until a trusted verifier is explicitly configured. v0.9 does not implement custom cryptography or embed a trust store.
+
+## Outcome states
+
+- `UNVERIFIED_EXTERNAL_RESPONSE`: structurally bound evidence exists, but external signature authenticity is not established.
+- `VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE`: an authenticated `CONFIRMED` response covers every requested check, but a human must still accept it.
+- `VERIFIED_RESPONSE_REQUIRES_HUMAN_REVIEW`: an authenticated `PARTIAL` response requires human review.
+- `VERIFIED_RESPONSE_REJECTED`: an authenticated reviewer rejection is preserved as a rejection.
+
+## Claims boundary
+
+Every v0.9 assessment keeps all of these false:
+
+- `partner_validated`
+- `live_environment_validated`
+- `flight_validated`
+- `operationally_validated`
+
+The only claimable labels remain:
+
+- `IMPLEMENTED IN SOFTWARE`
+- `REQUIRES PARTNER VALIDATION`
+
+A future human-acceptance workflow may record a governed acceptance decision, but it must remain distinct from flight or operational validation and must not infer facts that the external evidence did not attest.
+
+## Check coverage
+
+Each v0.8 requested check is represented by a SHA-256 digest of its canonical text. A `CONFIRMED` external response must cover every requested check. Unknown check references are rejected. A `REJECTED` response may not simultaneously assert confirmed checks.
+
+## Control boundary
+
+v0.9 adds no network transport, email/messaging, OAuth behavior, credentials, trust-store mutation, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP operation. It only assesses an externally supplied response object against an existing v0.8 request.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_partner_response.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_partner_response.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from worldshepherd_sara.hmaa_attestation import attest_candidate_captures
+from worldshepherd_sara.hmaa_interop import run_public_contract_replay
+from worldshepherd_sara.hmaa_lattice_capture import SandboxReadCaptureResult
+from worldshepherd_sara.hmaa_partner_package import build_partner_validation_request
+from worldshepherd_sara.hmaa_partner_response import (
+    ExternalSignature,
+    HMAAPartnerAttestationResponse,
+    PartnerAttestationOutcome,
+    PartnerAttestationState,
+    PartnerSignatureVerification,
+    assess_partner_attestation_response,
+    canonical_unsigned_response_bytes,
+    expected_response_sha256,
+    requested_check_digests,
+)
+
+
+def _capture(sequence: int) -> SandboxReadCaptureResult:
+    interop = run_public_contract_replay(
+        mission_id="PARTNER-RESPONSE-001",
+        source_label="authorized-sandbox-readonly-candidate",
+        items=[
+            {
+                "stream": "entities",
+                "message": {
+                    "heartbeat": {
+                        "timestamp": f"2026-09-04T23:1{sequence}:00Z",
+                        "sequence": sequence,
+                    }
+                },
+            }
+        ],
+    )
+    return SandboxReadCaptureResult(
+        live_environment_validated=False,
+        source_label="authorized-sandbox-readonly-candidate",
+        captured_entity_messages=1,
+        captured_task_messages=0,
+        interop=interop,
+    )
+
+
+def _request():
+    report = attest_candidate_captures([_capture(1), _capture(2), _capture(3)])
+    return build_partner_validation_request(report)
+
+
+def _response(request, *, outcome=PartnerAttestationOutcome.CONFIRMED, checks=None):
+    if checks is None:
+        checks = requested_check_digests(request) if outcome is not PartnerAttestationOutcome.REJECTED else []
+    response = HMAAPartnerAttestationResponse(
+        request_package_sha256=request.package_sha256,
+        mission_id=request.mission_id,
+        attested_scope=request.requested_scope,
+        organization_id="example-partner-org",
+        reviewer_id="reviewer-001",
+        attested_at=datetime(2026, 9, 4, 23, 20, tzinfo=timezone.utc),
+        outcome=outcome,
+        confirmed_check_sha256=checks,
+        evidence_references=["partner-evidence:case-001"],
+        signature=ExternalSignature(
+            algorithm="external-verifier-test",
+            key_id="partner-key-001",
+            value="test-signature-not-production-crypto",
+        ),
+        response_sha256="sha256:" + "0" * 64,
+    )
+    return response.model_copy(
+        update={"response_sha256": expected_response_sha256(response)}
+    )
+
+
+class _VerifiedTestVerifier:
+    def verify(self, *, canonical_payload: bytes, signature: ExternalSignature):
+        assert canonical_payload
+        assert signature.key_id == "partner-key-001"
+        return PartnerSignatureVerification(
+            verified=True,
+            verifier_id="test-verifier",
+            reason="test fixture authenticated the external response",
+        )
+
+
+class _RejectedTestVerifier:
+    def verify(self, *, canonical_payload: bytes, signature: ExternalSignature):
+        assert canonical_payload
+        return PartnerSignatureVerification(
+            verified=False,
+            verifier_id="test-verifier",
+            reason="signature authentication failed",
+        )
+
+
+def test_default_verifier_fails_closed_without_promoting_claims():
+    request = _request()
+    assessment = assess_partner_attestation_response(request, _response(request))
+
+    assert assessment.state is PartnerAttestationState.UNVERIFIED_EXTERNAL_RESPONSE
+    assert assessment.signature_verified is False
+    assert assessment.partner_validated is False
+    assert assessment.live_environment_validated is False
+    assert assessment.flight_validated is False
+    assert assessment.operationally_validated is False
+
+
+def test_authenticated_confirmation_requires_human_acceptance_and_still_sets_no_validation_flag():
+    request = _request()
+    assessment = assess_partner_attestation_response(
+        request,
+        _response(request),
+        verifier=_VerifiedTestVerifier(),
+    )
+
+    assert assessment.state is PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE
+    assert assessment.signature_verified is True
+    assert assessment.all_requested_checks_confirmed is True
+    assert assessment.human_acceptance_required is True
+    assert assessment.partner_validated is False
+    assert assessment.live_environment_validated is False
+    assert "REQUIRES PARTNER VALIDATION" in assessment.claimable_labels
+
+
+def test_partial_authenticated_response_requires_human_review():
+    request = _request()
+    subset = requested_check_digests(request)[:2]
+    assessment = assess_partner_attestation_response(
+        request,
+        _response(request, outcome=PartnerAttestationOutcome.PARTIAL, checks=subset),
+        verifier=_VerifiedTestVerifier(),
+    )
+
+    assert assessment.state is PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_REVIEW
+    assert assessment.all_requested_checks_confirmed is False
+    assert assessment.partner_validated is False
+
+
+def test_authenticated_rejection_is_preserved_as_rejected_not_validated():
+    request = _request()
+    assessment = assess_partner_attestation_response(
+        request,
+        _response(request, outcome=PartnerAttestationOutcome.REJECTED, checks=[]),
+        verifier=_VerifiedTestVerifier(),
+    )
+
+    assert assessment.state is PartnerAttestationState.VERIFIED_RESPONSE_REJECTED
+    assert assessment.signature_verified is True
+    assert assessment.partner_validated is False
+    assert assessment.live_environment_validated is False
+
+
+def test_explicit_failed_verifier_stays_unverified():
+    request = _request()
+    assessment = assess_partner_attestation_response(
+        request,
+        _response(request),
+        verifier=_RejectedTestVerifier(),
+    )
+
+    assert assessment.state is PartnerAttestationState.UNVERIFIED_EXTERNAL_RESPONSE
+    assert assessment.signature_verified is False
+    assert assessment.verifier_reason == "signature authentication failed"
+
+
+def test_response_must_bind_to_exact_request_hash_mission_and_scope():
+    request = _request()
+    response = _response(request)
+
+    wrong_hash = response.model_copy(update={"request_package_sha256": "sha256:" + "1" * 64})
+    with pytest.raises(ValueError, match="not bound"):
+        assess_partner_attestation_response(request, wrong_hash)
+
+    wrong_mission = response.model_copy(update={"mission_id": "OTHER"})
+    with pytest.raises(ValueError, match="mission_id"):
+        assess_partner_attestation_response(request, wrong_mission)
+
+    wrong_scope = response.model_copy(update={"attested_scope": "other-scope"})
+    with pytest.raises(ValueError, match="scope"):
+        assess_partner_attestation_response(request, wrong_scope)
+
+
+def test_response_hash_detects_tampering_before_signature_verification():
+    request = _request()
+    response = _response(request)
+    tampered = response.model_copy(update={"reviewer_id": "tampered-reviewer"})
+
+    with pytest.raises(ValueError, match="hash verification failed"):
+        assess_partner_attestation_response(
+            request,
+            tampered,
+            verifier=_VerifiedTestVerifier(),
+        )
+
+
+def test_confirmed_response_must_cover_every_requested_check():
+    request = _request()
+    incomplete = _response(
+        request,
+        outcome=PartnerAttestationOutcome.CONFIRMED,
+        checks=requested_check_digests(request)[:-1],
+    )
+
+    with pytest.raises(ValueError, match="every requested check"):
+        assess_partner_attestation_response(request, incomplete)
+
+
+def test_unknown_check_reference_is_rejected():
+    request = _request()
+    unknown = "sha256:" + "f" * 64
+    response = _response(
+        request,
+        outcome=PartnerAttestationOutcome.PARTIAL,
+        checks=[unknown],
+    )
+
+    with pytest.raises(ValueError, match="unknown requested-check"):
+        assess_partner_attestation_response(request, response)
+
+
+def test_rejected_response_cannot_simultaneously_confirm_checks():
+    request = _request()
+    response = _response(
+        request,
+        outcome=PartnerAttestationOutcome.REJECTED,
+        checks=requested_check_digests(request)[:1],
+    )
+
+    with pytest.raises(ValueError, match="must not claim confirmed"):
+        assess_partner_attestation_response(request, response)
+
+
+def test_signature_is_not_inside_canonical_unsigned_payload():
+    request = _request()
+    response = _response(request)
+    payload = canonical_unsigned_response_bytes(response)
+
+    assert b"test-signature-not-production-crypto" not in payload
+    assert b"response_sha256" not in payload
+    assert request.package_sha256.encode("utf-8") in payload

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_partner_response.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_partner_response.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field, field_validator
+
+from .hmaa_partner_package import HMAAPartnerValidationRequest
+
+
+HMAA_PARTNER_RESPONSE_VERSION = "worldshepherd.hmaa.partner-attestation-response.v0.9"
+
+
+class PartnerAttestationOutcome(str, Enum):
+    CONFIRMED = "CONFIRMED"
+    PARTIAL = "PARTIAL"
+    REJECTED = "REJECTED"
+
+
+class PartnerAttestationState(str, Enum):
+    UNVERIFIED_EXTERNAL_RESPONSE = "UNVERIFIED_EXTERNAL_RESPONSE"
+    VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE = (
+        "VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE"
+    )
+    VERIFIED_RESPONSE_REQUIRES_HUMAN_REVIEW = "VERIFIED_RESPONSE_REQUIRES_HUMAN_REVIEW"
+    VERIFIED_RESPONSE_REJECTED = "VERIFIED_RESPONSE_REJECTED"
+
+
+class ExternalSignature(BaseModel):
+    algorithm: str = Field(min_length=1, max_length=128)
+    key_id: str = Field(min_length=1, max_length=512)
+    value: str = Field(min_length=1, max_length=16384)
+
+
+class HMAAPartnerAttestationResponse(BaseModel):
+    response_version: str = HMAA_PARTNER_RESPONSE_VERSION
+    request_package_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    mission_id: str = Field(min_length=1, max_length=512)
+    attested_scope: str = Field(min_length=1, max_length=512)
+    organization_id: str = Field(min_length=1, max_length=512)
+    reviewer_id: str = Field(min_length=1, max_length=512)
+    attested_at: datetime
+    outcome: PartnerAttestationOutcome
+    confirmed_check_sha256: list[str] = Field(default_factory=list, max_length=64)
+    evidence_references: list[str] = Field(default_factory=list, max_length=64)
+    signature: ExternalSignature
+    response_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+    @field_validator("confirmed_check_sha256")
+    @classmethod
+    def validate_check_hashes(cls, value: list[str]) -> list[str]:
+        pattern_prefix = "sha256:"
+        for item in value:
+            if not item.startswith(pattern_prefix) or len(item) != 71:
+                raise ValueError("confirmed check references must be sha256 digests")
+            try:
+                int(item[len(pattern_prefix) :], 16)
+            except ValueError as exc:
+                raise ValueError("confirmed check references must be sha256 digests") from exc
+        if len(set(value)) != len(value):
+            raise ValueError("confirmed check references must be unique")
+        return value
+
+
+class PartnerSignatureVerification(BaseModel):
+    verified: bool
+    verifier_id: str = Field(min_length=1, max_length=512)
+    reason: str = Field(min_length=1, max_length=2048)
+
+
+class PartnerAttestationVerifier(Protocol):
+    def verify(
+        self,
+        *,
+        canonical_payload: bytes,
+        signature: ExternalSignature,
+    ) -> PartnerSignatureVerification: ...
+
+
+class NoPartnerAttestationVerifier:
+    """Fail-closed production default until a trusted verifier is configured."""
+
+    def verify(
+        self,
+        *,
+        canonical_payload: bytes,
+        signature: ExternalSignature,
+    ) -> PartnerSignatureVerification:
+        del canonical_payload, signature
+        return PartnerSignatureVerification(
+            verified=False,
+            verifier_id="none-configured",
+            reason="no trusted external-attestation verifier is configured",
+        )
+
+
+class HMAAPartnerAttestationAssessment(BaseModel):
+    state: PartnerAttestationState
+    request_package_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    response_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    outcome: PartnerAttestationOutcome
+    signature_verified: bool
+    verifier_id: str
+    verifier_reason: str
+    all_requested_checks_confirmed: bool
+    human_acceptance_required: bool = True
+    partner_validated: bool = False
+    live_environment_validated: bool = False
+    flight_validated: bool = False
+    operationally_validated: bool = False
+    claimable_labels: list[str] = Field(default_factory=list)
+    blocking_reasons: list[str] = Field(default_factory=list)
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return _sha256_bytes(value.encode("utf-8"))
+
+
+def requested_check_digests(request: HMAAPartnerValidationRequest) -> list[str]:
+    return sorted({_sha256_text(check) for check in request.requested_checks})
+
+
+def _response_unsigned_body(response: HMAAPartnerAttestationResponse) -> dict[str, Any]:
+    return response.model_dump(
+        mode="json",
+        exclude={"signature", "response_sha256"},
+    )
+
+
+def canonical_unsigned_response_bytes(response: HMAAPartnerAttestationResponse) -> bytes:
+    return json.dumps(
+        _response_unsigned_body(response),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def expected_response_sha256(response: HMAAPartnerAttestationResponse) -> str:
+    signed_container = {
+        **_response_unsigned_body(response),
+        "signature": response.signature.model_dump(mode="json"),
+    }
+    encoded = json.dumps(
+        signed_container,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return _sha256_bytes(encoded)
+
+
+def assess_partner_attestation_response(
+    request: HMAAPartnerValidationRequest,
+    response: HMAAPartnerAttestationResponse,
+    *,
+    verifier: PartnerAttestationVerifier | None = None,
+) -> HMAAPartnerAttestationAssessment:
+    if response.request_package_sha256 != request.package_sha256:
+        raise ValueError("partner response is not bound to this request package")
+    if response.mission_id != request.mission_id:
+        raise ValueError("partner response mission_id does not match request")
+    if response.attested_scope != request.requested_scope:
+        raise ValueError("partner response scope does not match request")
+    if expected_response_sha256(response) != response.response_sha256:
+        raise ValueError("partner response hash verification failed")
+
+    required_checks = set(requested_check_digests(request))
+    confirmed_checks = set(response.confirmed_check_sha256)
+    unknown_checks = confirmed_checks - required_checks
+    if unknown_checks:
+        raise ValueError("partner response contains unknown requested-check references")
+    all_confirmed = confirmed_checks == required_checks
+    if response.outcome is PartnerAttestationOutcome.CONFIRMED and not all_confirmed:
+        raise ValueError("CONFIRMED response must confirm every requested check")
+    if response.outcome is PartnerAttestationOutcome.REJECTED and confirmed_checks:
+        raise ValueError("REJECTED response must not claim confirmed requested checks")
+
+    active_verifier = verifier or NoPartnerAttestationVerifier()
+    verification = active_verifier.verify(
+        canonical_payload=canonical_unsigned_response_bytes(response),
+        signature=response.signature,
+    )
+
+    blockers: list[str] = []
+    if not verification.verified:
+        blockers.append("external signature authenticity has not been verified")
+        state = PartnerAttestationState.UNVERIFIED_EXTERNAL_RESPONSE
+    elif response.outcome is PartnerAttestationOutcome.CONFIRMED:
+        blockers.append("human acceptance is required before any partner-validation claim")
+        state = PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE
+    elif response.outcome is PartnerAttestationOutcome.PARTIAL:
+        blockers.append("partial external attestation requires human review")
+        state = PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_REVIEW
+    else:
+        blockers.append("external reviewer rejected the validation request")
+        state = PartnerAttestationState.VERIFIED_RESPONSE_REJECTED
+
+    return HMAAPartnerAttestationAssessment(
+        state=state,
+        request_package_sha256=request.package_sha256,
+        response_sha256=response.response_sha256,
+        outcome=response.outcome,
+        signature_verified=verification.verified,
+        verifier_id=verification.verifier_id,
+        verifier_reason=verification.reason,
+        all_requested_checks_confirmed=all_confirmed,
+        human_acceptance_required=True,
+        partner_validated=False,
+        live_environment_validated=False,
+        flight_validated=False,
+        operationally_validated=False,
+        claimable_labels=[
+            "IMPLEMENTED IN SOFTWARE",
+            "REQUIRES PARTNER VALIDATION",
+        ],
+        blocking_reasons=blockers,
+    )


### PR DESCRIPTION
## Summary
Adds a governed external-attestation response contract over the merged v0.8 partner validation request package.

### Added
- request-bound response envelope keyed to exact v0.8 package SHA-256, mission ID, and requested scope
- external organization/reviewer attribution, attestation timestamp, outcome, evidence references, and signature metadata
- deterministic response-container SHA-256 tamper detection
- SHA-256 digests for v0.8 requested-check coverage
- `PartnerAttestationVerifier` protocol separating structural integrity from signature authenticity
- fail-closed production default when no trusted verifier is configured
- explicit states for unverified response, authenticated confirmation requiring human acceptance, authenticated partial response requiring human review, and authenticated rejection
- hard rule that authenticated confirmation still does not set partner/live/flight/operational validation flags
- eleven tests covering binding, tamper detection, check coverage, unknown/contradictory checks, failed authentication, authenticated confirmation/partial/rejection, and unsigned canonical payload construction
- v0.9 external-response boundary documentation

### Claims / safety boundary
No v0.9 path can auto-promote `partner_validated`, `live_environment_validated`, `flight_validated`, or `operationally_validated`; all remain false. Authenticated confirmation stops at `VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE`.

No network, email/messaging, OAuth behavior, credential handling, trust-store mutation, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP operation is added.

### Validation gate
Merge only after protected SARA CI/recovery/resilience gates and CodeQL are green.