### PR TITLE
WS-QE-2026-PRI-001: prime-basis ablation

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_QE_2026_PRI_001.md
+++ b/deployments/sara_verified_local_v1/docs/WS_QE_2026_PRI_001.md
@@ -1,0 +1,88 @@
+# WS-QE-2026-PRI-001 — Prime-Indexed Basis Ablation
+
+Status: IMPLEMENTATION UNDER PROTECTED REVIEW
+
+Parent intake: `WS-RI-2026-0904-W3`
+
+## Question
+
+Does selecting prime-numbered modes provide a reproducible **numerical** advantage over equally sized control selections on a small deterministic synthetic Fourier benchmark?
+
+This test does not ask whether prime numbers are a new physical quantum law. It operationalizes prime indexing as one mode-selection rule so the idea can be challenged against controls.
+
+## Fixed controls
+
+Default configuration:
+
+- 64 uniformly sampled points
+- rank 5 for every selection rule
+- PRIME indices: `2, 3, 5, 7, 11`
+- CONTIGUOUS indices: `1, 2, 3, 4, 5`
+- COMPOSITE indices: `4, 6, 8, 9, 10`
+- two real Fourier terms per selected index (cosine and sine)
+- identical projection sample-operation budget for every rule
+
+## Scenario set
+
+The default benchmark intentionally includes cases that can disconfirm general superiority:
+
+1. `smooth_low_frequency` — control favoring contiguous low-order modes.
+2. `prime_sparse` — positive control concentrated on prime indices.
+3. `composite_sparse` — negative control concentrated on composite indices.
+4. `mixed_structure` — prime, composite, and low-order content.
+5. `broadband_decay` — frequencies 1 through 15 with decreasing amplitude.
+
+The prime-favorable case is therefore not sufficient by itself to promote a general claim.
+
+## Metrics
+
+For every basis/scenario pair:
+
+- relative L2 reconstruction error
+- retained energy fraction
+- selected indices and equal-rank budget
+- basis-term count
+- projection sample-operation count
+- maximum normalized cross-correlation between sampled basis vectors
+- Gram diagonal ratio
+
+The benchmark also records per-scenario winners, mean error, and win counts.
+
+## General-advantage gate
+
+`PRIME_ADVANTAGE_OBSERVED_IN_THIS_BENCHMARK` is allowed only when PRIME is no worse than both controls on every scenario within tolerance and strictly better somewhere.
+
+If a controlled baseline materially beats PRIME on any scenario, the default conclusion is `NO_GENERAL_PRIME_ADVANTAGE_OBSERVED`. Null and negative evidence are retained rather than discarded.
+
+## Evidence output
+
+The package command is:
+
+```text
+ws-prime-basis-ablation --output prime-ablation.json
+```
+
+The report is canonical SHA-256 bound. Verification is:
+
+```text
+ws-prime-basis-ablation --verify prime-ablation.json
+```
+
+A modified report must fail verification.
+
+## Claims boundary
+
+Successful software execution can establish only:
+
+- `SIMULATED_ONLY` numerical benchmark evidence;
+- behavior of this exact deterministic synthetic test;
+- whether prime mode selection did or did not dominate these controls.
+
+It cannot establish:
+
+- a quantum-physical mechanism;
+- a new quantum number law;
+- superiority for arbitrary PDEs or multi-physics systems;
+- physical, material, RF, flight, partner, or operational validation.
+
+A favorable result would justify broader numerical benchmarking, not physical promotion. An unfavorable or inconclusive result is valid evidence and must be retained.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -32,6 +32,7 @@ ws-sbom-evidence = "worldshepherd_sara.sbom_cli:main"
 ws-vulnerability-evidence = "worldshepherd_sara.vulnerability_cli:main"
 ws-human-triage-ledger = "worldshepherd_sara.human_triage_cli:main"
 ws-intake-minimum-ledger = "worldshepherd_sara.intake_minimum_cli:main"
