### PR TITLE
WS-HMAA v1.1: zero-network authorized-read preflight

### DIFF
--- a/deployments/sara_verified_local_v1/WS_HMAA_V1_1_PREFLIGHT_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/WS_HMAA_V1_1_PREFLIGHT_BOUNDARY.md
@@ -1,0 +1,57 @@
+# WS-HMAA v1.1 — Read-Only Preflight Boundary
+
+## Purpose
+
+v1.1 adds a zero-network preflight evaluator for the existing WS-HMAA read-only Sandbox path. It determines whether configuration, authorization posture, and the finite capture plan are internally ready without acquiring a token, constructing a live transport, or opening a stream.
+
+## Default behavior
+
+`network_enabled` defaults to `false`. Preflight evaluation always records `network_call_performed=false`.
+
+A dry run may return `DRY_RUN_READY` even when external Sandbox configuration is missing. That means the local evaluator and finite capture plan are usable; it does **not** mean an external read can be attempted.
+
+## Authorized-read readiness
+
+`AUTHORIZED_READ_READY` requires all of the following:
+
+1. `network_enabled=true`;
+2. `authorization_confirmed=true`;
+3. a valid HTTPS Lattice Sandbox environment endpoint;
+4. `SANDBOXES_TOKEN` present;
+5. exactly one complete environment-token mode:
+   - static `ENVIRONMENT_TOKEN`, or
+   - OAuth `LATTICE_CLIENT_ID` + `LATTICE_CLIENT_SECRET`;
+6. no simultaneous static + OAuth mode; and
+7. a finite valid entity/task capture plan requesting at least one message.
+
+This state is readiness only. v1.1 still performs no network operation.
+
+## Secret handling
+
+The preflight report records credential **presence booleans only**. It does not export:
+
+- environment bearer tokens;
+- OAuth client secrets;
+- Sandbox authorization token values; or
+- OAuth client IDs.
+
+The endpoint is retained because it is required to validate the permitted Sandbox host boundary.
+
+## Integrity
+
+Each report is bound to a canonical SHA-256 over the complete secret-free report body. The verifier detects later changes to the report representation.
+
+## Claims boundary
+
+Every v1.1 report keeps these false:
+
+- `live_environment_validated`
+- `partner_validated`
+- `flight_validated`
+- `operationally_validated`
+
+`AUTHORIZED_READ_READY` must never be interpreted as evidence that a read occurred or that any external environment was validated.
+
+## Control boundary
+
+v1.1 does not instantiate the OAuth token provider or read-only SSE transport and adds no network call, token acquisition, stream consumption, partner communication, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP operation.

