### PR TITLE
WMAF-SIM v0.1: compose read-only mobility assurance

### DIFF
--- a/deployments/sara_verified_local_v1/WS_WMAF_SIM_V0_1_BOUNDARY.md
+++ b/deployments/sara_verified_local_v1/WS_WMAF_SIM_V0_1_BOUNDARY.md
@@ -1,0 +1,75 @@
+# WS-WMAF-SIM v0.1 — Mobility Assurance Composition Boundary
+
+## Purpose
+
+WS-WMAF-SIM v0.1 composes existing Worldshepherd/SARA APNT normalization, bounded autonomy-policy evaluation, and canonical evidence-digest primitives into a synthetic/replay mobility-assurance assessment path.
+
+It is intentionally a thin composition layer. It does not introduce a second autonomy stack, a vehicle-control system, or a vendor-specific integration framework.
+
+## Implemented scope
+
+The v0.1 software path can:
+
+- accept a synthetic/replay mobility event using `WS-WMAF-EVENT-V0.1`;
+- normalize a synthetic PNT source through the existing `SyntheticPntAdapter`;
+- identify bounded risk conditions for PNT degradation, contradictory vehicle state, unauthorized software version, telemetry loss/staleness, and invalid telemetry age;
+- evaluate an optional action candidate through the existing Worldshepherd autonomy policy;
+- classify the assessment as `OBSERVE`, `FLAG`, `ESCALATE`, or `DENY`;
+- retain `execution_performed=false` for every assessment; and
+- bind the complete assessment inputs, disposition, and claims boundary to a canonical SHA-256 digest.
+
+## Default policy boundary
+
+The default WMAF-SIM policy allows only policy evaluation for the non-actuating action types:
+
+- `record_evidence`
+- `raise_alert`
+
+It explicitly denies:
+
+- `vehicle_control`
+- `steering`
+- `braking`
+- `throttle`
+- `route_override`
+- `actuation`
+
+An `AUTO_ELIGIBLE` policy result does not execute an action and does not confer external authority.
+
+## Validation boundary
+
+Current claimable state for WMAF-SIM v0.1 is limited to software/simulation evidence after tests pass.
+
+This increment does **not** establish:
+
+- physical or field validation;
+- roadworthiness or functional-safety compliance;
+- ISO 26262 conformity or certification;
+- ISO/SAE 21434 conformity or certification;
+- UNECE R155/R156 conformity;
+- ISO 3691-4 conformity;
+- ASPN, pntOS, GPNTS, or government-interface implementation;
+- production CAN, CAN-FD, Automotive Ethernet, ROS 2, DDS, or proprietary vehicle-bus integration;
+- NXP, Aeva, Hyster-Yale, NVIDIA, Mobileye, Toyota, Qualcomm, DENSO, Infineon, Ambarella, Wabtec, RoboSense, or other partner/vendor integration;
+- partner interest, endorsement, adoption, validation, or supplier approval;
+- autonomous steering, braking, throttle, routing, flight, weapons, or other actuation;
+- operational authority.
+
+## Audit-derived architecture decision
+
+The repository already contains APNT adapters/contracts, autonomy policy, sensor-fusion evidence, HMAA assurance/attestation, evidence stores, PRE qualification, and partner-screening machinery. WMAF therefore reuses those primitives rather than duplicating them.
+
+Vendor-specific adapters must remain separate future increments and require authoritative interface definitions, lawful access, test fixtures, and partner or lab validation before any integration claim is promoted.
+
+## Next evidence gate
+
+WMAF-SIM v0.1 is eligible for promotion only after:
+
+1. repository tests covering nominal and fault cases pass;
+2. protected SARA CI passes on the proposed revision;
+3. CodeQL/security checks pass where configured;
+4. the diff is reviewed for absence of network/write/control paths;
+5. claims-boundary language remains intact; and
+6. human review approves merge.
+
+After that gate, the next technical increment should be a replay-oriented generic mobility adapter or authoritative partner-specific fixture—not a live vehicle-control integration.

