### PR TITLE
Add bounded Astra solver profile with verified OpenAI runtime model

### DIFF
--- a/deployments/sara_verified_local_v1/.env.example
+++ b/deployments/sara_verified_local_v1/.env.example
@@ -8,6 +8,10 @@ SARA_HOST_PORT=9530
 SARA_DATA_DIR=./data
 SARA_MODE=local-verified
 SARA_LOG_LEVEL=info
+# Astra is a Worldshepherd solver profile, not a provider model name.
+# Keep inference disabled unless a reviewed provider transport and explicit SARA authorization are in place.
+SARA_ASTRA_MODEL=gpt-5.6-sol
+SARA_ASTRA_NETWORK_ENABLED=false
 # For an accepted build, set these to the exact tested source commit and release/baseline identifier.
 # UNKNOWN/UNVERIFIED must never be represented as an approved release identity.
 SARA_BUILD_COMMIT=UNKNOWN

--- a/deployments/sara_verified_local_v1/README.md
+++ b/deployments/sara_verified_local_v1/README.md
@@ -1,50 +1,20 @@
-# Worldshepherd SARA / SSPADAWANZZ
+# SARA Verified Local v1
 
-Evidence-governed local administration, relay-recording, and predictive-requirements qualification service for the Worldshepherd stack.
+This deployment is the evidence-governed local administration, relay, PRE qualification, and bounded solver environment for Worldshepherd SARA.
 
-## Verified boundary
+## Astra solver profile
 
-- Local interface: `http://127.0.0.1:9530/ui` by default
-- Set `SARA_HOST_PORT` to select another localhost-only publication port while retaining internal container port `9530`
-- Unauthenticated compatibility health check: `/health`
-- Liveness check: `/livez`
-- Persistent-storage readiness check: `/readyz`
-- Authenticated local relay record: `/v1/relay`
-- Administrator audit: `/v1/audit?limit=50`
-- Administrator registry: `/admin/registry`
-- Administrator self-test: `/admin/selftest`
+`Astra` is a Worldshepherd solver codename/profile. It is not a provider model identifier.
 
-External scanning, broadcasting, arbitrary command execution, third-party activation, and self-expanding network behavior are excluded.
+The current verified default OpenAI runtime target is `gpt-5.6-sol`, but network inference remains disabled by default. The implementation is in `worldshepherd_sara/astra_solver.py` and requires both an injected provider transport and explicit SARA model-inference authorization before a call can occur.
 
-The audit is an application-appended JSON Lines log on the local persistent volume. It is useful operational evidence, but it is not immutable, tamper-proof, or independently verified.
+Fail-closed defaults:
 
-## Quick start — SARA local service
+- `SARA_ASTRA_MODEL=gpt-5.6-sol`
+- `SARA_ASTRA_NETWORK_ENABLED=false`
+- tool allowlist empty
+- remote response storage disabled
+- no embedded provider credentials
+- no maturity upgrade from model output alone
 
-```bash
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install -e '.[test]'
-cp .env.example .env
-# Replace both tokens with different random values.
-./scripts/start_interface.sh
-```
-
-For the Docker-based acceptance sequence, see [`docs/VERIFIED_DEPLOYMENT.md`](docs/VERIFIED_DEPLOYMENT.md).
-
-## Quick start — PRE full-bloom qualification compiler
-
-After installing the package, compile the current frozen internal qualification evidence with:
-
-```bash
-rm -rf qualification_evidence
-ws-pre-bloom \
-  --fixtures fixtures \
-  --out qualification_evidence \
-  --software-commit "$(git rev-parse HEAD)" \
-  --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --operator "$(whoami)"
-```
-
-The compiler exits nonzero if a qualification record fails or ECHO-style custody verification fails. Expected outputs include `qualification_index.json`, domain qualification bundles, `capability_readiness_ledger.json`, `capability_horizons.json`, `software_provenance.json`, and the local hash-addressed `echo_store/`.
-
-See [`docs/PRE_FULL_BLOOM.md`](docs/PRE_FULL_BLOOM.md) for operation and evidence interpretation, and [`docs/COMPLIANCE_BOUNDARY.md`](docs/COMPLIANCE_BOUNDARY.md) for the exact distinction between internal software conformance and external regulatory, contractual, physical, partner, and government validation.
+See `../../docs/ASTRA_INTEGRATION.md` for the architecture and promotion gates.

--- a/deployments/sara_verified_local_v1/README.md
+++ b/deployments/sara_verified_local_v1/README.md
@@ -1,12 +1,59 @@
-# SARA Verified Local v1
+# Worldshepherd SARA / SSPADAWANZZ
 