--- a/deployments/sara_verified_local_v1/tests/test_hmaa_preflight.py
+++ b/deployments/sara_verified_local_v1/tests/test_hmaa_preflight.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from worldshepherd_sara.hmaa_lattice_capture import SandboxReadCapturePlan
+from worldshepherd_sara.hmaa_preflight import (
+    HMAAPreflightRequest,
+    HMAAPreflightState,
+    PreflightCredentialMode,
+    evaluate_preflight,
+    verify_preflight_report,
+)
+
+
+ENDPOINT = "https://example.env.sandboxes.developer.anduril.com"
+
+
+def _static_env():
+    return {
+        "LATTICE_ENDPOINT": ENDPOINT,
+        "ENVIRONMENT_TOKEN": "static-environment-secret",
+        "LATTICE_CLIENT_ID": None,
+        "LATTICE_CLIENT_SECRET": None,
+        "SANDBOXES_TOKEN": "sandbox-authorization-secret",
+    }
+
+
+def _oauth_env():
+    return {
+        "LATTICE_ENDPOINT": ENDPOINT,
+        "ENVIRONMENT_TOKEN": None,
+        "LATTICE_CLIENT_ID": "client-001",
+        "LATTICE_CLIENT_SECRET": "oauth-client-secret",
+        "SANDBOXES_TOKEN": "sandbox-authorization-secret",
+    }
+
+
+def test_default_dry_run_performs_zero_network_and_can_report_missing_external_config():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(mission_id="PREFLIGHT-001"),
+        env={},
+    )
+
+    assert report.state is HMAAPreflightState.DRY_RUN_READY
+    assert report.network_enabled is False
+    assert report.network_call_performed is False
+    assert report.credential_mode is PreflightCredentialMode.NONE
+    assert report.live_environment_validated is False
+    assert report.partner_validated is False
+    assert any("LATTICE_ENDPOINT" in item for item in report.blocking_reasons)
+    assert verify_preflight_report(report) is True
+
+
+def test_static_token_configuration_can_be_authorized_read_ready_only_with_explicit_opt_in():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-STATIC",
+            network_enabled=True,
+            authorization_confirmed=True,
+        ),
+        env=_static_env(),
+    )
+
+    assert report.state is HMAAPreflightState.AUTHORIZED_READ_READY
+    assert report.credential_mode is PreflightCredentialMode.STATIC_ENVIRONMENT_TOKEN
+    assert report.network_call_performed is False
+    assert report.endpoint == ENDPOINT
+    assert all(report.credential_presence[name] is True for name in ["LATTICE_ENDPOINT", "ENVIRONMENT_TOKEN", "SANDBOXES_TOKEN"])
+    assert report.flight_validated is False
+    assert verify_preflight_report(report) is True
+
+
+def test_oauth_configuration_can_be_authorized_read_ready_without_acquiring_token():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-OAUTH",
+            network_enabled=True,
+            authorization_confirmed=True,
+        ),
+        env=_oauth_env(),
+    )
+
+    assert report.state is HMAAPreflightState.AUTHORIZED_READ_READY
+    assert report.credential_mode is PreflightCredentialMode.OAUTH_CLIENT_CREDENTIALS
+    assert report.network_call_performed is False
+    assert report.credential_presence["ENVIRONMENT_TOKEN"] is False
+    assert report.credential_presence["LATTICE_CLIENT_SECRET"] is True
+
+
+def test_network_enabled_without_explicit_authorization_is_blocked():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-NO-AUTH",
+            network_enabled=True,
+            authorization_confirmed=False,
+        ),
+        env=_oauth_env(),
+    )
+
+    assert report.state is HMAAPreflightState.BLOCKED
+    assert report.network_call_performed is False
+    assert any("explicit authorization" in item for item in report.blocking_reasons)
+
+
+def test_ambiguous_static_and_oauth_modes_are_blocked_for_network_readiness():
+    env = _oauth_env()
+    env["ENVIRONMENT_TOKEN"] = "also-static"
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-AMBIGUOUS",
+            network_enabled=True,
+            authorization_confirmed=True,
+        ),
+        env=env,
+    )
+
+    assert report.state is HMAAPreflightState.BLOCKED
+    assert report.credential_mode is PreflightCredentialMode.AMBIGUOUS
+    assert any("both configured" in item for item in report.blocking_reasons)
+
+
+def test_incomplete_oauth_mode_is_blocked():
+    env = _oauth_env()
+    env["LATTICE_CLIENT_SECRET"] = None
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-INCOMPLETE",
+            network_enabled=True,
+            authorization_confirmed=True,
+        ),
+        env=env,
+    )
+
+    assert report.state is HMAAPreflightState.BLOCKED
+    assert report.credential_mode is PreflightCredentialMode.INCOMPLETE
+
+
+def test_invalid_endpoint_never_becomes_authorized_read_ready():
+    env = _static_env()
+    env["LATTICE_ENDPOINT"] = "https://example.invalid"
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-BAD-ENDPOINT",
+            network_enabled=True,
+            authorization_confirmed=True,
+        ),
+        env=env,
+    )
+
+    assert report.state is HMAAPreflightState.BLOCKED
+    assert report.endpoint_valid is False
+    assert report.endpoint is None
+
+
+def test_zero_message_capture_plan_is_blocked_even_in_dry_run():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(
+            mission_id="PREFLIGHT-ZERO",
+            capture_plan=SandboxReadCapturePlan(
+                max_entity_messages=0,
+                max_task_messages=0,
+            ),
+        ),
+        env=_static_env(),
+    )
+
+    assert report.state is HMAAPreflightState.BLOCKED
+    assert report.dry_run_checks["finite_capture_plan_valid"] is False
+
+
+def test_report_contains_credential_presence_only_not_secret_values():
+    env = _oauth_env()
+    report = evaluate_preflight(
+        HMAAPreflightRequest(mission_id="PREFLIGHT-REDACTION"),
+        env=env,
+    )
+    encoded = report.model_dump_json()
+
+    assert "oauth-client-secret" not in encoded
+    assert "sandbox-authorization-secret" not in encoded
+    assert "client-001" not in encoded
+    assert report.credential_presence["LATTICE_CLIENT_ID"] is True
+    assert report.credential_presence["LATTICE_CLIENT_SECRET"] is True
+
+
+def test_preflight_hash_detects_tampering():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(mission_id="PREFLIGHT-HASH"),
+        env=_static_env(),
+    )
+    tampered = report.model_copy(update={"mission_id": "TAMPERED"})
+
+    assert verify_preflight_report(report) is True
+    assert verify_preflight_report(tampered) is False
+
+
+def test_dry_run_never_promotes_any_validation_flag_even_when_fully_configured():
+    report = evaluate_preflight(
+        HMAAPreflightRequest(mission_id="PREFLIGHT-NO-PROMOTION"),
+        env=_oauth_env(),
+    )
+
+    assert report.state is HMAAPreflightState.DRY_RUN_READY
+    assert report.live_environment_validated is False
+    assert report.partner_validated is False
+    assert report.flight_validated is False
+    assert report.operationally_validated is False
+    assert report.dry_run_checks["no_validation_state_promotion"] is True

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_preflight.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/hmaa_preflight.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import Enum
+from typing import Any, Mapping
+
+from pydantic import BaseModel, Field, SecretStr, ValidationError
+
+from .hmaa_lattice_capture import SandboxReadCapturePlan
+from .hmaa_lattice_contract import (
+    validate_entity_stream_request,
+    validate_task_stream_request,
+)
+from .hmaa_lattice_sandbox import ALLOWED_READ_STREAM_PATHS, SandboxReadConfig
+
+
+HMAA_PREFLIGHT_VERSION = "worldshepherd.hmaa.preflight.v1.1"
+
+
+class PreflightCredentialMode(str, Enum):
+    NONE = "NONE"
+    STATIC_ENVIRONMENT_TOKEN = "STATIC_ENVIRONMENT_TOKEN"
+    OAUTH_CLIENT_CREDENTIALS = "OAUTH_CLIENT_CREDENTIALS"
+    AMBIGUOUS = "AMBIGUOUS"
+    INCOMPLETE = "INCOMPLETE"
+
+
+class HMAAPreflightState(str, Enum):
+    DRY_RUN_READY = "DRY_RUN_READY"
+    AUTHORIZED_READ_READY = "AUTHORIZED_READ_READY"
+    BLOCKED = "BLOCKED"
+
+
+class HMAAPreflightRequest(BaseModel):
+    mission_id: str = Field(min_length=1, max_length=512)
+    network_enabled: bool = False
+    authorization_confirmed: bool = False
+    capture_plan: SandboxReadCapturePlan = Field(default_factory=SandboxReadCapturePlan)
+
+
+class HMAAPreflightReport(BaseModel):
+    report_version: str = HMAA_PREFLIGHT_VERSION
+    state: HMAAPreflightState
+    mission_id: str
+    network_enabled: bool
+    authorization_confirmed: bool
+    network_call_performed: bool = False
+    credential_mode: PreflightCredentialMode
+    endpoint: str | None = None
+    endpoint_valid: bool = False
+    credential_presence: dict[str, bool]
+    allowed_paths: list[str]
+    capture_plan: dict[str, Any]
+    dry_run_checks: dict[str, bool]
+    blocking_reasons: list[str] = Field(default_factory=list)
+    live_environment_validated: bool = False
+    partner_validated: bool = False
+    flight_validated: bool = False
+    operationally_validated: bool = False
+    report_sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _present(env: Mapping[str, str | None], name: str) -> bool:
+    value = env.get(name)
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _credential_mode(presence: Mapping[str, bool]) -> PreflightCredentialMode:
+    static = bool(presence["ENVIRONMENT_TOKEN"])
+    oauth_id = bool(presence["LATTICE_CLIENT_ID"])
+    oauth_secret = bool(presence["LATTICE_CLIENT_SECRET"])
+    oauth_any = oauth_id or oauth_secret
+    oauth_complete = oauth_id and oauth_secret
+
+    if static and oauth_any:
+        return PreflightCredentialMode.AMBIGUOUS
+    if static:
+        return PreflightCredentialMode.STATIC_ENVIRONMENT_TOKEN
+    if oauth_complete:
+        return PreflightCredentialMode.OAUTH_CLIENT_CREDENTIALS
+    if oauth_any:
+        return PreflightCredentialMode.INCOMPLETE
+    return PreflightCredentialMode.NONE
+
+
+def _validate_endpoint_without_secrets(endpoint: str | None) -> tuple[str | None, bool, str | None]:
+    if not endpoint or not endpoint.strip():
+        return None, False, "LATTICE_ENDPOINT is missing"
+    try:
+        validated = SandboxReadConfig(
+            endpoint=endpoint,
+            environment_token=None,
+            sandboxes_token=SecretStr("preflight-presence-only"),
+        )
+    except ValidationError:
+        return None, False, "LATTICE_ENDPOINT failed Sandbox endpoint validation"
+    return validated.endpoint, True, None
+
+
+def _validated_plan(plan: SandboxReadCapturePlan) -> tuple[dict[str, Any], bool, str | None]:
+    if plan.max_entity_messages == 0 and plan.max_task_messages == 0:
+        return {}, False, "capture plan must request at least one finite stream message"
+    try:
+        entity_request = validate_entity_stream_request(plan.entity_request)
+        task_request = validate_task_stream_request(plan.task_request)
+    except (TypeError, ValueError) as exc:
+        return {}, False, f"capture plan contract validation failed: {type(exc).__name__}"
+    return {
+        "entity_request": entity_request,
+        "task_request": task_request,
+        "max_entity_messages": plan.max_entity_messages,
+        "max_task_messages": plan.max_task_messages,
+    }, True, None
+
+
+def evaluate_preflight(
+    request: HMAAPreflightRequest,
+    *,
+    env: Mapping[str, str | None],
+) -> HMAAPreflightReport:
+    """Evaluate HMAA read-only readiness without performing any network call."""
+
+    names = (
+        "LATTICE_ENDPOINT",
+        "ENVIRONMENT_TOKEN",
+        "LATTICE_CLIENT_ID",
+        "LATTICE_CLIENT_SECRET",
+        "SANDBOXES_TOKEN",
+    )
+    presence = {name: _present(env, name) for name in names}
+    mode = _credential_mode(presence)
+
+    endpoint, endpoint_valid, endpoint_error = _validate_endpoint_without_secrets(
+        env.get("LATTICE_ENDPOINT")
+    )
+    plan_body, plan_valid, plan_error = _validated_plan(request.capture_plan)
+
+    blockers: list[str] = []
+    if endpoint_error:
+        blockers.append(endpoint_error)
+    if plan_error:
+        blockers.append(plan_error)
+    if not presence["SANDBOXES_TOKEN"]:
+        blockers.append("SANDBOXES_TOKEN is missing")
+    if mode is PreflightCredentialMode.NONE:
+        blockers.append("no environment-token credential mode is configured")
+    elif mode is PreflightCredentialMode.INCOMPLETE:
+        blockers.append("OAuth client-credential configuration is incomplete")
+    elif mode is PreflightCredentialMode.AMBIGUOUS:
+        blockers.append("static and OAuth environment-token modes are both configured")
+
+    external_config_ready = (
+        endpoint_valid
+        and plan_valid
+        and presence["SANDBOXES_TOKEN"]
+        and mode
+        in {
+            PreflightCredentialMode.STATIC_ENVIRONMENT_TOKEN,
+            PreflightCredentialMode.OAUTH_CLIENT_CREDENTIALS,
+        }
+    )
+
+    if request.network_enabled:
+        if not request.authorization_confirmed:
+            blockers.append(
+                "network-enabled readiness requires explicit authorization confirmation"
+            )
+        state = (
+            HMAAPreflightState.AUTHORIZED_READ_READY
+            if external_config_ready and request.authorization_confirmed
+            else HMAAPreflightState.BLOCKED
+        )
+    else:
+        # Dry-run evaluation is useful even when external credentials are absent.
+        state = HMAAPreflightState.DRY_RUN_READY if plan_valid else HMAAPreflightState.BLOCKED
+
+    dry_run_checks = {
+        "zero_network_calls": True,
+        "endpoint_contract_valid": endpoint_valid,
+        "finite_capture_plan_valid": plan_valid,
+        "sandbox_authorization_token_present": presence["SANDBOXES_TOKEN"],
+        "single_environment_credential_mode": mode
+        in {
+            PreflightCredentialMode.STATIC_ENVIRONMENT_TOKEN,
+            PreflightCredentialMode.OAUTH_CLIENT_CREDENTIALS,
+        },
+        "explicit_authorization_if_network_enabled": (
+            not request.network_enabled or request.authorization_confirmed
+        ),
+        "read_only_paths_only": True,
+        "no_validation_state_promotion": True,
+    }
+
+    body = {
+        "report_version": HMAA_PREFLIGHT_VERSION,
+        "state": state.value,
+        "mission_id": request.mission_id,
+        "network_enabled": request.network_enabled,
+        "authorization_confirmed": request.authorization_confirmed,
+        "network_call_performed": False,
+        "credential_mode": mode.value,
+        "endpoint": endpoint,
+        "endpoint_valid": endpoint_valid,
+        "credential_presence": presence,
+        "allowed_paths": sorted(ALLOWED_READ_STREAM_PATHS),
+        "capture_plan": plan_body,
+        "dry_run_checks": dry_run_checks,
+        "blocking_reasons": blockers,
+        "live_environment_validated": False,
+        "partner_validated": False,
+        "flight_validated": False,
+        "operationally_validated": False,
+    }
+    return HMAAPreflightReport(
+        **body,
+        report_sha256=_sha256_json(body),
+    )
+
+
+def verify_preflight_report(report: HMAAPreflightReport) -> bool:
+    body = report.model_dump(mode="json", exclude={"report_sha256"})
+    return _sha256_json(body) == report.report_sha256


