### PR TITLE
WS-QE-2026-EMB-001: programmable boundary simulation benchmark

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_QE_2026_EMB_001.md
+++ b/deployments/sara_verified_local_v1/docs/WS_QE_2026_EMB_001.md
@@ -1,0 +1,116 @@
+# WS-QE-2026-EMB-001 — Programmable EM Boundary Benchmark
+
+Status: SIMULATION IMPLEMENTATION UNDER PROTECTED REVIEW
+
+Parent intake: `WS-RI-2026-0904-W3`
+
+## Question
+
+Can a bounded, deterministic finite-array surrogate reproduce the **generic field-shaping behaviors** expected from programmable amplitude/phase control while retaining disconfirming controls and explicit thermal degradation?
+
+The benchmark is derived from the Wave 3 programmable-EM-boundary source, which models each node/tile using a complex amplitude/phase state and proposes closed-loop RF/material control. This first qualification does **not** model the full source hardware stack.
+
+## Model scope
+
+The v0.1 benchmark uses a one-dimensional, eight-tile default array with half-wavelength spacing and a narrowband scalar array-factor surrogate.
+
+Included:
+
+- per-tile position, amplitude, and phase state;
+- passive uniform state;
+- deterministic target-unaware randomized/open-loop state;
+- coherent phase control at a generic observation angle;
+- a constrained generic field minimum at one angle while preserving a separate angle;
+- deterministic thermal phase drift and edge amplitude derating;
+- normalized field-pattern proxies over -60 to +60 degrees;
+- equal total element-power proxy for all nonthermal design controls;
+- canonical SHA-256 evidence binding.
+
+Not included:
+
+- Maxwell/full-wave field solution;
+- mutual impedance or near-field tile coupling;
+- measured permittivity, permeability, conductivity, or dispersive material response;
+- RFIC, varactor, MEMS, ferrite, graphene, semiconductor, or phase-change-device models;
+- calibrated S-parameters, antenna-range data, scattering cross section, or hardware telemetry;
+- the proposed 195 nm–9675 nm multi-band target;
+- stealth, cloaking, flight, platform, or operational performance.
+
+## Default control cases
+
+### 1. Passive reference
+Uniform unit-amplitude, zero-phase tiles. This is the non-adaptive control article.
+
+### 2. Random open loop
+A deterministic irrational phase progression that does not know the target angle. It tests whether arbitrary phase complexity is being mistaken for controlled field shaping.
+
+### 3. Coherent target
+Equal-power phase alignment at +20 degrees. It is a positive control for generic coherent field shaping.
+
+### 4. Constrained null target
+A complex-weight projection creates a generic field minimum at 0 degrees while preserving a separate +25-degree observation direction. The resulting weights are normalized to the same total element-power proxy as the other nonthermal designs.
+
+### 5. Thermal drift
+The coherent design is perturbed by a deterministic phase gradient and edge amplitude derating. It is **not** renormalized afterward, so modeled derating remains visible in both power proxy and field response.
+
+## Metrics
+
+Each scenario records:
+
+- normalized field at the scenario target angle;
+- normalized field at a separately preserved angle where applicable;
+- RMS pattern change relative to the passive reference;
+- peak normalized field and peak angle on the sampled grid;
+- RMS control phase excursion;
+- total element-power proxy;
+- per-tile amplitude, phase, position, and normalized thermal state.
+
+The summary records:
+
+- coherent target gain relative to passive;
+- randomized target gain relative to passive;
+- constrained-null suppression ratio relative to passive;
+- preserved-angle fraction;
+- thermal target-retention fraction;
+- equal-power-control result;
+- a bounded expected-control-behavior gate.
+
+## Expected-control-behavior gate
+
+The default benchmark passes its **simulation behavior** gate only when:
+
+1. nonthermal design controls have equal total element-power proxy;
+2. coherent targeting improves the generic target field by more than 1.5x over passive;
+3. the constrained field minimum is below `1e-6` of the passive response at that angle;
+4. the preserved direction retains more than 75% of its coherent-reference normalized field;
+5. thermal drift reduces coherent target response below 98% of the undisturbed coherent state.
+
+Passing this gate establishes only that the simple surrogate behaves consistently with its own control equations. It is not a validation of real hardware.
+
+## Evidence command
+
+```text
+ws-programmable-boundary-benchmark --output programmable-boundary.json
+```
+
+Verification:
+
+```text
+ws-programmable-boundary-benchmark --verify programmable-boundary.json
+```
+
+The report is hash-bound; a modified report must fail verification.
+
+## Claims boundary
+
+The report is hard-coded to `SIMULATED ONLY` and rejects promotion of the following flags:
+
+- full-wave solver used;
+- mutual impedance modeled;
+- measured material properties used;
+- laboratory validation performed;
+- stealth or cloaking validated;
+- broadband spectrum validated;
+- operational validation performed.
+
+A successful v0.1 result justifies a **next simulation step**: introduce controlled mutual-coupling/full-wave or measured component/material data with a passive baseline and uncertainty budget. It does not justify a physical-performance statement.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -33,6 +33,7 @@ ws-vulnerability-evidence = "worldshepherd_sara.vulnerability_cli:main"
 ws-human-triage-ledger = "worldshepherd_sara.human_triage_cli:main"
 ws-intake-minimum-ledger = "worldshepherd_sara.intake_minimum_cli:main"
 ws-prime-basis-ablation = "worldshepherd_sara.prime_basis_ablation_cli:main"