-This deployment is the evidence-governed local administration, relay, PRE qualification, and bounded solver environment for Worldshepherd SARA.
+Evidence-governed local administration, relay-recording, and predictive-requirements qualification service for the Worldshepherd stack.
+
+## Verified boundary
+
+- Local interface: `http://127.0.0.1:9530/ui` by default
+- Set `SARA_HOST_PORT` to select another localhost-only publication port while retaining internal container port `9530`
+- Unauthenticated compatibility health check: `/health`
+- Liveness check: `/livez`
+- Persistent-storage readiness check: `/readyz`
+- Authenticated local relay record: `/v1/relay`
+- Administrator audit: `/v1/audit?limit=50`
+- Administrator registry: `/admin/registry`
+- Administrator self-test: `/admin/selftest`
+
+External scanning, broadcasting, arbitrary command execution, third-party activation, and self-expanding network behavior are excluded.
+
+The audit is an application-appended JSON Lines log on the local persistent volume. It is useful operational evidence, but it is not immutable, tamper-proof, or independently verified.
+
+## Quick start — SARA local service
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[test]'
+cp .env.example .env
+# Replace both tokens with different random values.
+./scripts/start_interface.sh
+```
+
+For the Docker-based acceptance sequence, see [`docs/VERIFIED_DEPLOYMENT.md`](docs/VERIFIED_DEPLOYMENT.md).
+
+## Quick start — PRE full-bloom qualification compiler
+
+After installing the package, compile the current frozen internal qualification evidence with:
+
+```bash
+rm -rf qualification_evidence
+ws-pre-bloom \
+  --fixtures fixtures \
+  --out qualification_evidence \
+  --software-commit "$(git rev-parse HEAD)" \
+  --executed-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --operator "$(whoami)"
+```
+
+The compiler exits nonzero if a qualification record fails or ECHO-style custody verification fails. Expected outputs include `qualification_index.json`, domain qualification bundles, `capability_readiness_ledger.json`, `capability_horizons.json`, `software_provenance.json`, and the local hash-addressed `echo_store/`.
+
+See [`docs/PRE_FULL_BLOOM.md`](docs/PRE_FULL_BLOOM.md) for operation and evidence interpretation, and [`docs/COMPLIANCE_BOUNDARY.md`](docs/COMPLIANCE_BOUNDARY.md) for the exact distinction between internal software conformance and external regulatory, contractual, physical, partner, and government validation.
 
 ## Astra solver profile
 
-`Astra` is a Worldshepherd solver codename/profile. It is not a provider model identifier.
+`Astra` is a Worldshepherd solver codename/profile, not a provider model identifier.
 
-The current verified default OpenAI runtime target is `gpt-5.6-sol`, but network inference remains disabled by default. The implementation is in `worldshepherd_sara/astra_solver.py` and requires both an injected provider transport and explicit SARA model-inference authorization before a call can occur.
+The current verified default OpenAI runtime target is `gpt-5.6-sol`, while model inference remains disabled by default. The implementation is in `worldshepherd_sara/astra_solver.py` and requires both an injected provider transport and explicit SARA model-inference authorization before a call can occur.
 
 Fail-closed defaults:
 
@@ -17,4 +64,4 @@ Fail-closed defaults:
 - no embedded provider credentials
 - no maturity upgrade from model output alone
 
-See `../../docs/ASTRA_INTEGRATION.md` for the architecture and promotion gates.
+See [`../../docs/ASTRA_INTEGRATION.md`](../../docs/ASTRA_INTEGRATION.md) for the architecture and promotion gates.

--- a/deployments/sara_verified_local_v1/policy/astra_solver_profile.json
+++ b/deployments/sara_verified_local_v1/policy/astra_solver_profile.json
@@ -1,14 +1,22 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "profile_id": "WS-ASTRA-SOLVER-READ-ONLY",
-  "status": "DESIGN_INTEGRATION",
-  "model": "gpt-6-astra",
+  "status": "IMPLEMENTATION_PROFILE",
+  "profile_name": "Astra",
+  "profile_type": "WORLDSHEPHERD_SOLVER_CODENAME",
+  "provider": "openai",
+  "runtime_model": {
+    "default": "gpt-5.6-sol",
+    "verification_source": "https://platform.openai.com/docs/models",
+    "verified_date": "2026-09-04",
+    "astra_is_provider_model_id": false
+  },
   "authority": "CRE1AWS",
   "orchestrator": "SARA",
   "default_mode": "SOLVER_READ_ONLY",
   "network": {
-    "read": false,
-    "write": false,
+    "inference_enabled_by_default": false,
+    "provider_transport_embedded": false,
     "requires_explicit_sara_authorization": true
   },
   "external_actions": {
@@ -35,13 +43,24 @@
     "claims_red_team",
     "evidence_gap_analysis"
   ],
+  "tool_policy": {
+    "default_allowlist": [],
+    "deny_unlisted_tools": true,
+    "authorization_must_cover_requested_tools": true
+  },
   "required_output_fields": [
     "task_id",
+    "profile_id",
+    "provider",
+    "model_id",
     "evidence_refs",
     "claims_control_labels",
+    "input_digest",
+    "output_digest",
+    "authorization_id",
+    "network_call_performed",
     "uncertainty_notes",
     "disconfirming_evidence",
-    "output_digest",
     "recommended_follow_on"
   ],
   "claims_control": {
@@ -52,18 +71,19 @@
     "owned_or_explicitly_authorized_targets_only": true,
     "defensive_baseline_only": true,
     "autonomous_third_party_scanning": false,
-    "persistence_or_evasion": false
+    "persistence_or_evasion": false,
+    "no_special_capability_inferred_from_profile_name": true
   },
   "promotion_gates": [
-    "model_access_verified",
+    "target_model_access_verified",
     "secret_storage_verified",
-    "sara_adapter_implemented",
-    "provenance_logging_verified",
+    "provider_transport_reviewed",
+    "provenance_persistence_verified",
     "read_only_tests_pass",
-    "timeout_cancel_rollback_verified",
+    "timeout_cancel_behavior_verified",
     "tool_allowlist_verified",
     "claims_tagging_verified",
     "cyber_boundary_tests_pass",
-    "cre1aws_approval_for_elevated_mode"
+    "cre1aws_approval_for_network_or_elevated_mode"
   ]
 }

--- a/deployments/sara_verified_local_v1/policy/astra_solver_profile.json
+++ b/deployments/sara_verified_local_v1/policy/astra_solver_profile.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.0",
+  "profile_id": "WS-ASTRA-SOLVER-READ-ONLY",
+  "status": "DESIGN_INTEGRATION",
+  "model": "gpt-6-astra",
+  "authority": "CRE1AWS",
+  "orchestrator": "SARA",
+  "default_mode": "SOLVER_READ_ONLY",
+  "network": {
+    "read": false,
+    "write": false,
+    "requires_explicit_sara_authorization": true
+  },
+  "external_actions": {
+    "email_send": false,
+    "message_send": false,
+    "publish": false,
+    "purchase": false,
+    "account_change": false,
+    "third_party_security_testing": false,
+    "production_change": false,
+    "physical_control": false
+  },
+  "allowed_baseline_capabilities": [
+    "authorized_project_read",
+    "analysis",
+    "scientific_reasoning",
+    "mathematical_reasoning",
+    "code_review",
+    "patch_proposal",
+    "test_generation",
+    "simulation_plan_generation",
+    "requirement_extraction",
+    "requirement_delta_generation",
+    "claims_red_team",
+    "evidence_gap_analysis"
+  ],
+  "required_output_fields": [
+    "task_id",
+    "evidence_refs",
+    "claims_control_labels",
+    "uncertainty_notes",
+    "disconfirming_evidence",
+    "output_digest",
+    "recommended_follow_on"
+  ],
+  "claims_control": {
+    "model_output_may_upgrade_maturity": false,
+    "evidence_required_for_upgrade": true
+  },
+  "cyber": {
+    "owned_or_explicitly_authorized_targets_only": true,
+    "defensive_baseline_only": true,
+    "autonomous_third_party_scanning": false,
+    "persistence_or_evasion": false
+  },
+  "promotion_gates": [
+    "model_access_verified",
+    "secret_storage_verified",
+    "sara_adapter_implemented",
+    "provenance_logging_verified",
+    "read_only_tests_pass",
+    "timeout_cancel_rollback_verified",
+    "tool_allowlist_verified",
+    "claims_tagging_verified",
+    "cyber_boundary_tests_pass",
+    "cre1aws_approval_for_elevated_mode"
+  ]
+}

--- a/deployments/sara_verified_local_v1/tests/test_astra_solver.py
+++ b/deployments/sara_verified_local_v1/tests/test_astra_solver.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.astra_solver import (
+    DEFAULT_OPENAI_MODEL,
+    AstraInferenceAuthorization,
+    AstraRuntimeConfig,
+    AstraSolver,
+    AstraTask,
+)
+from worldshepherd_sara.qualification import CapabilityStatus
+
+
+def test_astra_defaults_to_documented_model_and_network_off() -> None:
+    config = AstraRuntimeConfig()
+    assert config.model_id == DEFAULT_OPENAI_MODEL == "gpt-5.6-sol"
+    assert config.network_enabled is False
+    assert config.allowed_tools == []
+
+
+def test_prepare_is_zero_network_and_provenance_bearing() -> None:
+    solver = AstraSolver()
+    task = AstraTask(
+        task_id="WS-ASTRA-TEST-0001",
+        prompt="Review this synthetic requirement for evidence gaps.",
+        evidence_refs=["fixture://synthetic-requirement"],
+        claims_control_labels=[CapabilityStatus.SIMULATED_ONLY],
+    )
+
+    prepared = solver.prepare(task)
+
+    assert prepared.network_call_performed is False
+    assert prepared.model_id == "gpt-5.6-sol"
+    assert prepared.request_payload["store"] is False
+    assert prepared.request_payload["metadata"]["worldshepherd_task_id"] == task.task_id
+    assert prepared.input_digest.startswith("sha256:")
+
+
+def test_unallowlisted_tool_fails_closed() -> None:
+    solver = AstraSolver()
+    task = AstraTask(
+        task_id="WS-ASTRA-TEST-0002",
+        prompt="Do not execute tools.",
+        requested_tools=["web_search"],
+    )
+
+    with pytest.raises(PermissionError, match="outside the Astra profile allowlist"):
+        solver.prepare(task)
+
+
+def test_execute_fails_when_network_disabled() -> None:
+    called = False
+
+    def transport(_: dict) -> dict:
+        nonlocal called
+        called = True
+        return {"id": "resp_fake", "output_text": "should not be reached"}
+
+    solver = AstraSolver(transport=transport)
+    task = AstraTask(task_id="WS-ASTRA-TEST-0003", prompt="Analyze only.")
+    authorization = AstraInferenceAuthorization(
+        authorization_id="AUTH-0003",
+        authorized_by="CRE1AWS",
+        allow_model_inference=True,
+        allowed_model_ids=["gpt-5.6-sol"],
+    )
+
+    with pytest.raises(PermissionError, match="network inference is disabled"):
+        solver.execute(task, authorization)
+    assert called is False
+
+
+def test_execute_requires_explicit_authorization() -> None:
+    solver = AstraSolver(
+        AstraRuntimeConfig(network_enabled=True),
+        transport=lambda _: {"id": "resp_fake", "output_text": "ok"},
+    )
+    task = AstraTask(task_id="WS-ASTRA-TEST-0004", prompt="Analyze only.")
+
+    with pytest.raises(PermissionError, match="explicit SARA model-inference authorization"):
+        solver.execute(task, None)
+
+
+def test_authorized_injected_transport_returns_digest_bearing_result() -> None:
+    calls: list[dict] = []
+
+    def transport(payload: dict) -> dict:
+        calls.append(payload)
+        return {
+            "id": "resp_test_123",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "Evidence gap: physical coupon data absent."}
+                    ],
+                }
+            ],
+        }
+
+    solver = AstraSolver(
+        AstraRuntimeConfig(network_enabled=True),
+        transport=transport,
+    )
+    task = AstraTask(
+        task_id="WS-ASTRA-TEST-0005",
+        prompt="Identify the strongest disconfirming evidence requirement.",
+        evidence_refs=["fixture://meta-alloy-synthetic"],
+        claims_control_labels=[CapabilityStatus.REQUIRES_LAB_VALIDATION],
+    )
+    authorization = AstraInferenceAuthorization(
+        authorization_id="AUTH-0005",
+        authorized_by="CRE1AWS",
+        allow_model_inference=True,
+        allowed_model_ids=["gpt-5.6-sol"],
+    )
+
+    result = solver.execute(task, authorization)
+
+    assert len(calls) == 1
+    assert calls[0]["model"] == "gpt-5.6-sol"
+    assert calls[0]["store"] is False
+    assert result.response_id == "resp_test_123"
+    assert result.network_call_performed is True
+    assert result.output_digest.startswith("sha256:")
+    assert result.input_digest.startswith("sha256:")
+    assert result.claims_control_labels == [CapabilityStatus.REQUIRES_LAB_VALIDATION]

--- a/deployments/sara_verified_local_v1/tests/test_astra_solver.py
+++ b/deployments/sara_verified_local_v1/tests/test_astra_solver.py
@@ -82,6 +82,28 @@ def test_execute_requires_explicit_authorization() -> None:
         solver.execute(task, None)
 
 
+def test_execute_rejects_model_outside_authorization() -> None:
+    called = False
+
+    def transport(_: dict) -> dict:
+        nonlocal called
+        called = True
+        return {"id": "resp_fake", "output_text": "should not be reached"}
+
+    solver = AstraSolver(AstraRuntimeConfig(network_enabled=True), transport=transport)
+    task = AstraTask(task_id="WS-ASTRA-TEST-0005", prompt="Analyze only.")
+    authorization = AstraInferenceAuthorization(
+        authorization_id="AUTH-0005",
+        authorized_by="CRE1AWS",
+        allow_model_inference=True,
+        allowed_model_ids=["gpt-5.6-terra"],
+    )
+
+    with pytest.raises(PermissionError, match="configured model is outside"):
+        solver.execute(task, authorization)
+    assert called is False
+
+
 def test_authorized_injected_transport_returns_digest_bearing_result() -> None:
     calls: list[dict] = []
 
@@ -104,13 +126,13 @@ def test_authorized_injected_transport_returns_digest_bearing_result() -> None:
         transport=transport,
     )
     task = AstraTask(
-        task_id="WS-ASTRA-TEST-0005",
+        task_id="WS-ASTRA-TEST-0006",
         prompt="Identify the strongest disconfirming evidence requirement.",
         evidence_refs=["fixture://meta-alloy-synthetic"],
         claims_control_labels=[CapabilityStatus.REQUIRES_LAB_VALIDATION],
     )
     authorization = AstraInferenceAuthorization(
-        authorization_id="AUTH-0005",
+        authorization_id="AUTH-0006",
         authorized_by="CRE1AWS",
         allow_model_inference=True,
         allowed_model_ids=["gpt-5.6-sol"],

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/__init__.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/__init__.py
@@ -1,3 +1,5 @@
-"""Worldshepherd SARA local administration service."""
-
 __version__ = "0.1.0"
+
+from .astra_solver import ASTRA_PROFILE_ID, DEFAULT_OPENAI_MODEL
+
+__all__ = ["ASTRA_PROFILE_ID", "DEFAULT_OPENAI_MODEL", "__version__"]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/astra_solver.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/astra_solver.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import CapabilityStatus, canonical_digest
+
+
+ASTRA_PROFILE_ID = "WS-ASTRA-SOLVER-READ-ONLY"
+DEFAULT_OPENAI_MODEL = "gpt-5.6-sol"
+
+
+class AstraExecutionMode(str, Enum):
+    SOLVER_READ_ONLY = "SOLVER_READ_ONLY"
+
+
+class AstraRuntimeConfig(BaseModel):
+    """Runtime configuration for the Worldshepherd Astra solver profile.
+
+    `Astra` is a Worldshepherd profile/codename. It is deliberately separated
+    from the provider model id so an undocumented model name cannot silently
+    become an API dependency.
+    """
+
+    profile_id: str = ASTRA_PROFILE_ID
+    provider: str = "openai"
+    model_id: str = DEFAULT_OPENAI_MODEL
+    mode: AstraExecutionMode = AstraExecutionMode.SOLVER_READ_ONLY
+    network_enabled: bool = False
+    allowed_tools: list[str] = Field(default_factory=list)
+    store_remote_response: bool = False
+
+    @model_validator(mode="after")
+    def validate_read_only_boundary(self) -> "AstraRuntimeConfig":
+        if self.mode != AstraExecutionMode.SOLVER_READ_ONLY:
+            raise ValueError("only SOLVER_READ_ONLY is implemented")
+        return self
+
+
+class AstraInferenceAuthorization(BaseModel):
+    authorization_id: str = Field(min_length=1)
+    authorized_by: str = Field(min_length=1)
+    allow_model_inference: bool = False
+    allowed_model_ids: list[str] = Field(default_factory=list)
+    allowed_tools: list[str] = Field(default_factory=list)
+    scope: str = "MODEL_INFERENCE_ONLY"
+
+
+class AstraTask(BaseModel):
+    task_id: str = Field(min_length=1)
+    prompt: str = Field(min_length=1)
+    evidence_refs: list[str] = Field(default_factory=list)
+    requested_tools: list[str] = Field(default_factory=list)
+    claims_control_labels: list[CapabilityStatus] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AstraPreparedRequest(BaseModel):
+    profile_id: str
+    task_id: str
+    provider: str
+    model_id: str
+    mode: AstraExecutionMode
+    input_digest: str
+    evidence_refs: list[str]
+    requested_tools: list[str]
+    request_payload: dict[str, Any]
+    prepared_utc: str
+    network_call_performed: bool = False
+
+
+class AstraResult(BaseModel):
+    profile_id: str
+    task_id: str
+    provider: str
+    model_id: str
+    response_id: str | None = None
+    input_digest: str
+    output_digest: str
+    output_text: str
+    evidence_refs: list[str]
+    claims_control_labels: list[CapabilityStatus]
+    uncertainty_notes: list[str] = Field(default_factory=list)
+    disconfirming_evidence: list[str] = Field(default_factory=list)
+    recommended_follow_on: list[str] = Field(default_factory=list)
+    authorization_id: str
+    authorized_by: str
+    network_call_performed: bool
+    completed_utc: str
+
+
+AstraTransport = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+class AstraSolver:
+    """Policy-gated adapter for the Worldshepherd Astra solver profile.
+
+    The adapter has no network implementation of its own. A transport must be
+    injected explicitly, and inference remains blocked unless both runtime
+    configuration and a SARA authorization allow it.
+    """
+
+    def __init__(
+        self,
+        config: AstraRuntimeConfig | None = None,
+        *,
+        transport: AstraTransport | None = None,
+    ) -> None:
+        self.config = config or AstraRuntimeConfig()
+        self._transport = transport
+
+    def _validate_requested_tools(
+        self,
+        task: AstraTask,
+        authorization: AstraInferenceAuthorization | None = None,
+    ) -> None:
+        configured = set(self.config.allowed_tools)
+        requested = set(task.requested_tools)
+        outside_profile = requested - configured
+        if outside_profile:
+            raise PermissionError(
+                "requested tools are outside the Astra profile allowlist: "
+                + ", ".join(sorted(outside_profile))
+            )
+        if authorization is not None:
+            outside_authorization = requested - set(authorization.allowed_tools)
+            if outside_authorization:
+                raise PermissionError(
+                    "requested tools are outside the inference authorization: "
+                    + ", ".join(sorted(outside_authorization))
+                )
+
+    def prepare(self, task: AstraTask) -> AstraPreparedRequest:
+        self._validate_requested_tools(task)
+        task_payload = task.model_dump(mode="json")
+        input_digest = canonical_digest(task_payload)
+        request_payload: dict[str, Any] = {
+            "model": self.config.model_id,
+            "instructions": (
+                "Operate as the Worldshepherd Astra solver profile. "
+                "Analyze and propose only. Preserve evidence references and claims-control "
+                "labels. Do not claim that model output upgrades physical or operational "
+                "maturity. Do not perform or request external actions."
+            ),
+            "input": task.prompt,
+            "store": self.config.store_remote_response,
+            "metadata": {
+                "worldshepherd_profile": self.config.profile_id,
+                "worldshepherd_task_id": task.task_id,
+                "worldshepherd_input_digest": input_digest,
+            },
+        }
+        return AstraPreparedRequest(
+            profile_id=self.config.profile_id,
+            task_id=task.task_id,
+            provider=self.config.provider,
+            model_id=self.config.model_id,
+            mode=self.config.mode,
+            input_digest=input_digest,
+            evidence_refs=list(task.evidence_refs),
+            requested_tools=list(task.requested_tools),
+            request_payload=request_payload,
+            prepared_utc=datetime.now(timezone.utc).isoformat(),
+            network_call_performed=False,
+        )
+
+    def execute(
+        self,
+        task: AstraTask,
+        authorization: AstraInferenceAuthorization | None,
+    ) -> AstraResult:
+        if not self.config.network_enabled:
+            raise PermissionError("Astra network inference is disabled by runtime policy")
+        if authorization is None or not authorization.allow_model_inference:
+            raise PermissionError("explicit SARA model-inference authorization is required")
+        if self.config.model_id not in set(authorization.allowed_model_ids):
+            raise PermissionError("configured model is outside the inference authorization")
+        if authorization.scope != "MODEL_INFERENCE_ONLY":
+            raise PermissionError("authorization scope must be MODEL_INFERENCE_ONLY")
+        self._validate_requested_tools(task, authorization)
+        if self._transport is None:
+            raise RuntimeError("no Astra transport is configured")
+
+        prepared = self.prepare(task)
+        raw_response = self._transport(prepared.request_payload)
+        output_text = _extract_output_text(raw_response)
+        output_digest = canonical_digest(
+            {
+                "task_id": task.task_id,
+                "model_id": self.config.model_id,
+                "output_text": output_text,
+                "raw_response_digest": canonical_digest(raw_response),
+            }
+        )
+        return AstraResult(
+            profile_id=self.config.profile_id,
+            task_id=task.task_id,
+            provider=self.config.provider,
+            model_id=self.config.model_id,
+            response_id=(
+                str(raw_response.get("id")) if raw_response.get("id") is not None else None
+            ),
+            input_digest=prepared.input_digest,
+            output_digest=output_digest,
+            output_text=output_text,
+            evidence_refs=list(task.evidence_refs),
+            claims_control_labels=list(task.claims_control_labels),
+            authorization_id=authorization.authorization_id,
+            authorized_by=authorization.authorized_by,
+            network_call_performed=True,
+            completed_utc=datetime.now(timezone.utc).isoformat(),
+        )
+
+
+def _extract_output_text(response: dict[str, Any]) -> str:
+    direct = response.get("output_text")
+    if isinstance(direct, str) and direct:
+        return direct
+
+    collected: list[str] = []
+    output = response.get("output")
+    if isinstance(output, list):
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    collected.append(text)
+    if not collected:
+        raise ValueError("model response did not contain output text")
+    return "\n".join(collected)

--- a/docs/ASTRA_INTEGRATION.md
+++ b/docs/ASTRA_INTEGRATION.md
@@ -1,20 +1,53 @@
 # Worldshepherd Astra Integration
 
-Status: DESIGN/INTEGRATION PROFILE — not production authorization
+Status: IMPLEMENTATION PROFILE — not production authorization
 Date: 2026-09-04
 Owner/authority: CRE1AWS
 Orchestrator: SARA
 
+## Verification correction
+
+`Astra` is the Worldshepherd solver profile/codename. It is **not** treated as an OpenAI model identifier.
+
+As verified against OpenAI's official model catalog on 2026-09-04, the documented flagship model for complex reasoning and coding is `gpt-5.6-sol`. No official `gpt-6-astra` model identifier was found. The earlier draft assumption that `gpt-6-astra` was a released model is therefore retracted and must not be used for runtime configuration or capability claims.
+
+Runtime model selection is intentionally separated from the Astra profile so the provider model can be changed only to a verified, available model identifier.
+
+Official model catalog: https://platform.openai.com/docs/models
+
 ## Purpose
 
-Integrate OpenAI GPT-6 Astra as a bounded high-capability solver for Worldshepherd while preserving SARA as the policy, authorization, provenance, and execution authority.
+Use Astra as a bounded high-capability solver profile for Worldshepherd while preserving SARA as the policy, authorization, provenance, and execution authority.
 
 Astra is not granted independent authority to perform network writes, external communications, procurement, deployment, security testing against third-party systems, or physical-control actions.
+
+## Current implementation
+
+The initial implementation lives in:
+
+- `deployments/sara_verified_local_v1/worldshepherd_sara/astra_solver.py`
+- `deployments/sara_verified_local_v1/tests/test_astra_solver.py`
+- `deployments/sara_verified_local_v1/policy/astra_solver_profile.json`
+
+Implemented controls:
+
+- default runtime model: `gpt-5.6-sol`
+- default mode: `SOLVER_READ_ONLY`
+- network inference disabled by default
+- no provider network client embedded in the adapter
+- explicit transport injection required for any model call
+- explicit SARA inference authorization required
+- model-id authorization enforced
+- tool allowlist enforced and empty by default
+- remote response storage disabled by default
+- canonical SHA-256 input/output provenance digests
+- Worldshepherd claims-control labels preserved in the result record
 
 ## Role separation
 
 - **SARA**: authoritative workflow/orchestration layer; enforces authorization, claims-control, evidence capture, rollback, and operator approval.
-- **GPT-6 Astra**: solver/research/review node; produces analyses, candidate designs, code, test plans, simulations, counterexamples, and evidence requests.
+- **Astra profile**: solver/research/review role; produces analyses, candidate designs, code, test plans, simulations, counterexamples, and evidence requests.
+- **Runtime model**: provider model selected from an independently verified model catalog. Initial verified default: `gpt-5.6-sol`.
 - **ECHO SENTINEL LINK**: provenance/telemetry record for Astra requests, outputs, tool use, evidence references, configuration, and disposition.
 - **PRIME SENTINEL**: policy gate for requested actions and tool access.
 - **OVERWATCH**: monitors performance, anomalies, drift, task duration, resource use, and policy events.
@@ -73,7 +106,9 @@ Allowed by default:
 - produce structured provenance and confidence records
 
 Disallowed by default:
-- network writes
+- network inference unless separately enabled and authorized
+- model/tool calls outside the configured allowlist
+- network writes to external systems
 - sending email/messages
 - creating external accounts
 - publishing
@@ -83,11 +118,11 @@ Disallowed by default:
 - changing physical-control parameters on live hardware
 - bypassing SARA/PRIME authorization
 
-Any expansion beyond read-only requires an explicit SARA authorization record and must be bounded to the named resource, action, and time window.
+Any expansion beyond read-only requires an explicit SARA authorization record bounded to the named model/tool/resource/action.
 
 ## Cybersecurity handling
 
-Because Astra is a cyber-critical-capability model, Worldshepherd treats cyber work as a separate high-risk lane.
+No special cybersecurity capability is inferred from the Astra profile name.
 
 Permitted baseline:
 - defensive review of Worldshepherd-owned code and configuration
@@ -104,17 +139,19 @@ Never inferred from general project authority:
 
 ## Evidence contract
 
-Every Astra task record should include:
+Every Astra task/result record should include:
 
 - task_id
 - timestamp_utc
 - requester/authority
-- model = `gpt-6-astra`
+- profile_id
+- provider
+- verified runtime model id
 - mode
 - input/evidence references
-- allowed tools
-- prohibited actions
-- output digest
+- allowed/requested tools
+- authorization id
+- input/output digests
 - claims-control labels
 - uncertainty/confidence notes
 - disconfirming evidence
@@ -141,7 +178,7 @@ Astra may recommend an upgrade; only evidence and the existing approval workflow
 
 ## Routing policy
 
-Route a task to Astra when one or more of these conditions hold:
+Route a task to the Astra profile when one or more of these conditions hold:
 - long-horizon/multistep reasoning is the bottleneck
 - repository-scale code understanding is required
 - deep scientific/mathematical reasoning is required
@@ -149,7 +186,7 @@ Route a task to Astra when one or more of these conditions hold:
 - PRE/opportunity analysis spans many interdependent requirements
 - a complex tool workflow benefits from persistent context
 
-Do not route routine low-risk work to Astra merely because it is available.
+Do not route routine low-risk work to Astra merely because the profile exists.
 
 ## First application lanes
 
@@ -169,16 +206,16 @@ Use Astra to review SARA changes, generate tests, and identify contradictions be
 
 Astra integration is not operationally complete until:
 
-1. model access is available to the chosen runtime/API account;
+1. target runtime model access is verified for the selected account;
 2. credentials are stored outside the repository;
-3. SARA adapter is implemented;
-4. request/response provenance is logged;
+3. provider transport is implemented and separately reviewed;
+4. request/response provenance is persisted through the designated evidence path;
 5. read-only tests pass;
-6. timeout/cancellation/rollback behavior is verified;
+6. timeout/cancellation behavior is verified;
 7. tool allow-list enforcement is verified;
 8. claims-control tagging is verified;
 9. cyber-specific boundary tests pass;
-10. CRE1AWS approves any mode beyond `SOLVER_READ_ONLY`.
+10. CRE1AWS approves any network-enabled or elevated mode.
 
 ## Non-negotiable architectural principle
 

--- a/docs/ASTRA_INTEGRATION.md
+++ b/docs/ASTRA_INTEGRATION.md
@@ -1,0 +1,185 @@
+# Worldshepherd Astra Integration
+
+Status: DESIGN/INTEGRATION PROFILE — not production authorization
+Date: 2026-09-04
+Owner/authority: CRE1AWS
+Orchestrator: SARA
+
+## Purpose
+
+Integrate OpenAI GPT-6 Astra as a bounded high-capability solver for Worldshepherd while preserving SARA as the policy, authorization, provenance, and execution authority.
+
+Astra is not granted independent authority to perform network writes, external communications, procurement, deployment, security testing against third-party systems, or physical-control actions.
+
+## Role separation
+
+- **SARA**: authoritative workflow/orchestration layer; enforces authorization, claims-control, evidence capture, rollback, and operator approval.
+- **GPT-6 Astra**: solver/research/review node; produces analyses, candidate designs, code, test plans, simulations, counterexamples, and evidence requests.
+- **ECHO SENTINEL LINK**: provenance/telemetry record for Astra requests, outputs, tool use, evidence references, configuration, and disposition.
+- **PRIME SENTINEL**: policy gate for requested actions and tool access.
+- **OVERWATCH**: monitors performance, anomalies, drift, task duration, resource use, and policy events.
+- **CRE1AWS**: final authority for consequential external action.
+
+## Priority Worldshepherd uses
+
+1. **Scientific and engineering solver**
+   - multiphysics model decomposition
+   - materials design and inverse design
+   - metasurface/RF control synthesis
+   - numerical verification and symbolic checks
+   - experiment and coupon-test design
+   - uncertainty quantification and disconfirming-evidence search
+
+2. **Software engineering and verification**
+   - repository-scale code review
+   - test generation
+   - architecture refactoring proposals
+   - CI failure diagnosis
+   - SBOM/provenance validation plans
+   - secure configuration review
+
+3. **Predictive Requirements Engine (PRE)**
+   - requirement extraction and recurrence analysis
+   - requirement-delta generation
+   - gap-to-demo planning
+   - partner-capability matching
+   - evidence-package planning
+   - bid-readiness red-team review
+
+4. **Opportunity intelligence**
+   - solicitation decomposition
+   - compliance matrices
+   - technical-volume review
+   - partner-vs-prime analysis
+   - contradiction and eligibility checks
+   - probability calibration support
+
+5. **Claims control / adversarial review**
+   - attempt to falsify technical claims
+   - distinguish literature support, simulation, implementation, and physical validation
+   - flag unsupported extrapolation
+   - identify missing measurements, standards, certifications, and legal review
+
+## Default execution policy
+
+Astra starts in `SOLVER_READ_ONLY` mode.
+
+Allowed by default:
+- read authorized local/project inputs
+- reason over evidence
+- generate candidate artifacts
+- generate code patches for review
+- propose simulations and test plans
+- produce structured provenance and confidence records
+
+Disallowed by default:
+- network writes
+- sending email/messages
+- creating external accounts
+- publishing
+- purchases or financial transactions
+- third-party security probing/exploitation
+- changing production infrastructure
+- changing physical-control parameters on live hardware
+- bypassing SARA/PRIME authorization
+
+Any expansion beyond read-only requires an explicit SARA authorization record and must be bounded to the named resource, action, and time window.
+
+## Cybersecurity handling
+
+Because Astra is a cyber-critical-capability model, Worldshepherd treats cyber work as a separate high-risk lane.
+
+Permitted baseline:
+- defensive review of Worldshepherd-owned code and configuration
+- static analysis
+- threat modeling
+- patch recommendations
+- lab-only tests against explicitly owned/authorized targets
+
+Never inferred from general project authority:
+- exploitation of third-party systems
+- credential acquisition
+- persistence/evasion
+- autonomous scanning outside the authorized lab boundary
+
+## Evidence contract
+
+Every Astra task record should include:
+
+- task_id
+- timestamp_utc
+- requester/authority
+- model = `gpt-6-astra`
+- mode
+- input/evidence references
+- allowed tools
+- prohibited actions
+- output digest
+- claims-control labels
+- uncertainty/confidence notes
+- disconfirming evidence
+- human disposition
+- follow-on action
+
+## Claims-control rules
+
+Astra output does **not** upgrade maturity by itself.
+
+Use existing Worldshepherd labels, including:
+- PROVEN INTERNALLY
+- IMPLEMENTED IN SOFTWARE
+- SUPPORTED BY LITERATURE
+- SIMULATED ONLY
+- HYPOTHESIS
+- SPECULATIVE EXTENSION
+- REQUIRES LAB VALIDATION
+- REQUIRES PARTNER VALIDATION
+- REQUIRES LEGAL REVIEW
+- NOT CURRENTLY CLAIMED
+
+Astra may recommend an upgrade; only evidence and the existing approval workflow may perform one.
+
+## Routing policy
+
+Route a task to Astra when one or more of these conditions hold:
+- long-horizon/multistep reasoning is the bottleneck
+- repository-scale code understanding is required
+- deep scientific/mathematical reasoning is required
+- a result needs adversarial falsification before promotion
+- PRE/opportunity analysis spans many interdependent requirements
+- a complex tool workflow benefits from persistent context
+
+Do not route routine low-risk work to Astra merely because it is available.
+
+## First application lanes
+
+### A. Programmable metasurface control
+Use Astra to derive and test constrained control laws across RF/material/thermal states, generate null-steering and beamforming test cases, and search for instability/energy-accounting failures before hardware promotion.
+
+### B. WS-AlTi meta-alloy
+Use Astra for inverse-design studies, phase/precipitate hypothesis generation, DED process-window optimization, sensitivity studies, coupon-matrix reduction, and falsification of claimed advantages before valuation upgrades.
+
+### C. SARA/PRE
+Use Astra to produce requirement-delta records, evidence matrices, partner gaps, and readiness-horizon actions while preserving source provenance and distinction between confirmed demand, emerging demand, and Worldshepherd forecast.
+
+### D. Repository assurance
+Use Astra to review SARA changes, generate tests, and identify contradictions between implementation, docs, CI, and claimed readiness.
+
+## Promotion gates
+
+Astra integration is not operationally complete until:
+
+1. model access is available to the chosen runtime/API account;
+2. credentials are stored outside the repository;
+3. SARA adapter is implemented;
+4. request/response provenance is logged;
+5. read-only tests pass;
+6. timeout/cancellation/rollback behavior is verified;
+7. tool allow-list enforcement is verified;
+8. claims-control tagging is verified;
+9. cyber-specific boundary tests pass;
+10. CRE1AWS approves any mode beyond `SOLVER_READ_ONLY`.
+
+## Non-negotiable architectural principle
+
+**Astra proposes and solves; SARA authorizes and records; CRE1AWS controls consequential action.**


### PR DESCRIPTION
Implements the Worldshepherd **Astra** solver profile as a governed SARA component without treating `Astra` as an OpenAI provider model name.

## Verification correction

OpenAI's official model catalog was checked on 2026-09-04. The documented flagship runtime target is `gpt-5.6-sol`; no official `gpt-6-astra` model identifier was found. This PR therefore retracts the earlier draft assumption and cleanly separates the internal Astra profile/codename from the provider model ID.

## Included

- `docs/ASTRA_INTEGRATION.md`
- `deployments/sara_verified_local_v1/policy/astra_solver_profile.json`
- `deployments/sara_verified_local_v1/worldshepherd_sara/astra_solver.py`
- `deployments/sara_verified_local_v1/tests/test_astra_solver.py`
- fail-closed Astra defaults in `.env.example`
- package-root Astra identifiers
- Astra section appended to the verified deployment README

## Implemented controls

- SARA remains authoritative orchestrator.
- Astra defaults to `SOLVER_READ_ONLY`.
- Verified default runtime model is `gpt-5.6-sol`.
- Network inference is disabled by default.
- No provider transport is embedded; transport must be explicitly injected.
- Explicit SARA model-inference authorization is required before execution.
- Authorized model IDs are enforced.
- Tool allowlist is empty by default and fails closed.
- Remote response storage defaults to disabled.
- Canonical SHA-256 input/output provenance digests are generated.
- Existing Worldshepherd claims-control labels are preserved.
- Model output cannot itself upgrade capability maturity.
- No external communications, production changes, third-party security testing, or physical-control authority are implied.

## Validation scope

The added test suite covers zero-network preparation, model selection, tool rejection, network-disable enforcement, explicit authorization, model authorization, and digest-bearing result generation using an injected fake transport.

This PR intentionally does **not** add credentials or enable provider network access. It remains draft until protected CI is reviewed and the provider transport/provenance persistence gates are satisfied.