--- a/deployments/sara_verified_local_v1/tests/test_wmaf.py
+++ b/deployments/sara_verified_local_v1/tests/test_wmaf.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from worldshepherd_sara.autonomy_policy import (
+    AutonomousActionCandidate,
+    ExecutionDisposition,
+)
+from worldshepherd_sara.wmaf import (
+    MobilityAsset,
+    MobilitySource,
+    WmafDisposition,
+    WmafEvent,
+    assess_event,
+)
+
+
+def _event(**overrides) -> WmafEvent:
+    payload = {
+        "event_id": "WMAF-EVT-001",
+        "observed_utc": "2026-09-04T23:59:00Z",
+        "asset": MobilityAsset(asset_id="SIM-VEH-001", asset_type="synthetic_vehicle"),
+        "source": MobilitySource(
+            vendor="synthetic",
+            device="fixture-v1",
+            firmware="fixture",
+            interface="simulation",
+        ),
+        "pnt_payload": {
+            "source_id": "PNT-001",
+            "source_kind": "synthetic_gnss",
+            "health": "nominal",
+            "confidence": 0.99,
+            "observed_utc": "2026-09-04T23:59:00Z",
+        },
+        "vehicle_state": {
+            "telemetry_connected": True,
+            "telemetry_age_seconds": 0.1,
+        },
+        "cyber_state": {"software_version_authorized": True},
+    }
+    payload.update(overrides)
+    return WmafEvent(**payload)
+
+
+def test_nominal_event_is_observe_only_and_digest_bound():
+    assessment = assess_event(_event())
+
+    assert assessment.disposition is WmafDisposition.OBSERVE
+    assert assessment.risk_flags == []
+    assert assessment.execution_performed is False
+    assert assessment.evidence_digest.startswith("sha256:")
+    assert len(assessment.evidence_digest) == len("sha256:") + 64
+
+
+def test_degraded_pnt_is_flagged_without_execution():
+    event = _event(
+        pnt_payload={
+            "source_id": "PNT-002",
+            "source_kind": "synthetic_gnss",
+            "health": "degraded",
+            "confidence": 0.50,
+        }
+    )
+    assessment = assess_event(event)
+
+    assert assessment.disposition is WmafDisposition.FLAG
+    assert "PNT_DEGRADED" in assessment.risk_flags
+    assert assessment.execution_performed is False
+
+
+def test_contradictory_vehicle_state_escalates():
+    event = _event(
+        vehicle_state={
+            "telemetry_connected": True,
+            "telemetry_age_seconds": 0.1,
+            "contradictory_state": True,
+        }
+    )
+    assessment = assess_event(event)
+
+    assert assessment.disposition is WmafDisposition.ESCALATE
+    assert "CONTRADICTORY_VEHICLE_STATE" in assessment.risk_flags
+
+
+def test_unauthorized_software_version_escalates():
+    assessment = assess_event(
+        _event(cyber_state={"software_version_authorized": False})
+    )
+
+    assert assessment.disposition is WmafDisposition.ESCALATE
+    assert "UNAUTHORIZED_SOFTWARE_VERSION" in assessment.risk_flags
+
+
+def test_telemetry_loss_and_staleness_are_flagged():
+    lost = assess_event(
+        _event(vehicle_state={"telemetry_connected": False})
+    )
+    stale = assess_event(
+        _event(
+            event_id="WMAF-EVT-STALE",
+            vehicle_state={
+                "telemetry_connected": True,
+                "telemetry_age_seconds": 6.0,
+            },
+        )
+    )
+
+    assert lost.disposition is WmafDisposition.FLAG
+    assert "TELEMETRY_LOSS" in lost.risk_flags
+    assert stale.disposition is WmafDisposition.FLAG
+    assert "TELEMETRY_STALE" in stale.risk_flags
+
+
+def test_malformed_or_negative_telemetry_age_fails_closed_to_flag():
+    malformed = assess_event(
+        _event(
+            event_id="WMAF-EVT-BAD-AGE",
+            vehicle_state={
+                "telemetry_connected": True,
+                "telemetry_age_seconds": "not-a-number",
+            },
+        )
+    )
+    negative = assess_event(
+        _event(
+            event_id="WMAF-EVT-NEG-AGE",
+            vehicle_state={
+                "telemetry_connected": True,
+                "telemetry_age_seconds": -1,
+            },
+        )
+    )
+
+    assert malformed.disposition is WmafDisposition.FLAG
+    assert "TELEMETRY_AGE_INVALID" in malformed.risk_flags
+    assert negative.disposition is WmafDisposition.FLAG
+    assert "TELEMETRY_AGE_INVALID" in negative.risk_flags
+
+
+def test_denied_vehicle_control_action_is_denied_but_never_executed():
+    event = _event(
+        requested_action=AutonomousActionCandidate(
+            action_id="ACT-STEER",
+            action_type="steering",
+            confidence=1.0,
+            requested_authority=0,
+            reversible=True,
+        )
+    )
+    assessment = assess_event(event)
+
+    assert assessment.action_disposition is ExecutionDisposition.DENIED
+    assert assessment.disposition is WmafDisposition.DENY
+    assert assessment.execution_performed is False
+
+
+def test_non_allowlisted_action_requires_human_review():
+    event = _event(
+        requested_action=AutonomousActionCandidate(
+            action_id="ACT-UNKNOWN",
+            action_type="modify_route_plan",
+            confidence=1.0,
+            requested_authority=0,
+            reversible=True,
+        )
+    )
+    assessment = assess_event(event)
+
+    assert assessment.action_disposition is ExecutionDisposition.HUMAN_REVIEW_REQUIRED
+    assert assessment.disposition is WmafDisposition.ESCALATE
+    assert assessment.execution_performed is False
+
+
+def test_allowlisted_record_action_can_be_policy_eligible_but_is_not_executed():
+    event = _event(
+        requested_action=AutonomousActionCandidate(
+            action_id="ACT-RECORD",
+            action_type="record_evidence",
+            confidence=1.0,
+            requested_authority=0,
+            reversible=True,
+        )
+    )
+    assessment = assess_event(event)
+
+    assert assessment.action_disposition is ExecutionDisposition.AUTO_ELIGIBLE
+    assert assessment.disposition is WmafDisposition.OBSERVE
+    assert assessment.execution_performed is False
+    assert any("must not be interpreted as execution authority" in item for item in assessment.claims_boundary)
+
+
+def test_schema_identifier_cannot_be_overridden():
+    with pytest.raises(ValidationError):
+        _event(schema_id="WS-WMAF-EVENT-V9")
+
+
+def test_claims_boundary_explicitly_excludes_vendor_and_field_validation():
+    assessment = assess_event(_event())
+    boundary = "\n".join(assessment.claims_boundary).lower()
+
+    assert "no nxp" in boundary
+    assert "no physical or field validation" in boundary
+    assert "no steering" in boundary
+    assert "operational validation remain required" in boundary

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/wmaf.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/wmaf.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .apnt_adapter import NormalizedPntSource, SyntheticPntAdapter
+from .autonomy_policy import (
+    AutonomousActionCandidate,
+    AutonomyPolicy,
+    ExecutionDisposition,
+    evaluate_candidate,
+)
+from .qualification import canonical_digest
+
+
+class WmafDisposition(str, Enum):
+    OBSERVE = "OBSERVE"
+    FLAG = "FLAG"
+    ESCALATE = "ESCALATE"
+    DENY = "DENY"
+
+
+class MobilityAsset(BaseModel):
+    asset_id: str = Field(min_length=1)
+    asset_type: str = Field(min_length=1)
+
+
+class MobilitySource(BaseModel):
+    vendor: str = Field(min_length=1)
+    device: str = Field(min_length=1)
+    firmware: str | None = None
+    interface: str = Field(min_length=1)
+
+
+class WmafEvent(BaseModel):
+    schema_id: str = "WS-WMAF-EVENT-V0.1"
+    event_id: str = Field(min_length=1)
+    observed_utc: str = Field(min_length=1)
+    asset: MobilityAsset
+    source: MobilitySource
+    pnt_payload: dict[str, Any]
+    vehicle_state: dict[str, Any] = Field(default_factory=dict)
+    autonomy_state: dict[str, Any] = Field(default_factory=dict)
+    cyber_state: dict[str, Any] = Field(default_factory=dict)
+    requested_action: AutonomousActionCandidate | None = None
+
+
+class WmafAssessment(BaseModel):
+    schema_id: str = "WS-WMAF-ASSESSMENT-V0.1"
+    event_id: str
+    normalized_pnt: NormalizedPntSource
+    risk_flags: list[str] = Field(default_factory=list)
+    action_disposition: ExecutionDisposition | None = None
+    action_reasons: list[str] = Field(default_factory=list)
+    disposition: WmafDisposition
+    execution_performed: bool = False
+    evidence_digest: str
+    claims_boundary: list[str]
+
+
+DEFAULT_WMAF_POLICY = AutonomyPolicy(
+    policy_id="WS-WMAF-SIM-READONLY-V0.1",
+    allowed_auto_action_types=["record_evidence", "raise_alert"],
+    denied_action_types=[
+        "vehicle_control",
+        "steering",
+        "braking",
+        "throttle",
+        "route_override",
+        "actuation",
+    ],
+    minimum_auto_confidence=0.95,
+    maximum_auto_authority=0,
+    require_reversible_for_auto=True,
+)
+
+
+CLAIMS_BOUNDARY = [
+    "Synthetic/replay mobility assurance only; no physical or field validation is claimed.",
+    "No NXP, Aeva, Hyster-Yale, NVIDIA, Mobileye, Toyota, Qualcomm, or other vendor integration is implemented or validated by this module.",
+    "No ASPN, pntOS, GPNTS, production vehicle bus, or proprietary automotive interface is implemented by this module.",
+    "No steering, braking, throttle, route, flight, weapons, or other actuation command is executed.",
+    "AUTO_ELIGIBLE is a policy-evaluation result only and must not be interpreted as execution authority or evidence that an action occurred.",
+    "External, partner, laboratory, hardware, safety, cybersecurity, regulatory, and operational validation remain required.",
+]
+
+
+def _risk_flags(event: WmafEvent, pnt: NormalizedPntSource) -> list[str]:
+    flags: list[str] = []
+    health = pnt.health.strip().lower()
+
+    if pnt.confidence < 0.75 or health not in {"nominal", "healthy", "ok"}:
+        flags.append("PNT_DEGRADED")
+
+    if bool(event.vehicle_state.get("contradictory_state", False)):
+        flags.append("CONTRADICTORY_VEHICLE_STATE")
+
+    if event.cyber_state.get("software_version_authorized") is False:
+        flags.append("UNAUTHORIZED_SOFTWARE_VERSION")
+
+    if event.vehicle_state.get("telemetry_connected") is False:
+        flags.append("TELEMETRY_LOSS")
+    else:
+        telemetry_age = event.vehicle_state.get("telemetry_age_seconds")
+        if telemetry_age is not None and float(telemetry_age) > 5.0:
+            flags.append("TELEMETRY_STALE")
+
+    return flags
+
+
+def _overall_disposition(
+    *,
+    risk_flags: list[str],
+    action_disposition: ExecutionDisposition | None,
+) -> WmafDisposition:
+    if action_disposition is ExecutionDisposition.DENIED:
+        return WmafDisposition.DENY
+
+    critical_flags = {
+        "CONTRADICTORY_VEHICLE_STATE",
+        "UNAUTHORIZED_SOFTWARE_VERSION",
+    }
+    if critical_flags.intersection(risk_flags):
+        return WmafDisposition.ESCALATE
+
+    if action_disposition is ExecutionDisposition.HUMAN_REVIEW_REQUIRED:
+        return WmafDisposition.ESCALATE
+
+    if risk_flags:
+        return WmafDisposition.FLAG
+
+    return WmafDisposition.OBSERVE
+
+
+def assess_event(
+    event: WmafEvent,
+    *,
+    policy: AutonomyPolicy = DEFAULT_WMAF_POLICY,
+    pnt_adapter: SyntheticPntAdapter | None = None,
+) -> WmafAssessment:
+    """Assess one synthetic/replay mobility event without executing any action.
+
+    WMAF-SIM v0.1 is intentionally a thin composition layer over the existing
+    Worldshepherd APNT normalization and autonomy-policy primitives. It does not
+    open a vehicle interface, contact a vendor system, or perform actuation.
+    """
+
+    adapter = pnt_adapter or SyntheticPntAdapter()
+    normalized_pnt = adapter.normalize(event.pnt_payload)
+    flags = _risk_flags(event, normalized_pnt)
+
+    action_disposition: ExecutionDisposition | None = None
+    action_reasons: list[str] = []
+    if event.requested_action is not None:
+        action_disposition, action_reasons = evaluate_candidate(
+            event.requested_action,
+            policy,
+        )
+
+    disposition = _overall_disposition(
+        risk_flags=flags,
+        action_disposition=action_disposition,
+    )
+
+    digest_body = {
+        "schema_id": "WS-WMAF-ASSESSMENT-V0.1",
+        "event": event.model_dump(mode="json"),
+        "normalized_pnt": normalized_pnt.model_dump(mode="json"),
+        "risk_flags": flags,
+        "action_disposition": action_disposition.value if action_disposition else None,
+        "action_reasons": action_reasons,
+        "disposition": disposition.value,
+        "execution_performed": False,
+        "claims_boundary": CLAIMS_BOUNDARY,
+    }
+
+    return WmafAssessment(
+        event_id=event.event_id,
+        normalized_pnt=normalized_pnt,
+        risk_flags=flags,
+        action_disposition=action_disposition,
+        action_reasons=action_reasons,
+        disposition=disposition,
+        execution_performed=False,
+        evidence_digest=canonical_digest(digest_body),
+        claims_boundary=list(CLAIMS_BOUNDARY),
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/wmaf.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/wmaf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -35,7 +35,7 @@ class MobilitySource(BaseModel):
 
 
 class WmafEvent(BaseModel):
-    schema_id: str = "WS-WMAF-EVENT-V0.1"
+    schema_id: Literal["WS-WMAF-EVENT-V0.1"] = "WS-WMAF-EVENT-V0.1"
     event_id: str = Field(min_length=1)
     observed_utc: str = Field(min_length=1)
     asset: MobilityAsset
@@ -48,7 +48,7 @@ class WmafEvent(BaseModel):
 
 
 class WmafAssessment(BaseModel):
-    schema_id: str = "WS-WMAF-ASSESSMENT-V0.1"
+    schema_id: Literal["WS-WMAF-ASSESSMENT-V0.1"] = "WS-WMAF-ASSESSMENT-V0.1"
     event_id: str
     normalized_pnt: NormalizedPntSource
     risk_flags: list[str] = Field(default_factory=list)
@@ -104,8 +104,16 @@ def _risk_flags(event: WmafEvent, pnt: NormalizedPntSource) -> list[str]:
         flags.append("TELEMETRY_LOSS")
     else:
         telemetry_age = event.vehicle_state.get("telemetry_age_seconds")
-        if telemetry_age is not None and float(telemetry_age) > 5.0:
-            flags.append("TELEMETRY_STALE")
+        if telemetry_age is not None:
+            try:
+                age_seconds = float(telemetry_age)
+            except (TypeError, ValueError):
+                flags.append("TELEMETRY_AGE_INVALID")
+            else:
+                if age_seconds < 0.0:
+                    flags.append("TELEMETRY_AGE_INVALID")
+                elif age_seconds > 5.0:
+                    flags.append("TELEMETRY_STALE")
 
     return flags
 
@@ -137,7 +145,7 @@ def _overall_disposition(
 def assess_event(
     event: WmafEvent,
     *,
-    policy: AutonomyPolicy = DEFAULT_WMAF_POLICY,
+    policy: AutonomyPolicy | None = None,
     pnt_adapter: SyntheticPntAdapter | None = None,
 ) -> WmafAssessment:
     """Assess one synthetic/replay mobility event without executing any action.
@@ -148,6 +156,7 @@ def assess_event(
     """
 
     adapter = pnt_adapter or SyntheticPntAdapter()
+    effective_policy = policy or DEFAULT_WMAF_POLICY
     normalized_pnt = adapter.normalize(event.pnt_payload)
     flags = _risk_flags(event, normalized_pnt)
 
@@ -156,7 +165,7 @@ def assess_event(
     if event.requested_action is not None:
         action_disposition, action_reasons = evaluate_candidate(
             event.requested_action,
-            policy,
+            effective_policy,
         )
 
     disposition = _overall_disposition(


### PR DESCRIPTION
## Audit result

This increment follows an audit of the DRIV-derived mobility plan against current `main` and the repository claims-control doctrine.

The audit found that a new parallel assurance framework would duplicate existing SARA capabilities. Current `main` already contains APNT normalization/contracts, bounded autonomy policy, sensor-fusion evidence, HMAA assurance/attestation, qualification/evidence primitives, PRE, and partner-screening machinery.

WMAF-SIM v0.1 therefore adds only a thin synthetic/replay mobility composition layer.

## Scope

- Add `worldshepherd_sara/wmaf.py`.
- Reuse `SyntheticPntAdapter` for PNT normalization.
- Reuse `AutonomyPolicy` / `evaluate_candidate` for bounded policy evaluation.
- Reuse `canonical_digest` for deterministic evidence binding.
- Classify mobility observations as `OBSERVE`, `FLAG`, `ESCALATE`, or `DENY`.
- Detect PNT degradation, contradictory vehicle state, unauthorized software versions, telemetry loss/staleness, and malformed/negative telemetry age.
- Hard-deny vehicle-control, steering, braking, throttle, route-override, and actuation action types under the default WMAF policy.
- Keep `execution_performed=false` in every assessment, including when a non-actuating action is policy-eligible.
- Add 11 targeted tests and an explicit WMAF-SIM claims/control boundary.

## Claims boundary

This PR is software/simulation work only. It does not claim or implement:

- physical, road, warehouse, fleet, or field validation;
- production CAN/CAN-FD/Automotive Ethernet or proprietary vehicle integration;
- ASPN, pntOS, GPNTS, or government-interface integration;
- NXP, Aeva, Hyster-Yale, NVIDIA, Mobileye, Toyota, Qualcomm, or other partner/vendor integration;
- ISO 26262, ISO/SAE 21434, UNECE R155/R156, or ISO 3691-4 conformity/certification;
- steering, braking, throttle, routing, flight, weapons, or any other actuation;
- partner interest, endorsement, validation, supplier approval, or operational authority.

`AUTO_ELIGIBLE` remains a policy-evaluation result only and never means an action was executed.

## Review gate

Keep this PR in draft until:

1. protected SARA CI is green;
2. CodeQL/security checks are green where configured;
3. WMAF tests are reviewed;
4. the diff is confirmed to add no network/write/control path; and
5. human review approves any promotion or merge.
