### PR TITLE
WS-HMAA v1.0: governed human acceptance record

### DIFF
--- a/deployments/sara_verified_local_v1/WS_HMAA_V1_0_HUMAN_ACCEPTANCE_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/WS_HMAA_V1_0_HUMAN_ACCEPTANCE_BOUNDARY.md
@@ -1,0 +1,59 @@
+# WS-HMAA v1.0 — Human Acceptance Boundary
+
+## Purpose
+
+v1.0 adds the governed human decision step that follows a v0.9 external-attestation assessment. It records acceptance, rejection, or deferral without allowing a narrow partner attestation to become a broad validation claim.
+
+## Acceptance preconditions
+
+`ACCEPT` is legal only when the input assessment:
+
+1. is `VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE`;
+2. has an authenticated external signature;
+3. carries a `CONFIRMED` outcome;
+4. confirms every requested validation check;
+5. still requires human acceptance; and
+6. contains no preexisting partner/live/flight/operational validation claim.
+
+Any violation fails closed.
+
+## Decision states
+
+- `PARTNER_ATTESTATION_ACCEPTED_FOR_REQUESTED_SCOPE`
+- `PARTNER_ATTESTATION_REJECTED`
+- `PARTNER_ATTESTATION_DEFERRED`
+
+Rejection and deferral remain recordable for adverse, incomplete, or unverified assessments so the evidence trail can preserve an explicit human disposition.
+
+## Evidence record
+
+Each decision record binds to:
+
+- decision ID and reviewer identifier;
+- decision timestamp, action, and rationale;
+- v0.8 request package SHA-256;
+- v0.9 response SHA-256;
+- verifier identifier; and
+- a canonical record SHA-256.
+
+The record hash detects later modification of the stored decision representation.
+
+## Claims boundary
+
+An accepted decision may state only:
+
+- `IMPLEMENTED IN SOFTWARE`
+- `PARTNER ATTESTATION ACCEPTED FOR REQUESTED SCOPE`
+
+It explicitly keeps all of these false:
+
+- `partner_validated`
+- `live_environment_validated`
+- `flight_validated`
+- `operationally_validated`
+
+The distinction is intentional: accepting an authenticated partner attestation for the narrow `read-only-sandbox-interoperability` request does not establish generalized partner validation, live-environment validation, flight validation, or operational validation.
+
+## Control boundary
+
+v1.0 adds no network transport, partner communication, OAuth behavior, credentials, signature trust store, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP operation. It records a human evidence disposition only.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_human_acceptance.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_human_acceptance.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from worldshepherd_sara.hmaa_human_acceptance import (
+    HMAAHumanAcceptanceDecision,
+    HumanAcceptanceAction,
+    HumanAcceptanceState,
+    record_human_acceptance,
+    verify_human_acceptance_record,
+)
+from worldshepherd_sara.hmaa_partner_response import (
+    HMAAPartnerAttestationAssessment,
+    PartnerAttestationOutcome,
+    PartnerAttestationState,
+)
+
+
+REQUEST_HASH = "sha256:" + "1" * 64
+RESPONSE_HASH = "sha256:" + "2" * 64
+
+
+def _assessment(
+    *,
+    state=PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE,
+    outcome=PartnerAttestationOutcome.CONFIRMED,
+    signature_verified=True,
+    all_checks=True,
+    partner_validated=False,
+    live=False,
+    flight=False,
+    operational=False,
+):
+    return HMAAPartnerAttestationAssessment(
+        state=state,
+        request_package_sha256=REQUEST_HASH,
+        response_sha256=RESPONSE_HASH,
+        outcome=outcome,
+        signature_verified=signature_verified,
+        verifier_id="trusted-verifier-001",
+        verifier_reason="external signature authenticated",
+        all_requested_checks_confirmed=all_checks,
+        human_acceptance_required=True,
+        partner_validated=partner_validated,
+        live_environment_validated=live,
+        flight_validated=flight,
+        operationally_validated=operational,
+        claimable_labels=["IMPLEMENTED IN SOFTWARE", "REQUIRES PARTNER VALIDATION"],
+        blocking_reasons=["human acceptance is required"],
+    )
+
+
+def _decision(action=HumanAcceptanceAction.ACCEPT):
+    return HMAAHumanAcceptanceDecision(
+        decision_id="decision-001",
+        decision_by="authorized-human-reviewer",
+        decided_at=datetime(2026, 9, 4, 23, 30, tzinfo=timezone.utc),
+        action=action,
+        rationale="Reviewed the authenticated evidence and scope boundaries.",
+    )
+
+
+def test_accept_records_partner_attestation_for_requested_scope_only():
+    record = record_human_acceptance(_assessment(), _decision())
+
+    assert record.state is HumanAcceptanceState.PARTNER_ATTESTATION_ACCEPTED_FOR_REQUESTED_SCOPE
+    assert record.partner_attestation_accepted is True
+    assert record.accepted_scope_limited_to_request is True
+    assert record.partner_validated is False
+    assert record.live_environment_validated is False
+    assert record.flight_validated is False
+    assert record.operationally_validated is False
+    assert "PARTNER ATTESTATION ACCEPTED FOR REQUESTED SCOPE" in record.claimable_labels
+    assert verify_human_acceptance_record(record) is True
+
+
+def test_unverified_response_cannot_be_accepted():
+    assessment = _assessment(
+        state=PartnerAttestationState.UNVERIFIED_EXTERNAL_RESPONSE,
+        signature_verified=False,
+    )
+
+    with pytest.raises(ValueError, match="verified CONFIRMED"):
+        record_human_acceptance(assessment, _decision())
+
+
+def test_partial_response_cannot_be_accepted():
+    assessment = _assessment(
+        state=PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_REVIEW,
+        outcome=PartnerAttestationOutcome.PARTIAL,
+        all_checks=False,
+    )
+
+    with pytest.raises(ValueError, match="verified CONFIRMED"):
+        record_human_acceptance(assessment, _decision())
+
+
+def test_preexisting_validation_claim_blocks_acceptance():
+    assessment = _assessment(partner_validated=True)
+
+    with pytest.raises(ValueError, match="preexisting validation claim"):
+        record_human_acceptance(assessment, _decision())
+
+
+def test_reject_is_recordable_without_promoting_claims():
+    record = record_human_acceptance(
+        _assessment(
+            state=PartnerAttestationState.VERIFIED_RESPONSE_REJECTED,
+            outcome=PartnerAttestationOutcome.REJECTED,
+            all_checks=False,
+        ),
+        _decision(HumanAcceptanceAction.REJECT),
+    )
+
+    assert record.state is HumanAcceptanceState.PARTNER_ATTESTATION_REJECTED
+    assert record.partner_attestation_accepted is False
+    assert "REQUIRES PARTNER VALIDATION" in record.claimable_labels
+    assert verify_human_acceptance_record(record) is True
+
+
+def test_defer_is_recordable_for_unverified_response():
+    record = record_human_acceptance(
+        _assessment(
+            state=PartnerAttestationState.UNVERIFIED_EXTERNAL_RESPONSE,
+            signature_verified=False,
+        ),
+        _decision(HumanAcceptanceAction.DEFER),
+    )
+
+    assert record.state is HumanAcceptanceState.PARTNER_ATTESTATION_DEFERRED
+    assert record.partner_attestation_accepted is False
+    assert record.live_environment_validated is False
+    assert verify_human_acceptance_record(record) is True
+
+
+def test_accept_requires_complete_requested_check_coverage():
+    assessment = _assessment(all_checks=False)
+
+    with pytest.raises(ValueError, match="every requested check"):
+        record_human_acceptance(assessment, _decision())
+
+
+def test_accept_requires_signature_authentication():
+    assessment = _assessment(signature_verified=False)
+
+    with pytest.raises(ValueError, match="authenticated external signature"):
+        record_human_acceptance(assessment, _decision())
+
+
+def test_record_hash_detects_tampering():
+    record = record_human_acceptance(_assessment(), _decision())
+    tampered = record.model_copy(update={"rationale": "tampered rationale"})
+
+    assert verify_human_acceptance_record(tampered) is False

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_human_acceptance.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_human_acceptance.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .hmaa_partner_response import (
+    HMAAPartnerAttestationAssessment,
+    PartnerAttestationOutcome,
+    PartnerAttestationState,
+)
+
+
+HMAA_HUMAN_ACCEPTANCE_VERSION = "worldshepherd.hmaa.human-acceptance.v1.0"
+
+
+class HumanAcceptanceAction(str, Enum):
+    ACCEPT = "ACCEPT"
+    REJECT = "REJECT"
+    DEFER = "DEFER"
+
+
+class HumanAcceptanceState(str, Enum):
+    PARTNER_ATTESTATION_ACCEPTED_FOR_REQUESTED_SCOPE = (
+        "PARTNER_ATTESTATION_ACCEPTED_FOR_REQUESTED_SCOPE"
+    )
+    PARTNER_ATTESTATION_REJECTED = "PARTNER_ATTESTATION_REJECTED"
+    PARTNER_ATTESTATION_DEFERRED = "PARTNER_ATTESTATION_DEFERRED"
+
+
+class HMAAHumanAcceptanceDecision(BaseModel):
+    decision_id: str = Field(min_length=1, max_length=512)
+    decision_by: str = Field(min_length=1, max_length=512)
+    decided_at: datetime
+    action: HumanAcceptanceAction
+    rationale: str = Field(min_length=1, max_length=4096)
+
+
+class HMAAHumanAcceptanceRecord(BaseModel):
+    record_version: str = HMAA_HUMAN_ACCEPTANCE_VERSION
+    state: HumanAcceptanceState
+    decision_id: str
+    decision_by: str
+    decided_at: datetime
+    action: HumanAcceptanceAction
+    rationale: str
+    request_package_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    response_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    verifier_id: str = Field(min_length=1, max_length=512)
+    partner_attestation_accepted: bool = False
+    accepted_scope_limited_to_request: bool = False
+    partner_validated: bool = False
+    live_environment_validated: bool = False
+    flight_validated: bool = False
+    operationally_validated: bool = False
+    claimable_labels: list[str] = Field(default_factory=list)
+    blocking_reasons: list[str] = Field(default_factory=list)
+    record_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _acceptance_preconditions(assessment: HMAAPartnerAttestationAssessment) -> None:
+    if assessment.state is not PartnerAttestationState.VERIFIED_RESPONSE_REQUIRES_HUMAN_ACCEPTANCE:
+        raise ValueError(
+            "ACCEPT requires a verified CONFIRMED response awaiting human acceptance"
+        )
+    if not assessment.signature_verified:
+        raise ValueError("ACCEPT requires authenticated external signature evidence")
+    if assessment.outcome is not PartnerAttestationOutcome.CONFIRMED:
+        raise ValueError("ACCEPT requires a CONFIRMED external outcome")
+    if not assessment.all_requested_checks_confirmed:
+        raise ValueError("ACCEPT requires every requested check to be confirmed")
+    if not assessment.human_acceptance_required:
+        raise ValueError("assessment does not require a human acceptance decision")
+    if (
+        assessment.partner_validated
+        or assessment.live_environment_validated
+        or assessment.flight_validated
+        or assessment.operationally_validated
+    ):
+        raise ValueError("assessment contains a preexisting validation claim")
+
+
+def record_human_acceptance(
+    assessment: HMAAPartnerAttestationAssessment,
+    decision: HMAAHumanAcceptanceDecision,
+) -> HMAAHumanAcceptanceRecord:
+    if decision.action is HumanAcceptanceAction.ACCEPT:
+        _acceptance_preconditions(assessment)
+        state = HumanAcceptanceState.PARTNER_ATTESTATION_ACCEPTED_FOR_REQUESTED_SCOPE
+        partner_attestation_accepted = True
+        scope_limited = True
+        blocking = [
+            "acceptance is limited to the partner attestation and requested scope",
+            "live-environment, flight, and operational validation require separate evidence",
+        ]
+        claimable = [
+            "IMPLEMENTED IN SOFTWARE",
+            "PARTNER ATTESTATION ACCEPTED FOR REQUESTED SCOPE",
+        ]
+    elif decision.action is HumanAcceptanceAction.REJECT:
+        state = HumanAcceptanceState.PARTNER_ATTESTATION_REJECTED
+        partner_attestation_accepted = False
+        scope_limited = False
+        blocking = ["human reviewer rejected the partner attestation"]
+        claimable = ["IMPLEMENTED IN SOFTWARE", "REQUIRES PARTNER VALIDATION"]
+    else:
+        state = HumanAcceptanceState.PARTNER_ATTESTATION_DEFERRED
+        partner_attestation_accepted = False
+        scope_limited = False
+        blocking = ["human acceptance decision is deferred"]
+        claimable = ["IMPLEMENTED IN SOFTWARE", "REQUIRES PARTNER VALIDATION"]
+
+    body = {
+        "record_version": HMAA_HUMAN_ACCEPTANCE_VERSION,
+        "state": state.value,
+        "decision_id": decision.decision_id,
+        "decision_by": decision.decision_by,
+        "decided_at": decision.decided_at.isoformat(),
+        "action": decision.action.value,
+        "rationale": decision.rationale,
+        "request_package_sha256": assessment.request_package_sha256,
+        "response_sha256": assessment.response_sha256,
+        "verifier_id": assessment.verifier_id,
+        "partner_attestation_accepted": partner_attestation_accepted,
+        "accepted_scope_limited_to_request": scope_limited,
+        "partner_validated": False,
+        "live_environment_validated": False,
+        "flight_validated": False,
+        "operationally_validated": False,
+        "claimable_labels": claimable,
+        "blocking_reasons": blocking,
+    }
+    return HMAAHumanAcceptanceRecord(
+        **body,
+        record_sha256=_sha256_json(body),
+    )
+
+
+def verify_human_acceptance_record(record: HMAAHumanAcceptanceRecord) -> bool:
+    body = record.model_dump(mode="json", exclude={"record_sha256"})
+    return _sha256_json(body) == record.record_sha256

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_human_acceptance.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_human_acceptance.py
@@ -124,29 +124,29 @@ def record_human_acceptance(
         blocking = ["human acceptance decision is deferred"]
         claimable = ["IMPLEMENTED IN SOFTWARE", "REQUIRES PARTNER VALIDATION"]
 
-    body = {
-        "record_version": HMAA_HUMAN_ACCEPTANCE_VERSION,
-        "state": state.value,
-        "decision_id": decision.decision_id,
-        "decision_by": decision.decision_by,
-        "decided_at": decision.decided_at.isoformat(),
-        "action": decision.action.value,
-        "rationale": decision.rationale,
-        "request_package_sha256": assessment.request_package_sha256,
-        "response_sha256": assessment.response_sha256,
-        "verifier_id": assessment.verifier_id,
-        "partner_attestation_accepted": partner_attestation_accepted,
-        "accepted_scope_limited_to_request": scope_limited,
-        "partner_validated": False,
-        "live_environment_validated": False,
-        "flight_validated": False,
-        "operationally_validated": False,
-        "claimable_labels": claimable,
-        "blocking_reasons": blocking,
-    }
-    return HMAAHumanAcceptanceRecord(
-        **body,
-        record_sha256=_sha256_json(body),
+    provisional = HMAAHumanAcceptanceRecord(
+        state=state,
+        decision_id=decision.decision_id,
+        decision_by=decision.decision_by,
+        decided_at=decision.decided_at,
+        action=decision.action,
+        rationale=decision.rationale,
+        request_package_sha256=assessment.request_package_sha256,
+        response_sha256=assessment.response_sha256,
+        verifier_id=assessment.verifier_id,
+        partner_attestation_accepted=partner_attestation_accepted,
+        accepted_scope_limited_to_request=scope_limited,
+        partner_validated=False,
+        live_environment_validated=False,
+        flight_validated=False,
+        operationally_validated=False,
+        claimable_labels=claimable,
+        blocking_reasons=blocking,
+        record_sha256="sha256:" + "0" * 64,
+    )
+    canonical_body = provisional.model_dump(mode="json", exclude={"record_sha256"})
+    return provisional.model_copy(
+        update={"record_sha256": _sha256_json(canonical_body)}
     )
 
 


### PR DESCRIPTION
## Summary
Adds the governed human ACCEPT/REJECT/DEFER disposition step over merged v0.9 external-attestation assessments.

### Added
- explicit human acceptance decision model with reviewer, timestamp, rationale, and action
- strict ACCEPT preconditions: authenticated signature, CONFIRMED outcome, complete requested-check coverage, human-acceptance-required state, and no preexisting validation claim
- explicit acceptance/rejection/deferral states
- acceptance limited to `PARTNER_ATTESTATION_ACCEPTED_FOR_REQUESTED_SCOPE`
- tamper-evident human-decision record bound to v0.8 request SHA-256, v0.9 response SHA-256, and verifier identity
- record-hash verification helper
- nine tests covering valid narrow-scope acceptance, unverified/partial rejection, preexisting-claim blocking, reject/defer preservation, check coverage, signature authentication, and tamper detection
- v1.0 human-acceptance boundary documentation

### Claims / safety boundary
Even an accepted authenticated partner attestation keeps `partner_validated`, `live_environment_validated`, `flight_validated`, and `operationally_validated` false. The accepted statement is explicitly limited to the requested partner-attestation scope.

No network, partner communication, OAuth behavior, credentials, signature trust-store mutation, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP operation is added.

### Validation gate
Merge only after protected SARA CI/recovery/resilience gates and CodeQL are green.