### PR DESCRIPTION
## Summary
Adds a secret-free, zero-network preflight evaluator for the existing WS-HMAA read-only Sandbox path.

### Added
- dry-run-first preflight request with `network_enabled=false` default
- explicit `authorization_confirmed` gate for any future network-enabled readiness state
- credential-presence-only inspection for static environment-token and OAuth client-credentials modes
- rejection of incomplete or ambiguous credential modes
- reuse of the documented Sandbox endpoint validator without constructing the live OAuth provider or SSE transport
- finite entity/task capture-plan validation with nonzero bounded message requirement
- `DRY_RUN_READY`, `AUTHORIZED_READ_READY`, and `BLOCKED` states
- hard invariant `network_call_performed=false` for all v1.1 evaluations
- secret-free canonical SHA-256 preflight report and verification helper
- eleven tests covering dry-run behavior, static/OAuth readiness, authorization gating, ambiguous/incomplete credentials, invalid endpoints, zero-message plans, secret exclusion, tamper detection, and no validation promotion
- v1.1 preflight boundary documentation

### Claims / safety boundary
`AUTHORIZED_READ_READY` means configuration and authorization posture are ready for a separately governed future read attempt. It does not mean any network call occurred. All partner/live/flight/operational validation flags remain false.

No token acquisition, network call, SSE stream, partner communication, entity publication, task mutation, manual-control, flight-control, weapons, or arbitrary HTTP path is added.

### Validation gate
Merge only after protected SARA CI/recovery/resilience gates and CodeQL are green.