+ws-prime-basis-ablation = "worldshepherd_sara.prime_basis_ablation_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_prime_basis_ablation.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_basis_ablation.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from worldshepherd_sara.prime_basis_ablation import (
+    AblationOutcome,
+    BasisKind,
+    default_scenarios,
+    is_prime,
+    run_prime_basis_ablation,
+    verify_prime_basis_ablation_report,
+)
+from worldshepherd_sara.qualification import CapabilityStatus
+
+
+def _scenario(report, scenario_id: str):
+    return next(item for item in report.scenarios if item.scenario_id == scenario_id)
+
+
+def _by_basis(scenario):
+    return {item.basis: item for item in scenario.results}
+
+
+def test_prime_predicate_rejects_one_and_forty_nine():
+    assert is_prime(1) is False
+    assert is_prime(2) is True
+    assert is_prime(3) is True
+    assert is_prime(49) is False
+    assert is_prime(97) is True
+
+
+def test_default_scenarios_include_positive_negative_and_neutral_controls():
+    scenario_ids = {item.scenario_id for item in default_scenarios()}
+    assert scenario_ids == {
+        "smooth_low_frequency",
+        "prime_sparse",
+        "composite_sparse",
+        "mixed_structure",
+        "broadband_decay",
+    }
+
+
+def test_all_basis_rules_receive_equal_rank_and_projection_budget():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    for scenario in report.scenarios:
+        ranks = {item.rank for item in scenario.results}
+        terms = {item.basis_terms for item in scenario.results}
+        operations = {item.projection_sample_operations for item in scenario.results}
+        assert ranks == {5}
+        assert terms == {10}
+        assert operations == {640}
+
+
+def test_selected_indices_are_distinct_and_match_declared_rules():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    first = report.scenarios[0]
+    by_basis = _by_basis(first)
+    assert by_basis[BasisKind.PRIME].selected_indices == (2, 3, 5, 7, 11)
+    assert by_basis[BasisKind.CONTIGUOUS].selected_indices == (1, 2, 3, 4, 5)
+    assert by_basis[BasisKind.COMPOSITE].selected_indices == (4, 6, 8, 9, 10)
+
+
+def test_positive_control_is_won_by_prime_basis():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    scenario = _scenario(report, "prime_sparse")
+    assert scenario.winner == BasisKind.PRIME
+    by_basis = _by_basis(scenario)
+    assert by_basis[BasisKind.PRIME].relative_l2_error < 1e-10
+    assert by_basis[BasisKind.PRIME].relative_l2_error < by_basis[BasisKind.CONTIGUOUS].relative_l2_error
+    assert by_basis[BasisKind.PRIME].relative_l2_error < by_basis[BasisKind.COMPOSITE].relative_l2_error
+
+
+def test_negative_control_is_won_by_composite_basis():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    scenario = _scenario(report, "composite_sparse")
+    assert scenario.winner == BasisKind.COMPOSITE
+    by_basis = _by_basis(scenario)
+    assert by_basis[BasisKind.COMPOSITE].relative_l2_error < 1e-10
+    assert by_basis[BasisKind.COMPOSITE].relative_l2_error < by_basis[BasisKind.PRIME].relative_l2_error
+
+
+def test_low_frequency_control_is_won_by_contiguous_basis():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    scenario = _scenario(report, "smooth_low_frequency")
+    assert scenario.winner == BasisKind.CONTIGUOUS
+    by_basis = _by_basis(scenario)
+    assert by_basis[BasisKind.CONTIGUOUS].relative_l2_error < 1e-10
+    assert by_basis[BasisKind.CONTIGUOUS].relative_l2_error < by_basis[BasisKind.PRIME].relative_l2_error
+
+
+def test_default_ablation_does_not_claim_general_prime_advantage():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    assert report.summary.prime_dominates_every_scenario is False
+    assert report.summary.outcome == AblationOutcome.NO_GENERAL_PRIME_ADVANTAGE_OBSERVED
+    assert report.preferred_basis_for_general_use is None
+    assert report.capability_status == CapabilityStatus.SIMULATED_ONLY
+    assert report.physical_validation_performed is False
+    assert report.quantum_physics_claimed is False
+
+
+def test_basis_vectors_remain_numerically_orthogonal_on_test_grid():
+    report = run_prime_basis_ablation(sample_count=64, rank=5)
+    for scenario in report.scenarios:
+        for result in scenario.results:
+            assert result.max_normalized_cross_correlation < 1e-12
+            assert abs(result.gram_diagonal_ratio - 1.0) < 1e-12
+
+
+def test_report_is_deterministic_hash_bound_and_tamper_detectable():
+    first = run_prime_basis_ablation(sample_count=64, rank=5)
+    second = run_prime_basis_ablation(sample_count=64, rank=5)
+    assert first == second
+    assert first.report_digest is not None
+    assert first.report_digest.startswith("sha256:")
+    assert verify_prime_basis_ablation_report(first) is True
+
+    tampered = first.model_copy(update={"rank": 4})
+    assert verify_prime_basis_ablation_report(tampered) is False
+
+
+def test_invalid_sampling_or_rank_fails_closed():
+    import pytest
+
+    with pytest.raises(ValueError):
+        run_prime_basis_ablation(sample_count=63, rank=5)
+    with pytest.raises(ValueError):
+        run_prime_basis_ablation(sample_count=16, rank=5)
+    with pytest.raises(ValueError):
+        run_prime_basis_ablation(sample_count=64, rank=0)