+ws-programmable-boundary-benchmark = "worldshepherd_sara.programmable_boundary_benchmark_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.programmable_boundary_benchmark import (
+    BoundaryControlMode,
+    ProgrammableBoundaryBenchmarkReport,
+    run_programmable_boundary_benchmark,
+    verify_programmable_boundary_benchmark_report,
+)
+from worldshepherd_sara.qualification import CapabilityStatus
+
+
+def _by_id(report):
+    return {scenario.scenario_id: scenario for scenario in report.scenarios}
+
+
+def test_default_benchmark_contains_required_disconfirming_controls():
+    report = run_programmable_boundary_benchmark()
+    scenarios = _by_id(report)
+    assert set(scenarios) == {
+        "passive_reference",
+        "random_open_loop",
+        "coherent_target",
+        "null_target",
+        "thermal_drift",
+    }
+    assert scenarios["passive_reference"].mode == BoundaryControlMode.PASSIVE
+    assert scenarios["random_open_loop"].mode == BoundaryControlMode.RANDOM_OPEN_LOOP
+    assert scenarios["coherent_target"].mode == BoundaryControlMode.COHERENT_TARGET
+    assert scenarios["null_target"].mode == BoundaryControlMode.NULL_TARGET
+    assert scenarios["thermal_drift"].mode == BoundaryControlMode.THERMAL_DRIFT
+
+
+def test_nonthermal_design_controls_use_equal_total_power_proxy():
+    report = run_programmable_boundary_benchmark()
+    scenarios = _by_id(report)
+    for scenario_id in (
+        "passive_reference",
+        "random_open_loop",
+        "coherent_target",
+        "null_target",
+    ):
+        assert scenarios[scenario_id].total_element_power_proxy == pytest.approx(
+            report.tile_count, abs=1e-10
+        )
+    assert report.summary.equal_power_design_controls is True
+
+
+def test_coherent_control_improves_generic_target_over_passive():
+    report = run_programmable_boundary_benchmark()
+    scenarios = _by_id(report)
+    coherent = scenarios["coherent_target"].target_normalized_field
+    passive = scenarios["passive_reference"].target_normalized_field
+    assert coherent is not None and passive is not None
+    assert coherent > 0.99
+    assert coherent > passive * 1.5
+    assert report.summary.coherent_gain_over_passive > 1.5
+
+
+def test_random_open_loop_is_not_mistaken_for_target_aware_control():
+    report = run_programmable_boundary_benchmark()
+    scenarios = _by_id(report)
+    random_field = scenarios["random_open_loop"].target_normalized_field
+    coherent = scenarios["coherent_target"].target_normalized_field
+    assert random_field is not None and coherent is not None
+    assert random_field < coherent
+
+
+def test_constrained_null_suppresses_generic_angle_and_preserves_other_angle():
+    report = run_programmable_boundary_benchmark()
+    scenario = _by_id(report)["null_target"]
+    assert scenario.target_angle_degrees == 0.0
+    assert scenario.preserve_angle_degrees == 25.0
+    assert scenario.target_normalized_field is not None
+    assert scenario.preserve_normalized_field is not None
+    assert scenario.target_normalized_field < 1e-8
+    assert scenario.preserve_normalized_field > 0.75
+    assert report.summary.null_suppression_ratio_vs_passive < 1e-6
+    assert report.summary.null_preserve_fraction > 0.75
+
+
+def test_thermal_drift_degrades_target_and_reduces_power_proxy():
+    report = run_programmable_boundary_benchmark()
+    scenarios = _by_id(report)
+    coherent = scenarios["coherent_target"]
+    thermal = scenarios["thermal_drift"]
+    assert coherent.target_normalized_field is not None
+    assert thermal.target_normalized_field is not None
+    assert thermal.target_normalized_field < coherent.target_normalized_field
+    assert thermal.total_element_power_proxy < coherent.total_element_power_proxy
+    assert report.summary.thermal_target_retention_fraction < 0.98
+    assert max(state.normalized_temperature for state in thermal.tile_states) == pytest.approx(1.0)
+
+
+def test_expected_control_behavior_gate_is_observed_without_physical_promotion():
+    report = run_programmable_boundary_benchmark()
+    assert report.summary.expected_control_behavior_observed is True
+    assert report.capability_status == CapabilityStatus.SIMULATED_ONLY
+    assert report.full_wave_solver_used is False
+    assert report.mutual_impedance_modeled is False
+    assert report.measured_material_properties_used is False
+    assert report.laboratory_validation_performed is False
+    assert report.stealth_or_cloaking_validated is False
+    assert report.broadband_spectrum_validated is False
+    assert report.operational_validation_performed is False
+
+
+def test_report_is_deterministic_hash_bound_and_tamper_detectable():
+    first = run_programmable_boundary_benchmark()
+    second = run_programmable_boundary_benchmark()
+    assert first == second
+    assert first.report_digest is not None
+    assert first.report_digest.startswith("sha256:")
+    assert verify_programmable_boundary_benchmark_report(first) is True
+
+    tampered = first.model_copy(update={"tile_spacing_wavelengths": 0.4})
+    assert verify_programmable_boundary_benchmark_report(tampered) is False
+
+
+def test_fail_closed_model_rejects_physical_claim_promotion():
+    report = run_programmable_boundary_benchmark()
+    payload = report.model_dump(mode="json")
+    payload["laboratory_validation_performed"] = True
+    with pytest.raises(ValueError):
+        ProgrammableBoundaryBenchmarkReport.model_validate(payload)
+
+    payload = report.model_dump(mode="json")
+    payload["stealth_or_cloaking_validated"] = True
+    with pytest.raises(ValueError):
+        ProgrammableBoundaryBenchmarkReport.model_validate(payload)
+
+
+def test_invalid_geometry_and_angles_fail_closed():
+    with pytest.raises(ValueError):
+        run_programmable_boundary_benchmark(tile_count=3)
+    with pytest.raises(ValueError):
+        run_programmable_boundary_benchmark(tile_spacing_wavelengths=0.75)
+    with pytest.raises(ValueError):
+        run_programmable_boundary_benchmark(coherent_target_angle_degrees=80.0)

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark_cli.py
@@ -13,7 +13,7 @@ def test_cli_exports_and_verifies_simulation_report(tmp_path, capsys):
 
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["qualification_id"] == "WS-QE-2026-EMB-001"
-    assert payload["capability_status"] == "SIMULATED ONLY"
+    assert payload["capability_status"] == "SIMULATED_ONLY"
     assert payload["summary"]["expected_control_behavior_observed"] is True
     assert payload["laboratory_validation_performed"] is False
     assert payload["stealth_or_cloaking_validated"] is False

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+from worldshepherd_sara.programmable_boundary_benchmark_cli import main
+
+
+def test_cli_exports_and_verifies_simulation_report(tmp_path, capsys):
+    output = tmp_path / "programmable-boundary.json"
+    assert main(["--output", str(output)]) == 0
+    digest = capsys.readouterr().out.strip()
+    assert digest.startswith("sha256:")
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["qualification_id"] == "WS-QE-2026-EMB-001"
+    assert payload["capability_status"] == "SIMULATED ONLY"
+    assert payload["summary"]["expected_control_behavior_observed"] is True
+    assert payload["laboratory_validation_performed"] is False
+    assert payload["stealth_or_cloaking_validated"] is False
+    assert payload["operational_validation_performed"] is False
+
+    assert main(["--verify", str(output)]) == 0
+    assert capsys.readouterr().out.strip() == "VALID"
+
+
+def test_cli_rejects_tampered_report(tmp_path, capsys):
+    output = tmp_path / "programmable-boundary.json"
+    assert main(["--output", str(output)]) == 0
+    capsys.readouterr()
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    payload["tile_spacing_wavelengths"] = 0.4
+    output.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert main(["--verify", str(output)]) == 1
+    assert capsys.readouterr().out.strip() == "INVALID"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import cmath
+import math
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import CapabilityStatus, canonical_digest
+
+
+class BoundaryControlMode(str, Enum):
+    PASSIVE = "PASSIVE"
+    RANDOM_OPEN_LOOP = "RANDOM_OPEN_LOOP"
+    COHERENT_TARGET = "COHERENT_TARGET"
+    NULL_TARGET = "NULL_TARGET"
+    THERMAL_DRIFT = "THERMAL_DRIFT"
+
+
+class TileState(BaseModel):
+    tile_index: int = Field(ge=0)
+    position_wavelengths: float
+    amplitude: float = Field(ge=0.0)
+    phase_radians: float
+    normalized_temperature: float = Field(ge=0.0, le=1.0)
+
+
+class BoundaryScenarioResult(BaseModel):
+    scenario_id: str
+    purpose: str
+    mode: BoundaryControlMode
+    target_angle_degrees: float | None
+    preserve_angle_degrees: float | None
+    tile_states: tuple[TileState, ...]
+    total_element_power_proxy: float = Field(ge=0.0)
+    target_normalized_field: float | None
+    preserve_normalized_field: float | None
+    pattern_rms_change_from_passive: float = Field(ge=0.0)
+    peak_normalized_field: float = Field(ge=0.0)
+    peak_angle_degrees: float
+    control_phase_rms_radians: float = Field(ge=0.0)
+    claims_boundary: tuple[str, ...]
+
+
+class BoundaryBenchmarkSummary(BaseModel):
+    coherent_gain_over_passive: float
+    random_gain_over_passive: float
+    null_suppression_ratio_vs_passive: float
+    null_preserve_fraction: float
+    thermal_target_retention_fraction: float
+    equal_power_design_controls: bool
+    expected_control_behavior_observed: bool
+
+
+class ProgrammableBoundaryBenchmarkReport(BaseModel):
+    qualification_id: str = "WS-QE-2026-EMB-001"
+    benchmark_version: str = "0.1"
+    tile_count: int = Field(ge=4)
+    tile_spacing_wavelengths: float = Field(gt=0.0)
+    pattern_angles_degrees: tuple[float, ...]
+    scenarios: tuple[BoundaryScenarioResult, ...]
+    summary: BoundaryBenchmarkSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    full_wave_solver_used: bool = False
+    mutual_impedance_modeled: bool = False
+    measured_material_properties_used: bool = False
+    laboratory_validation_performed: bool = False
+    stealth_or_cloaking_validated: bool = False
+    broadband_spectrum_validated: bool = False
+    operational_validation_performed: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "This is a deterministic synthetic array-factor surrogate, not a full-wave electromagnetic solver.",
+        "No measured material property, mutual-impedance model, calibrated scattering result, stealth result, or cloaking result is represented.",
+        "Successful execution establishes only bounded SIMULATED_ONLY field-shaping behavior for this exact benchmark.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "ProgrammableBoundaryBenchmarkReport":
+        prohibited = (
+            self.full_wave_solver_used,
+            self.mutual_impedance_modeled,
+            self.measured_material_properties_used,
+            self.laboratory_validation_performed,
+            self.stealth_or_cloaking_validated,
+            self.broadband_spectrum_validated,
+            self.operational_validation_performed,
+        )
+        if any(prohibited):
+            raise ValueError("v0.1 benchmark cannot promote physical/full-wave/operational claims")
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("v0.1 benchmark must remain SIMULATED_ONLY")
+        return self
+
+
+def _positions(tile_count: int, spacing: float) -> tuple[float, ...]:
+    center = (tile_count - 1) / 2.0
+    return tuple((index - center) * spacing for index in range(tile_count))
+
+
+def _steering_vector(
+    *,
+    angle_degrees: float,
+    tile_count: int,
+    spacing: float,
+) -> tuple[complex, ...]:
+    sine = math.sin(math.radians(angle_degrees))
+    return tuple(
+        cmath.exp(1j * 2.0 * math.pi * position * sine)
+        for position in _positions(tile_count, spacing)
+    )
+
+
+def _field(weights: tuple[complex, ...], steering: tuple[complex, ...]) -> complex:
+    return sum(weight * response for weight, response in zip(weights, steering, strict=True))
+
+
+def _power_proxy(weights: tuple[complex, ...]) -> float:
+    return sum(abs(weight) ** 2 for weight in weights)
+
+
+def _normalize_design_power(weights: tuple[complex, ...], tile_count: int) -> tuple[complex, ...]:
+    power = _power_proxy(weights)
+    if power <= 0.0:
+        raise ValueError("control weights must have positive power proxy")
+    scale = math.sqrt(tile_count / power)
+    return tuple(weight * scale for weight in weights)
+
+
+def _passive_weights(tile_count: int) -> tuple[complex, ...]:
+    return tuple(1.0 + 0.0j for _ in range(tile_count))
+
+
+def _coherent_weights(*, angle_degrees: float, tile_count: int, spacing: float) -> tuple[complex, ...]:
+    steering = _steering_vector(
+        angle_degrees=angle_degrees,
+        tile_count=tile_count,
+        spacing=spacing,
+    )
+    return _normalize_design_power(tuple(value.conjugate() for value in steering), tile_count)
+
+
+def _random_open_loop_weights(tile_count: int) -> tuple[complex, ...]:
+    # Deterministic irrational phase progression: repeatable and intentionally not target-aware.
+    golden_conjugate = (math.sqrt(5.0) - 1.0) / 2.0
+    weights = tuple(
+        cmath.exp(1j * 2.0 * math.pi * ((index * golden_conjugate) % 1.0))
+        for index in range(tile_count)
+    )
+    return _normalize_design_power(weights, tile_count)
+
+
+def _null_weights(
+    *,
+    preserve_angle_degrees: float,
+    null_angle_degrees: float,
+    tile_count: int,
+    spacing: float,
+) -> tuple[complex, ...]:
+    preserve = _coherent_weights(
+        angle_degrees=preserve_angle_degrees,
+        tile_count=tile_count,
+        spacing=spacing,
+    )
+    null_steering = _steering_vector(
+        angle_degrees=null_angle_degrees,
+        tile_count=tile_count,
+        spacing=spacing,
+    )
+    null_conjugate = tuple(value.conjugate() for value in null_steering)
+    numerator = _field(preserve, null_steering)
+    denominator = _field(null_conjugate, null_steering)
+    if abs(denominator) <= 1e-15:
+        raise ValueError("degenerate null constraint")
+    projected = tuple(
+        weight - (numerator / denominator) * null_basis
+        for weight, null_basis in zip(preserve, null_conjugate, strict=True)
+    )
+    return _normalize_design_power(projected, tile_count)
+
+
+def _apply_thermal_drift(
+    weights: tuple[complex, ...],
+    *,
+    phase_edge_radians: float = 0.8,
+    edge_amplitude_derating: float = 0.12,
+) -> tuple[complex, ...]:
+    if not 0.0 <= edge_amplitude_derating < 1.0:
+        raise ValueError("edge amplitude derating must be in [0, 1)")
+    center = (len(weights) - 1) / 2.0
+    if center <= 0.0:
+        raise ValueError("thermal model requires multiple tiles")
+    drifted: list[complex] = []
+    for index, weight in enumerate(weights):
+        normalized_position = (index - center) / center
+        phase_error = phase_edge_radians * normalized_position
+        amplitude_scale = 1.0 - edge_amplitude_derating * abs(normalized_position)
+        drifted.append(weight * amplitude_scale * cmath.exp(1j * phase_error))
+    return tuple(drifted)
+
+
+def _phase_rms(weights: tuple[complex, ...]) -> float:
+    phases = tuple(cmath.phase(weight) for weight in weights)
+    return math.sqrt(sum(phase * phase for phase in phases) / len(phases))
+
+
+def _temperature_profile(tile_count: int, *, thermal: bool) -> tuple[float, ...]:
+    if not thermal:
+        return tuple(0.0 for _ in range(tile_count))
+    center = (tile_count - 1) / 2.0
+    return tuple(abs((index - center) / center) for index in range(tile_count))
+
+
+def _states(
+    weights: tuple[complex, ...],
+    *,
+    spacing: float,
+    thermal: bool,
+) -> tuple[TileState, ...]:
+    temperatures = _temperature_profile(len(weights), thermal=thermal)
+    return tuple(
+        TileState(
+            tile_index=index,
+            position_wavelengths=position,
+            amplitude=abs(weight),
+            phase_radians=cmath.phase(weight),
+            normalized_temperature=temperatures[index],
+        )
+        for index, (position, weight) in enumerate(
+            zip(_positions(len(weights), spacing), weights, strict=True)
+        )
+    )
+
+
+def _pattern(
+    weights: tuple[complex, ...],
+    *,
+    angles: tuple[float, ...],
+    spacing: float,
+) -> tuple[float, ...]:
+    normalization = max(1e-15, sum(abs(weight) for weight in weights))
+    return tuple(
+        abs(
+            _field(
+                weights,
+                _steering_vector(
+                    angle_degrees=angle,
+                    tile_count=len(weights),
+                    spacing=spacing,
+                ),
+            )
+        )
+        / normalization
+        for angle in angles
+    )
+
+
+def _at_angle(
+    weights: tuple[complex, ...],
+    *,
+    angle: float,
+    spacing: float,
+) -> float:
+    normalization = max(1e-15, sum(abs(weight) for weight in weights))
+    return abs(
+        _field(
+            weights,
+            _steering_vector(
+                angle_degrees=angle,
+                tile_count=len(weights),
+                spacing=spacing,
+            ),
+        )
+    ) / normalization
+
+
+def _rms_difference(left: tuple[float, ...], right: tuple[float, ...]) -> float:
+    return math.sqrt(
+        sum((a - b) ** 2 for a, b in zip(left, right, strict=True)) / len(left)
+    )
+
+
+def _scenario_result(
+    *,
+    scenario_id: str,
+    purpose: str,
+    mode: BoundaryControlMode,
+    weights: tuple[complex, ...],
+    passive_pattern: tuple[float, ...],
+    pattern_angles: tuple[float, ...],
+    spacing: float,
+    target_angle: float | None,
+    preserve_angle: float | None,
+    thermal: bool = False,
+) -> BoundaryScenarioResult:
+    response = _pattern(weights, angles=pattern_angles, spacing=spacing)
+    peak_index = max(range(len(response)), key=response.__getitem__)
+    return BoundaryScenarioResult(
+        scenario_id=scenario_id,
+        purpose=purpose,
+        mode=mode,
+        target_angle_degrees=target_angle,
+        preserve_angle_degrees=preserve_angle,
+        tile_states=_states(weights, spacing=spacing, thermal=thermal),
+        total_element_power_proxy=_power_proxy(weights),
+        target_normalized_field=(
+            None if target_angle is None else _at_angle(weights, angle=target_angle, spacing=spacing)
+        ),
+        preserve_normalized_field=(
+            None
+            if preserve_angle is None
+            else _at_angle(weights, angle=preserve_angle, spacing=spacing)
+        ),
+        pattern_rms_change_from_passive=_rms_difference(response, passive_pattern),
+        peak_normalized_field=response[peak_index],
+        peak_angle_degrees=pattern_angles[peak_index],
+        control_phase_rms_radians=_phase_rms(weights),
+        claims_boundary=(
+            "Normalized field values are synthetic array-factor proxies.",
+            "No physical scattering cross section or material response is inferred.",
+        ),
+    )
+
+
+def run_programmable_boundary_benchmark(
+    *,
+    tile_count: int = 8,
+    tile_spacing_wavelengths: float = 0.5,
+    coherent_target_angle_degrees: float = 20.0,
+    null_angle_degrees: float = 0.0,
+    preserve_angle_degrees: float = 25.0,
+) -> ProgrammableBoundaryBenchmarkReport:
+    if tile_count < 4:
+        raise ValueError("tile_count must be >= 4")
+    if not 0.0 < tile_spacing_wavelengths <= 0.5:
+        raise ValueError("v0.1 requires tile spacing in (0, 0.5] wavelengths")
+    for angle in (
+        coherent_target_angle_degrees,
+        null_angle_degrees,
+        preserve_angle_degrees,
+    ):
+        if not -60.0 <= angle <= 60.0:
+            raise ValueError("benchmark angles must remain within [-60, 60] degrees")
+
+    pattern_angles = tuple(float(angle) for angle in range(-60, 61, 5))
+    passive = _passive_weights(tile_count)
+    random_weights = _random_open_loop_weights(tile_count)
+    coherent = _coherent_weights(
+        angle_degrees=coherent_target_angle_degrees,
+        tile_count=tile_count,
+        spacing=tile_spacing_wavelengths,
+    )
+    null_control = _null_weights(
+        preserve_angle_degrees=preserve_angle_degrees,
+        null_angle_degrees=null_angle_degrees,
+        tile_count=tile_count,
+        spacing=tile_spacing_wavelengths,
+    )
+    thermal = _apply_thermal_drift(coherent)
+    passive_pattern = _pattern(
+        passive,
+        angles=pattern_angles,
+        spacing=tile_spacing_wavelengths,
+    )
+
+    scenarios = (
+        _scenario_result(
+            scenario_id="passive_reference",
+            purpose="non-adaptive reference with uniform tile state",
+            mode=BoundaryControlMode.PASSIVE,
+            weights=passive,
+            passive_pattern=passive_pattern,
+            pattern_angles=pattern_angles,
+            spacing=tile_spacing_wavelengths,
+            target_angle=coherent_target_angle_degrees,
+            preserve_angle=preserve_angle_degrees,
+        ),
+        _scenario_result(
+            scenario_id="random_open_loop",
+            purpose="deterministic target-unaware open-loop control",
+            mode=BoundaryControlMode.RANDOM_OPEN_LOOP,
+            weights=random_weights,
+            passive_pattern=passive_pattern,
+            pattern_angles=pattern_angles,
+            spacing=tile_spacing_wavelengths,
+            target_angle=coherent_target_angle_degrees,
+            preserve_angle=preserve_angle_degrees,
+        ),
+        _scenario_result(
+            scenario_id="coherent_target",
+            purpose="phase-coherent positive control at a generic observation angle",
+            mode=BoundaryControlMode.COHERENT_TARGET,
+            weights=coherent,
+            passive_pattern=passive_pattern,
+            pattern_angles=pattern_angles,
+            spacing=tile_spacing_wavelengths,
+            target_angle=coherent_target_angle_degrees,
+            preserve_angle=preserve_angle_degrees,
+        ),
+        _scenario_result(
+            scenario_id="null_target",
+            purpose="constrained generic field minimum while preserving a separate observation angle",
+            mode=BoundaryControlMode.NULL_TARGET,
+            weights=null_control,
+            passive_pattern=passive_pattern,
+            pattern_angles=pattern_angles,
+            spacing=tile_spacing_wavelengths,
+            target_angle=null_angle_degrees,
+            preserve_angle=preserve_angle_degrees,
+        ),
+        _scenario_result(
+            scenario_id="thermal_drift",
+            purpose="coherent-control sensitivity to deterministic phase drift and edge derating",
+            mode=BoundaryControlMode.THERMAL_DRIFT,
+            weights=thermal,
+            passive_pattern=passive_pattern,
+            pattern_angles=pattern_angles,
+            spacing=tile_spacing_wavelengths,
+            target_angle=coherent_target_angle_degrees,
+            preserve_angle=preserve_angle_degrees,
+            thermal=True,
+        ),
+    )
+    by_id = {scenario.scenario_id: scenario for scenario in scenarios}
+    passive_target = by_id["passive_reference"].target_normalized_field or 0.0
+    random_target = by_id["random_open_loop"].target_normalized_field or 0.0
+    coherent_target = by_id["coherent_target"].target_normalized_field or 0.0
+    passive_null = _at_angle(passive, angle=null_angle_degrees, spacing=tile_spacing_wavelengths)
+    controlled_null = by_id["null_target"].target_normalized_field or 0.0
+    null_preserve = by_id["null_target"].preserve_normalized_field or 0.0
+    coherent_preserve_reference = _at_angle(
+        _coherent_weights(
+            angle_degrees=preserve_angle_degrees,
+            tile_count=tile_count,
+            spacing=tile_spacing_wavelengths,
+        ),
+        angle=preserve_angle_degrees,
+        spacing=tile_spacing_wavelengths,
+    )
+    thermal_target = by_id["thermal_drift"].target_normalized_field or 0.0
+
+    equal_power = all(
+        abs(by_id[key].total_element_power_proxy - tile_count) <= 1e-10
+        for key in (
+            "passive_reference",
+            "random_open_loop",
+            "coherent_target",
+            "null_target",
+        )
+    )
+    coherent_gain = coherent_target / max(passive_target, 1e-15)
+    random_gain = random_target / max(passive_target, 1e-15)
+    null_suppression = controlled_null / max(passive_null, 1e-15)
+    null_preserve_fraction = null_preserve / max(coherent_preserve_reference, 1e-15)
+    thermal_retention = thermal_target / max(coherent_target, 1e-15)
+    behavior_observed = (
+        equal_power
+        and coherent_gain > 1.5
+        and null_suppression < 1e-6
+        and null_preserve_fraction > 0.75
+        and thermal_retention < 0.98
+    )
+
+    report = ProgrammableBoundaryBenchmarkReport(
+        tile_count=tile_count,
+        tile_spacing_wavelengths=tile_spacing_wavelengths,
+        pattern_angles_degrees=pattern_angles,
+        scenarios=scenarios,
+        summary=BoundaryBenchmarkSummary(
+            coherent_gain_over_passive=coherent_gain,
+            random_gain_over_passive=random_gain,
+            null_suppression_ratio_vs_passive=null_suppression,
+            null_preserve_fraction=null_preserve_fraction,
+            thermal_target_retention_fraction=thermal_retention,
+            equal_power_design_controls=equal_power,
+            expected_control_behavior_observed=behavior_observed,
+        ),
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_programmable_boundary_benchmark_report(
+    report: ProgrammableBoundaryBenchmarkReport,
+) -> bool:
+    expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.report_digest == expected

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark_cli.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .programmable_boundary_benchmark import (
+    ProgrammableBoundaryBenchmarkReport,
+    run_programmable_boundary_benchmark,
+    verify_programmable_boundary_benchmark_report,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the deterministic WS-QE-2026-EMB-001 programmable-boundary simulation benchmark."
+    )
+    parser.add_argument("--tile-count", type=int, default=8)
+    parser.add_argument("--spacing", type=float, default=0.5)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _serialize(report: ProgrammableBoundaryBenchmarkReport) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = ProgrammableBoundaryBenchmarkReport.model_validate(payload)
+        if not verify_programmable_boundary_benchmark_report(report):
+            print("INVALID")
+            return 1
+        print("VALID")
+        return 0
+
+    report = run_programmable_boundary_benchmark(
+        tile_count=args.tile_count,
+        tile_spacing_wavelengths=args.spacing,
+    )
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements the first bounded programmable-EM-boundary qualification from Wave 3 as a deterministic narrowband finite-array simulation with explicit passive, randomized/open-loop, coherent, constrained-field-minimum, and thermal-drift controls.

### Added
- pure-Python/Pydantic array-factor surrogate; no new scientific dependency
- per-tile amplitude/phase/position/normalized thermal state
- equal total element-power proxy across all nonthermal design controls
- passive and deterministic target-unaware controls
- coherent positive-control field shaping at a generic observation angle
- constrained generic field minimum while preserving a separate observation angle
- deterministic thermal phase drift and edge derating
- normalized pattern/target/preserve/control-effort/power metrics
- canonical SHA-256 report binding and tamper verification
- `ws-programmable-boundary-benchmark` export/verify CLI
- unit and CLI tests
- explicit model/claims boundary documentation

### Claims boundary
This is a narrowband scalar array-factor surrogate only. It does not model full-wave Maxwell behavior, mutual impedance, measured material properties, calibrated scattering, the proposed 195 nm–9675 nm range, stealth, cloaking, flight, or operational performance. Reports are hard-gated to `SIMULATED ONLY` and reject physical/operational validation flags.

### Scientific controls
The benchmark must demonstrate equal design-power accounting, coherent improvement over passive, a constrained generic field minimum with preserved response elsewhere, and degradation under thermal drift. A randomized/open-loop state is retained so arbitrary phase complexity cannot be mistaken for target-aware control.

### Validation gate
Do not merge unless the complete protected SARA unit/API, deployment, destructive recovery, rollback/TLS/resilience, evidence, and CodeQL paths are green on the exact reviewed head.