--- a/deployments/sara_verified_local_v1/tests/test_prime_basis_ablation_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_basis_ablation_cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+
+from worldshepherd_sara.prime_basis_ablation_cli import main
+
+
+def test_cli_exports_and_verifies_hash_bound_report(tmp_path, capsys):
+    output = tmp_path / "prime-ablation.json"
+    assert main(["--output", str(output)]) == 0
+    digest = capsys.readouterr().out.strip()
+    assert digest.startswith("sha256:")
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["qualification_id"] == "WS-QE-2026-PRI-001"
+    assert payload["summary"]["outcome"] == "NO_GENERAL_PRIME_ADVANTAGE_OBSERVED"
+    assert payload["physical_validation_performed"] is False
+    assert payload["quantum_physics_claimed"] is False
+
+    assert main(["--verify", str(output)]) == 0
+    assert capsys.readouterr().out.strip() == "VALID"
+
+
+def test_cli_rejects_tampered_report(tmp_path, capsys):
+    output = tmp_path / "prime-ablation.json"
+    assert main(["--output", str(output)]) == 0
+    capsys.readouterr()
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    payload["rank"] = 4
+    output.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert main(["--verify", str(output)]) == 1
+    assert capsys.readouterr().out.strip() == "INVALID"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_basis_ablation.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_basis_ablation.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import math
+from enum import Enum
+from typing import Iterable
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import CapabilityStatus, canonical_digest
+
+
+class BasisKind(str, Enum):
+    PRIME = "PRIME"
+    CONTIGUOUS = "CONTIGUOUS"
+    COMPOSITE = "COMPOSITE"
+
+
+class AblationOutcome(str, Enum):
+    PRIME_ADVANTAGE_OBSERVED_IN_THIS_BENCHMARK = (
+        "PRIME_ADVANTAGE_OBSERVED_IN_THIS_BENCHMARK"
+    )
+    NO_GENERAL_PRIME_ADVANTAGE_OBSERVED = "NO_GENERAL_PRIME_ADVANTAGE_OBSERVED"
+    INCONCLUSIVE = "INCONCLUSIVE"
+
+
+class SignalComponent(BaseModel):
+    frequency_index: int = Field(ge=1)
+    amplitude: float = Field(gt=0.0)
+    phase_radians: float = 0.0
+
+
+class ScenarioDefinition(BaseModel):
+    scenario_id: str = Field(min_length=1)
+    purpose: str = Field(min_length=1)
+    components: tuple[SignalComponent, ...]
+
+    @model_validator(mode="after")
+    def requires_components(self) -> "ScenarioDefinition":
+        if not self.components:
+            raise ValueError("scenario requires at least one component")
+        return self
+
+
+class BasisResult(BaseModel):
+    basis: BasisKind
+    selected_indices: tuple[int, ...]
+    rank: int = Field(ge=1)
+    basis_terms: int = Field(ge=2)
+    projection_sample_operations: int = Field(ge=1)
+    relative_l2_error: float = Field(ge=0.0)
+    energy_retained_fraction: float = Field(ge=0.0, le=1.0)
+    max_normalized_cross_correlation: float = Field(ge=0.0)
+    gram_diagonal_ratio: float = Field(ge=1.0)
+
+
+class ScenarioResult(BaseModel):
+    scenario_id: str
+    purpose: str
+    results: tuple[BasisResult, ...]
+    winner: BasisKind | None
+
+
+class AblationSummary(BaseModel):
+    mean_relative_l2_error: dict[BasisKind, float]
+    wins: dict[BasisKind, int]
+    prime_dominates_every_scenario: bool
+    outcome: AblationOutcome
+
+
+class PrimeBasisAblationReport(BaseModel):
+    qualification_id: str = "WS-QE-2026-PRI-001"
+    benchmark_version: str = "1.0"
+    sample_count: int = Field(ge=16)
+    rank: int = Field(ge=1)
+    scenarios: tuple[ScenarioResult, ...]
+    summary: AblationSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    physical_validation_performed: bool = False
+    quantum_physics_claimed: bool = False
+    preferred_basis_for_general_use: BasisKind | None = None
+    claims_boundary: tuple[str, ...] = (
+        "This is a deterministic synthetic numerical ablation, not physical validation.",
+        "Prime indexing is evaluated as a numerical selection rule, not a quantum law.",
+        "A favorable case does not establish general superiority; adversarial and null cases are retained.",
+    )
+    report_digest: str | None = None
+
+
+def is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value == 2:
+        return True
+    if value % 2 == 0:
+        return False
+    limit = int(math.isqrt(value))
+    for divisor in range(3, limit + 1, 2):
+        if value % divisor == 0:
+            return False
+    return True
+
+
+def _indices_for_basis(kind: BasisKind, *, rank: int, max_index: int) -> tuple[int, ...]:
+    if rank < 1:
+        raise ValueError("rank must be >= 1")
+    if max_index < 1:
+        raise ValueError("max_index must be >= 1")
+
+    if kind == BasisKind.CONTIGUOUS:
+        values = tuple(range(1, min(max_index, rank) + 1))
+    elif kind == BasisKind.PRIME:
+        values = tuple(value for value in range(2, max_index + 1) if is_prime(value))[:rank]
+    elif kind == BasisKind.COMPOSITE:
+        values = tuple(
+            value
+            for value in range(4, max_index + 1)
+            if value > 1 and not is_prime(value)
+        )[:rank]
+    else:  # pragma: no cover - Enum protects callers
+        raise ValueError(f"unsupported basis: {kind}")
+
+    if len(values) != rank:
+        raise ValueError(f"{kind.value} basis cannot supply rank {rank} below index {max_index}")
+    return values
+
+
+def _signal(sample_count: int, components: Iterable[SignalComponent]) -> tuple[float, ...]:
+    values: list[float] = []
+    for sample in range(sample_count):
+        angle_scale = (2.0 * math.pi * sample) / sample_count
+        value = 0.0
+        for component in components:
+            value += component.amplitude * math.cos(
+                (component.frequency_index * angle_scale) + component.phase_radians
+            )
+        values.append(value)
+    return tuple(values)
+
+
+def _basis_vectors(sample_count: int, indices: tuple[int, ...]) -> tuple[tuple[float, ...], ...]:
+    vectors: list[tuple[float, ...]] = []
+    for frequency in indices:
+        cosine = tuple(
+            math.cos((2.0 * math.pi * frequency * sample) / sample_count)
+            for sample in range(sample_count)
+        )
+        sine = tuple(
+            math.sin((2.0 * math.pi * frequency * sample) / sample_count)
+            for sample in range(sample_count)
+        )
+        vectors.extend((cosine, sine))
+    return tuple(vectors)
+
+
+def _dot(left: tuple[float, ...], right: tuple[float, ...]) -> float:
+    return sum(a * b for a, b in zip(left, right, strict=True))
+
+
+def _orthogonality_metrics(vectors: tuple[tuple[float, ...], ...]) -> tuple[float, float]:
+    diagonals = [_dot(vector, vector) for vector in vectors]
+    min_diagonal = min(diagonals)
+    max_diagonal = max(diagonals)
+    if min_diagonal <= 0:
+        raise ValueError("degenerate basis vector")
+
+    max_cross = 0.0
+    for left_index, left in enumerate(vectors):
+        for right_index in range(left_index + 1, len(vectors)):
+            right = vectors[right_index]
+            denominator = math.sqrt(diagonals[left_index] * diagonals[right_index])
+            max_cross = max(max_cross, abs(_dot(left, right)) / denominator)
+    return max_cross, max_diagonal / min_diagonal
+
+
+def _project_and_score(
+    signal: tuple[float, ...],
+    *,
+    kind: BasisKind,
+    indices: tuple[int, ...],
+) -> BasisResult:
+    sample_count = len(signal)
+    reconstruction = [0.0] * sample_count
+    for frequency in indices:
+        cosine_coefficient = (2.0 / sample_count) * sum(
+            value * math.cos((2.0 * math.pi * frequency * sample) / sample_count)
+            for sample, value in enumerate(signal)
+        )
+        sine_coefficient = (2.0 / sample_count) * sum(
+            value * math.sin((2.0 * math.pi * frequency * sample) / sample_count)
+            for sample, value in enumerate(signal)
+        )
+        for sample in range(sample_count):
+            angle = (2.0 * math.pi * frequency * sample) / sample_count
+            reconstruction[sample] += (
+                cosine_coefficient * math.cos(angle)
+                + sine_coefficient * math.sin(angle)
+            )
+
+    residual_energy = sum(
+        (observed - predicted) ** 2
+        for observed, predicted in zip(signal, reconstruction, strict=True)
+    )
+    total_energy = sum(value * value for value in signal)
+    if total_energy <= 0:
+        raise ValueError("signal energy must be positive")
+
+    relative_l2_error = math.sqrt(residual_energy / total_energy)
+    energy_retained = max(0.0, min(1.0, 1.0 - (residual_energy / total_energy)))
+    vectors = _basis_vectors(sample_count, indices)
+    cross, diagonal_ratio = _orthogonality_metrics(vectors)
+
+    return BasisResult(
+        basis=kind,
+        selected_indices=indices,
+        rank=len(indices),
+        basis_terms=len(indices) * 2,
+        projection_sample_operations=sample_count * len(indices) * 2,
+        relative_l2_error=relative_l2_error,
+        energy_retained_fraction=energy_retained,
+        max_normalized_cross_correlation=cross,
+        gram_diagonal_ratio=diagonal_ratio,
+    )
+
+
+def default_scenarios() -> tuple[ScenarioDefinition, ...]:
+    def components(*items: tuple[int, float, float]) -> tuple[SignalComponent, ...]:
+        return tuple(
+            SignalComponent(frequency_index=freq, amplitude=amp, phase_radians=phase)
+            for freq, amp, phase in items
+        )
+
+    return (
+        ScenarioDefinition(
+            scenario_id="smooth_low_frequency",
+            purpose="control case favoring low-order contiguous modes",
+            components=components(
+                (1, 1.0, 0.10),
+                (2, 0.70, 0.20),
+                (3, 0.45, -0.30),
+                (4, 0.30, 0.40),
+                (5, 0.20, -0.15),
+            ),
+        ),
+        ScenarioDefinition(
+            scenario_id="prime_sparse",
+            purpose="positive-control case intentionally concentrated on prime indices",
+            components=components(
+                (2, 1.0, 0.00),
+                (3, 0.80, 0.25),
+                (5, 0.65, -0.40),
+                (7, 0.50, 0.15),
+                (11, 0.35, -0.20),
+            ),
+        ),
+        ScenarioDefinition(
+            scenario_id="composite_sparse",
+            purpose="negative-control case intentionally concentrated on composite indices",
+            components=components(
+                (4, 1.0, 0.05),
+                (6, 0.80, -0.20),
+                (8, 0.65, 0.35),
+                (9, 0.50, -0.10),
+                (10, 0.35, 0.30),
+            ),
+        ),
+        ScenarioDefinition(
+            scenario_id="mixed_structure",
+            purpose="mixed case with prime, composite, and low-order content",
+            components=components(
+                (1, 0.90, 0.00),
+                (2, 0.75, 0.20),
+                (4, 0.60, -0.25),
+                (5, 0.50, 0.35),
+                (7, 0.40, -0.10),
+                (9, 0.30, 0.45),
+            ),
+        ),
+        ScenarioDefinition(
+            scenario_id="broadband_decay",
+            purpose="broadband control with amplitude decreasing by frequency index",
+            components=tuple(
+                SignalComponent(
+                    frequency_index=frequency,
+                    amplitude=1.0 / frequency,
+                    phase_radians=((frequency % 5) - 2) * 0.11,
+                )
+                for frequency in range(1, 16)
+            ),
+        ),
+    )
+
+
+def run_prime_basis_ablation(
+    *,
+    sample_count: int = 64,
+    rank: int = 5,
+    scenarios: tuple[ScenarioDefinition, ...] | None = None,
+    winner_tolerance: float = 1e-12,
+) -> PrimeBasisAblationReport:
+    """Compare equal-rank Fourier mode-selection rules on deterministic synthetic signals.
+
+    This is a numerical ablation only. Selecting prime-numbered Fourier modes is an
+    operational proxy for testing a prime-indexed representation. It neither tests
+    the complete multi-physics formulation nor establishes a quantum mechanism.
+    """
+    if sample_count < 16 or sample_count % 2:
+        raise ValueError("sample_count must be an even integer >= 16")
+    if rank < 1:
+        raise ValueError("rank must be >= 1")
+    if winner_tolerance < 0:
+        raise ValueError("winner_tolerance must be >= 0")
+
+    active_scenarios = scenarios or default_scenarios()
+    if not active_scenarios:
+        raise ValueError("at least one scenario is required")
+
+    max_index = (sample_count // 2) - 1
+    selections = {
+        kind: _indices_for_basis(kind, rank=rank, max_index=max_index)
+        for kind in BasisKind
+    }
+
+    scenario_results: list[ScenarioResult] = []
+    error_accumulator = {kind: [] for kind in BasisKind}
+    wins = {kind: 0 for kind in BasisKind}
+
+    for scenario in active_scenarios:
+        if max(component.frequency_index for component in scenario.components) > max_index:
+            raise ValueError(
+                f"scenario {scenario.scenario_id} contains frequency above usable limit {max_index}"
+            )
+        signal = _signal(sample_count, scenario.components)
+        results = tuple(
+            _project_and_score(signal, kind=kind, indices=selections[kind])
+            for kind in BasisKind
+        )
+        for result in results:
+            error_accumulator[result.basis].append(result.relative_l2_error)
+
+        minimum_error = min(result.relative_l2_error for result in results)
+        tied = [
+            result.basis
+            for result in results
+            if abs(result.relative_l2_error - minimum_error) <= winner_tolerance
+        ]
+        winner = tied[0] if len(tied) == 1 else None
+        if winner is not None:
+            wins[winner] += 1
+
+        scenario_results.append(
+            ScenarioResult(
+                scenario_id=scenario.scenario_id,
+                purpose=scenario.purpose,
+                results=results,
+                winner=winner,
+            )
+        )
+
+    prime_dominates = True
+    prime_strictly_better_somewhere = False
+    for scenario in scenario_results:
+        by_basis = {result.basis: result.relative_l2_error for result in scenario.results}
+        prime_error = by_basis[BasisKind.PRIME]
+        for baseline in (BasisKind.CONTIGUOUS, BasisKind.COMPOSITE):
+            baseline_error = by_basis[baseline]
+            if prime_error > baseline_error + winner_tolerance:
+                prime_dominates = False
+            if prime_error + winner_tolerance < baseline_error:
+                prime_strictly_better_somewhere = True
+
+    prime_dominates = prime_dominates and prime_strictly_better_somewhere
+    mean_errors = {
+        kind: sum(values) / len(values)
+        for kind, values in error_accumulator.items()
+    }
+
+    if prime_dominates:
+        outcome = AblationOutcome.PRIME_ADVANTAGE_OBSERVED_IN_THIS_BENCHMARK
+        preferred_basis = BasisKind.PRIME
+    else:
+        any_material_prime_loss = any(
+            result.winner not in {None, BasisKind.PRIME}
+            for result in scenario_results
+        )
+        outcome = (
+            AblationOutcome.NO_GENERAL_PRIME_ADVANTAGE_OBSERVED
+            if any_material_prime_loss
+            else AblationOutcome.INCONCLUSIVE
+        )
+        preferred_basis = None
+
+    report = PrimeBasisAblationReport(
+        sample_count=sample_count,
+        rank=rank,
+        scenarios=tuple(scenario_results),
+        summary=AblationSummary(
+            mean_relative_l2_error=mean_errors,
+            wins=wins,
+            prime_dominates_every_scenario=prime_dominates,
+            outcome=outcome,
+        ),
+        preferred_basis_for_general_use=preferred_basis,
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_prime_basis_ablation_report(report: PrimeBasisAblationReport) -> bool:
+    expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.report_digest == expected

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_basis_ablation_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_basis_ablation_cli.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .prime_basis_ablation import (
+    PrimeBasisAblationReport,
+    run_prime_basis_ablation,
+    verify_prime_basis_ablation_report,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the deterministic WS-QE-2026-PRI-001 prime-basis numerical ablation."
+    )
+    parser.add_argument("--sample-count", type=int, default=64)
+    parser.add_argument("--rank", type=int, default=5)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional UTF-8 JSON output path. Without this option the report is printed.",
+    )
+    parser.add_argument(
+        "--verify",
+        type=Path,
+        help="Verify an existing JSON report and exit without running a new benchmark.",
+    )
+    return parser
+
+
+def _serialize(report: PrimeBasisAblationReport) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = PrimeBasisAblationReport.model_validate(payload)
+        if not verify_prime_basis_ablation_report(report):
+            print("INVALID")
+            return 1
+        print("VALID")
+        return 0
+
+    report = run_prime_basis_ablation(sample_count=args.sample_count, rank=args.rank)
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements the first governed Wave 3 qualification experiment: a deterministic, equal-rank numerical ablation of prime-indexed Fourier mode selection against contiguous and composite controls.

### Added
- pure-Python/Pydantic ablation harness with no new dependency
- fixed prime, contiguous, and composite equal-rank selection rules
- five deterministic scenarios including prime-positive, composite-negative, low-frequency, mixed, and broadband controls
- relative L2 error, retained energy, equal-budget, and sampled-basis orthogonality metrics
- strict general-advantage gate that rejects cherry-picked prime wins
- canonical SHA-256 report binding and tamper verification
- `ws-prime-basis-ablation` export/verification CLI
- unit and CLI tests
- explicit qualification/claims boundary documentation

### Scientific/claims boundary
This operationalizes prime indexing as a numerical mode-selection rule only. It does not claim a new quantum law or physical mechanism. Successful execution can establish only `SIMULATED_ONLY` evidence for this exact synthetic benchmark. Negative and null results are retained.

### Expected disconfirming behavior
The default benchmark is designed so prime, composite, and contiguous rules each have favorable controls. A general prime advantage is allowed only if PRIME is no worse than both baselines in every scenario and strictly better somewhere.

### Validation gate
Do not merge unless the complete protected SARA test/deployment/recovery/resilience path and CodeQL are green on the exact reviewed head.