### PR TITLE
PRE: ingest DARPA Release 6 AI, propulsion, and RF demand

### DIFF
--- a/docs/PRE_DARPA_RELEASE6_2026-09-07.md
+++ b/docs/PRE_DARPA_RELEASE6_2026-09-07.md
@@ -2,13 +2,17 @@
 
 Claims-controlled capture ingest from official DARPA topic pages. Prediction/preparation does not upgrade Worldshepherd capability maturity.
 
+## SOURCE STATUS — OFFICIAL DATE CONFLICT
+DARPA's official Release-6 topic/program pages and official opportunity-index pages currently disagree on several deadlines. For DPA26BZ06-DV026 and DPA26BZ06-DV023, the program/topic pages show 2026-10-21, while the official opportunity pages show 2026-10-23. DARPA's aggregate SBIR/STTR topic page also lists 2026-10-21 for several Release-6 topics. Treat these records as CONFLICTING_SOURCES for proposal-freeze timing and verify the controlling DSIP/BAA deadline before submission. Do not silently choose the later date.
+
 ## PRE-RD-2026-0062 — Influence Benchmarks for AI Systems
 - Demand: CONFIRMED_DEMAND
 - Topic: DPA26BZ06-DV026
 - Official source: https://www.darpa.mil/research/programs/influence-benchmarks-ai-systems
+- Secondary official opportunity page: https://www.darpa.mil/work-with-us/opportunities/dpa26bz06-dv026
 - Publication: 2026-09-02
 - Opens: 2026-09-23
-- Closes: 2026-10-21
+- Deadline status: CONFLICTING_OFFICIAL — topic page 2026-10-21; opportunity page 2026-10-23; DSIP/BAA controlling freeze check required.
 - Requirement signal: multi-agent market/auction sandbox; dynamic information feed; behavioral classifiers; comparison of human-like and AI-agent behavior; collaboration/deception analysis; quantitative metrics; government-deliverable software/data.
 - Recurrence: HIGH across trusted AI, autonomy assurance, human-machine teaming, agent evaluation and C2 decision support.
 - Horizon: 0-90D / 3-12M
@@ -25,7 +29,7 @@ Claims-controlled capture ingest from official DARPA topic pages. Prediction/pre
 - Official source: https://www.darpa.mil/research/programs/fuel-flexible-spacecraft-electric-propulsion-system
 - Publication: 2026-09-02
 - Opens: 2026-09-23
-- Closes: 2026-10-23
+- Deadline status: topic page currently 2026-10-23; aggregate Release-6 topic page shows 2026-10-21. Treat as CONFLICTING_OFFICIAL pending DSIP/BAA freeze check.
 - Requirement signal: integrated electric propulsion operating on air, water and mixed molecular propellants with >30% electrical efficiency, long-duration vacuum evidence, shared componentry, standard spacecraft bus interface and qualification testing.
 - Current-cycle gate: Direct-to-Phase-II STTR; requires prior >30% anode efficiency on air or water plus >100 cumulative operating hours on one article, with calibrated in-situ vacuum thrust-stand evidence at <3e-5 Torr during full-power operation.
 - Horizon: 3-12M / 12-24M_PLUS
@@ -40,9 +44,10 @@ Claims-controlled capture ingest from official DARPA topic pages. Prediction/pre
 - Demand: CONFIRMED_DEMAND
 - Topic: DPA26BZ06-DV023
 - Official source: https://www.darpa.mil/research/programs/novel-radio-frequency-sensing-technologies
+- Secondary official opportunity page: https://www.darpa.mil/work-with-us/opportunities/dpa26bz06-dv023
 - Publication: 2026-09-02
 - Opens: 2026-09-23
-- Closes: 2026-10-21
+- Deadline status: CONFLICTING_OFFICIAL — topic page 2026-10-21; opportunity page 2026-10-23; DSIP/BAA controlling freeze check required.
 - Requirement signal: high-altitude/high-speed airborne geologic RF sensing; 3D subsurface tomography; high-power RF; FPGA edge processing; RF shielding/EMC; flight safety/readiness; critical-minerals discovery.
 - Current-cycle gate: Direct-to-Phase-II SBIR; requires prior physically integrated and validated airborne subsurface-radar/similar system. Modeling/simulation alone is explicitly insufficient.
 - Horizon: 3-12M / 12-24M_PLUS
@@ -53,10 +58,45 @@ Claims-controlled capture ingest from official DARPA topic pages. Prediction/pre
 - Prime/partner: PARTNER ONLY today.
 - BAE configurations: strong later sensor/platform-integration or co-development path; no current BAE interest/adoption is claimed.
 
+## PRE-RD-2026-0065 — Casualty Operations & Resource Prediction Software (CORPS)
+- Demand: CONFIRMED_DEMAND
+- Topic: DPA26BZ06-DV027
+- Official source: https://www.darpa.mil/research/programs/corps
+- Official opportunity page: https://www.darpa.mil/work-with-us/opportunities/dpa26bz06-dv027
+- Publication: 2026-09-02
+- Opens: 2026-09-23
+- Deadline status: program/opportunity pages show 2026-10-23 while aggregate Release-6 topic page shows 2026-10-21; treat as CONFLICTING_OFFICIAL pending DSIP/BAA freeze check.
+- Requirement signal: casualty/patient-stream prediction, medical-resource needs, metrics-based COA evaluation, sparse/low-quality data, DDIL operation, civilian-network and DoD-planning-tool integration, uncertainty quantification and decision support.
+- Current-cycle gate: Direct-to-Phase-II SBIR; offeror must document Phase-I-like feasibility/proof-of-concept and preliminary supporting data. Phase II expects at least four progressively mature prototypes and operationally relevant tabletop/user evaluations.
+- Recurrence: HIGH across contested logistics, DDIL C2, predictive decision support, human-machine teaming and digital-twin/operational-modeling lanes.
+- Horizon: 0-90D / 3-12M
+- Existing Worldshepherd capability: DDIL transport/fault campaigns, provenance, bounded decision workflows, C2-style orchestration and synthetic evaluation — INTERNAL SOFTWARE ONLY where retained.
+- Missing: validated casualty/medical models, medically governed data, clinical/operational ground truth, medical SME ownership, representative tabletop-user validation, cybersecurity/ATO pathway and demonstrated DoD-planning-tool interoperability.
+- Build now: generic sparse-data COA decision benchmark with uncertainty propagation, stale/conflicting-input handling, provenance-preserving recommendation rationale and safe abstention. Keep all casualty/medical model claims NOT CURRENTLY CLAIMED unless supplied by a qualified partner.
+- Evidence target: prediction calibration, uncertainty coverage, COA ranking stability under missing data, latency, provenance completeness, operator override/abstention, DDIL degradation/rejoin behavior and independent scenario replay.
+- Prime/partner: PARTNER or software-prime only with a qualified medical-model/clinical-operations team and defensible Phase-I-like feasibility evidence.
+- BAE configurations: BAE-led C5ISR/mission-engineering integration plus Worldshepherd decision-assurance layer is strategically strong for later phases; no bilateral interest is claimed.
+
+## PRE-RD-2026-0066 — QBI Independent Verification & Validation
+- Demand: CONFIRMED_DEMAND / STRATEGIC PARTNER ROUTE
+- Opportunity: DARPA-PA-26-02-01
+- Official source: https://www.darpa.mil/work-with-us/opportunities/darpa-pa-26-02-01
+- Program context: https://www.darpa.mil/research/programs/quantum-benchmarking-initiative
+- Requirement signal: independent infrastructure, equipment and expertise for verification and validation of utility-scale quantum-computing approaches.
+- Deadline status: CONFLICTING_OFFICIAL — some DARPA opportunity/program pages show 2026-10-15 while other current DARPA program/office listings show 2026-12-30. Controlling solicitation must be checked before any submission decision.
+- Horizon: 0-90D / 3-12M
+- Existing Worldshepherd capability: quantum evidence-governance contracts, provider-neutral evidence intake, reproducibility controls and bounded QPU-access preparation — INTERNAL SOFTWARE/PROCESS EVIDENCE ONLY.
+- Missing: recognized independent IV&V standing, quantum-hardware metrology infrastructure, independent lab personnel, conflict-of-interest review, government-acceptable verification methods and externally reproduced results.
+- Build now: provider-neutral quantum IV&V evidence schema, cross-provider reproducibility protocol, cost-vs-computational-value evidence model, and OCI disclosure checklist.
+- Evidence target: exact configuration custody, raw-result hashes, calibration lineage, statistical reproduction, cross-provider comparison, uncertainty, negative/null result retention and independent reviewer identity.
+- Prime/partner: PARTNER ONLY today; strongest route is joining a recognized quantum metrology/verification institution rather than claiming independent-validator status.
+- BAE configurations: low-to-moderate direct fit versus national-lab/university/metrology partners; BAE should not be forced into this lane unless a genuine quantum IV&V role emerges.
+
 ## Cross-topic forecast
-WORLDSHEPHERD_FORECAST: Government demand is converging on testable software/hardware systems that retain configuration, behavior, uncertainty and human-decision provenance across dynamic/adversarial environments. Worldshepherd should prioritize reusable qualification harnesses that can attach to AI-agent, propulsion and RF campaigns without inheriting physical maturity.
+WORLDSHEPHERD_FORECAST: Government demand is converging on testable software/hardware systems that retain configuration, behavior, uncertainty and human-decision provenance across dynamic/adversarial environments. Worldshepherd should prioritize reusable qualification harnesses that can attach to AI-agent, contested-logistics, quantum, propulsion and RF campaigns without inheriting physical or domain maturity.
 
 ## Claims boundary
-- Internal CI/software evidence is not DARPA acceptance, BAE validation, CMMC/NIST conformity, clearance, platform integration, physical performance, flight evidence or operational effectiveness.
-- DP2/STTR physical gates cannot be self-closed by simulation or documentation.
+- Internal CI/software evidence is not DARPA acceptance, BAE validation, CMMC/NIST conformity, clearance, platform integration, physical performance, flight evidence, medical validation, quantum IV&V standing or operational effectiveness.
+- DP2/STTR physical/domain gates cannot be self-closed by simulation or documentation.
+- Official-source deadline conflicts are retained until the controlling solicitation/DSIP record resolves them.
 - BAE teaming scores are planning aids, not evidence of bilateral interest or partnership.

--- a/docs/PRE_DARPA_RELEASE6_2026-09-07.md
+++ b/docs/PRE_DARPA_RELEASE6_2026-09-07.md
@@ -100,3 +100,35 @@ WORLDSHEPHERD_FORECAST: Government demand is converging on testable software/har
 - DP2/STTR physical/domain gates cannot be self-closed by simulation or documentation.
 - Official-source deadline conflicts are retained until the controlling solicitation/DSIP record resolves them.
 - BAE teaming scores are planning aids, not evidence of bilateral interest or partnership.
+
+
+## PRE-RD-2026-0068 — CHIPS Quantum Manufacturing Awards
+- Demand: EMERGING_DEMAND / VALIDATION_AND_SUPPLY_CHAIN_SIGNAL
+- Official sources: https://www.nist.gov/news-events/news/2026/09/department-commerce-announces-finalization-chips-rd-award-quantinuum ; https://www.nist.gov/news-events/news/2026/09/department-commerce-announces-finalization-chips-rd-award-rigetti
+- Released: 2026-09-08
+- Funding status: two finalized CHIPS R&D awards, each up to $100 million; these are not open Worldshepherd solicitations.
+- Requirement signal: trapped-ion scaling requires low-loss integrated photonics, cryogenic-specialized semiconductors and reliable optical components at critical wavelengths; superconducting scaling requires readout electronics, cryostat architectures and fabrication for high-connectivity chip architectures.
+- Recurrence: HIGH across quantum manufacturing, metrology, configuration custody, component qualification, supply-chain provenance and independent verification.
+- Horizon: 3-12M / 12-24M_PLUS
+- Existing Worldshepherd capability: provider-neutral quantum evidence contracts, configuration/provenance concepts and QPU-access preparation — INTERNAL SOFTWARE/PROCESS EVIDENCE ONLY where retained.
+- Missing: semiconductor/photonic fabrication, cryogenic test infrastructure, device metrology, component qualification, recognized independent-validator standing, Quantinuum/Rigetti/Commerce acceptance and any verified partner relationship.
+- Build now: extend the quantum IV&V evidence schema to distinguish architecture-specific physical stacks while preserving a common evidence core: device/wafer/lot identity, fabrication route, cryogenic configuration, optical/readout chain, calibration lineage, raw-result custody, error budget, yield/reliability and independent reproduction.
+- Cheapest useful falsification test: run the same provider-neutral evidence package against one public trapped-ion benchmark dataset and one public superconducting benchmark dataset; measure which fields remain genuinely common and which require architecture-specific extensions.
+- Prime/partner: PARTNER/VALIDATION-INFRASTRUCTURE only; no direct award route or recipient interest is claimed.
+
+## PRE-RD-2026-0069 — NIST IR 8615 Secure-Hardware Assurance Convergence
+- Demand: EMERGING_DEMAND / STANDARD
+- Official source: https://www.nist.gov/news-events/news/2026/09/workshop-report-rolling-next-generation-secure-hardware-standards-nist-ir
+- Released: 2026-09-01
+- Requirement signal: lifecycle-wide hardware security using interoperable trust models, tiered assurance, cryptographic identities, SBOMs, attestation, verification, provenance/traceability, resilient evaluation, formal methods and fuzzing.
+- Recurrence: HIGH across BAE supplier readiness, defense software/hardware supply chains, AI hardware, chiplets, quantum hardware and Sentinel digital infrastructure.
+- Horizon: 0-90D / 3-12M / 12-24M_PLUS
+- Current Worldshepherd capability: software-side provenance, audit, claims-control and synthetic integrity tests where retained; not hardware-rooted attestation, semiconductor traceability, conformity, certification or NIST acceptance.
+- Build now: add a hardware-assurance evidence profile linking component identity, firmware/SBOM, build/fabrication lot, attestation evidence, vulnerability state, configuration changes, incident response and end-of-life custody.
+- Evidence target: tamper-evident lifecycle lineage, negative/adversarial tests, rollback resistance, dependency disclosure, reproducible verification and independent review.
+- BAE/Sentinel relevance: strengthens the supplier-readiness and governed-infrastructure proposition, but does not establish BAE acceptance, DFARS/CMMC conformity, facility clearance or operational deployment.
+- Cheapest useful falsification test: attempt to represent a synthetic component swap, vulnerable firmware rollback and missing provenance event; the profile must fail closed without converting synthetic evidence into an external compliance claim.
+
+## 2026-09-08 intake boundary
+- A WEF Strategic Intelligence newsletter highlighted accelerated glacier loss and downstream water-security risk. Treat as DISCOVERY_ONLY until underlying WMO/ICIMOD primary sources are independently ingested; no funding, endorsement, partnership or validated Worldshepherd climate capability is inferred.
+- AARO's official UAP Records page showed no content newer than 2026-07-08 at this check. No new UAP technical release was promoted.

--- a/docs/PRE_DARPA_RELEASE6_2026-09-07.md
+++ b/docs/PRE_DARPA_RELEASE6_2026-09-07.md
@@ -1,0 +1,62 @@
+# PRE DARPA Release 6 — 2026-09-07
+
+Claims-controlled capture ingest from official DARPA topic pages. Prediction/preparation does not upgrade Worldshepherd capability maturity.
+
+## PRE-RD-2026-0062 — Influence Benchmarks for AI Systems
+- Demand: CONFIRMED_DEMAND
+- Topic: DPA26BZ06-DV026
+- Official source: https://www.darpa.mil/research/programs/influence-benchmarks-ai-systems
+- Publication: 2026-09-02
+- Opens: 2026-09-23
+- Closes: 2026-10-21
+- Requirement signal: multi-agent market/auction sandbox; dynamic information feed; behavioral classifiers; comparison of human-like and AI-agent behavior; collaboration/deception analysis; quantitative metrics; government-deliverable software/data.
+- Recurrence: HIGH across trusted AI, autonomy assurance, human-machine teaming, agent evaluation and C2 decision support.
+- Horizon: 0-90D / 3-12M
+- Existing Worldshepherd capability: bounded workflow/orchestration, authorization, provenance, replay and synthetic evaluation patterns — INTERNAL SOFTWARE ONLY where repository evidence exists.
+- Missing: validated economic-market simulator; behavioral ground truth; human-comparison dataset; demonstrated classifier performance; ten-LLM reference-agent suite; DARPA acceptance.
+- Build now: governed multi-agent influence benchmark harness with frozen market mechanics, dynamic news events, behavior/strategy provenance, human-approval gates, deception/collaboration metrics and reproducible replay.
+- Evidence target: determinism/replay; allocative-efficiency baseline; classifier accuracy/calibration; response-to-news deltas; strategy diversity; deception/collaboration measures; provenance completeness; safe abstention/error handling.
+- Prime/partner: POTENTIAL SOFTWARE PRIME if SBIR eligibility and staffing are verified; otherwise partner.
+- BAE configurations: strongest = co-development/IR&D or Worldshepherd insertion into BAE trusted-AI / mission-engineering environments; no BAE partnership or interest is claimed.
+
+## PRE-RD-2026-0063 — Fuel-Flexible Spacecraft Electric Propulsion
+- Demand: CONFIRMED_DEMAND
+- Topic: DPA26TZ06-DV005
+- Official source: https://www.darpa.mil/research/programs/fuel-flexible-spacecraft-electric-propulsion-system
+- Publication: 2026-09-02
+- Opens: 2026-09-23
+- Closes: 2026-10-23
+- Requirement signal: integrated electric propulsion operating on air, water and mixed molecular propellants with >30% electrical efficiency, long-duration vacuum evidence, shared componentry, standard spacecraft bus interface and qualification testing.
+- Current-cycle gate: Direct-to-Phase-II STTR; requires prior >30% anode efficiency on air or water plus >100 cumulative operating hours on one article, with calibrated in-situ vacuum thrust-stand evidence at <3e-5 Torr during full-power operation.
+- Horizon: 3-12M / 12-24M_PLUS
+- Existing Worldshepherd capability: software evidence governance / test provenance only.
+- Missing: qualifying thruster hardware, calibrated thrust-stand campaign, durability data, vacuum facility access, STTR research-institution team, flight/qualification evidence.
+- Build now: propulsion test-evidence schema and bus-control/provenance adapter only; do not claim propulsion performance.
+- Evidence target: thrust, mass flow, power, efficiency, duration, pressure, calibration, uncertainty and configuration lineage from a qualified partner.
+- Prime/partner: PARTNER ONLY today.
+- BAE configurations: later spacecraft/power/integration insertion or co-development could be useful, but BAE cannot substitute for the required STTR small-business/research-institution structure or missing physical evidence.
+
+## PRE-RD-2026-0064 — Novel Radio Frequency Sensing Technologies
+- Demand: CONFIRMED_DEMAND
+- Topic: DPA26BZ06-DV023
+- Official source: https://www.darpa.mil/research/programs/novel-radio-frequency-sensing-technologies
+- Publication: 2026-09-02
+- Opens: 2026-09-23
+- Closes: 2026-10-21
+- Requirement signal: high-altitude/high-speed airborne geologic RF sensing; 3D subsurface tomography; high-power RF; FPGA edge processing; RF shielding/EMC; flight safety/readiness; critical-minerals discovery.
+- Current-cycle gate: Direct-to-Phase-II SBIR; requires prior physically integrated and validated airborne subsurface-radar/similar system. Modeling/simulation alone is explicitly insufficient.
+- Horizon: 3-12M / 12-24M_PLUS
+- Existing Worldshepherd capability: RF synthetic discrepancy accounting, evidence/provenance patterns and programmable-boundary simulation only where retained.
+- Missing: airborne radar hardware, empirical flight data, receiver characterization, high-power RF chain, antenna/aerostructure, FPGA implementation, EMC/flight-clearance evidence.
+- Build now: generic RF simulation-to-flight evidence contract; high-power-RF safety/EMC evidence schema; edge-tomography benchmark using public/synthetic data.
+- Evidence target: empirical tomogram quality, SNR, receiver noise floor, flight condition, radiated power, penetration, FPGA latency/resource use, EMC and calibration provenance.
+- Prime/partner: PARTNER ONLY today.
+- BAE configurations: strong later sensor/platform-integration or co-development path; no current BAE interest/adoption is claimed.
+
+## Cross-topic forecast
+WORLDSHEPHERD_FORECAST: Government demand is converging on testable software/hardware systems that retain configuration, behavior, uncertainty and human-decision provenance across dynamic/adversarial environments. Worldshepherd should prioritize reusable qualification harnesses that can attach to AI-agent, propulsion and RF campaigns without inheriting physical maturity.
+
+## Claims boundary
+- Internal CI/software evidence is not DARPA acceptance, BAE validation, CMMC/NIST conformity, clearance, platform integration, physical performance, flight evidence or operational effectiveness.
+- DP2/STTR physical gates cannot be self-closed by simulation or documentation.
+- BAE teaming scores are planning aids, not evidence of bilateral interest or partnership.

--- a/docs/PRE_DOE_ASPECT_2026-09-07.md
+++ b/docs/PRE_DOE_ASPECT_2026-09-07.md
@@ -1,0 +1,30 @@
+# PRE DOE ASPECT — 2026-09-07
+
+Claims-controlled Requirement Delta Record derived from official U.S. Department of Energy sources. Prediction/preparation does not upgrade Worldshepherd capability maturity.
+
+## PRE-RD-2026-0067 — Accelerating Scale-up and Pre-piloting of Emerging Chemical Technologies (ASPECT)
+- Demand: CONFIRMED_DEMAND
+- Agency: U.S. Department of Energy, Alternative Fuels and Feedstocks Office
+- Funding opportunity: DE-FOA-0003647
+- Official source: https://www.energy.gov/cmei/fuels/funding-notice-accelerating-scale-and-pre-piloting-emerging-chemical-technologies-aspect
+- Released: 2026-09-04
+- Funding ceiling/program amount: up to $58,000,000 total program funding; project-specific limits must be taken from the controlling FOA.
+- Concept paper deadline: 2026-10-09 17:00 ET; concept paper is required to remain eligible for Stage 1 full application.
+- Stage 1 deadline: 2026-12-01.
+- Stage 2 deadline: 2027-02-12.
+- Requirement signal: design, construction and operation of pre-pilot chemical-process facilities using domestically sourced alternative/waste feedstocks; unit-operation pre-piloting; pre-pilot system integration; scale-up and commercialization evidence.
+- Recurrence: HIGH across advanced manufacturing, industrial-base scale-up, critical-materials processing, qualification, digital-thread and transition-to-production programs.
+- Horizon: 0-90D / 3-12M / 12-24M_PLUS.
+- Existing Worldshepherd capability: manufacturing lineage, configuration/evidence custody, digital-thread patterns and machine-readable qualification evidence — INTERNAL SOFTWARE/CI ONLY where retained.
+- Missing: qualifying chemical-process technology, feedstock/process chemistry evidence, pre-pilot hardware/facility, process-safety/environmental evidence, techno-economic validation, commercialization partner and DOE-acceptable scale-up data.
+- Build now: generic pre-pilot manufacturing evidence package linking feedstock lot, process configuration, unit operation, instrumentation/calibration, mass/energy-balance evidence, deviations, product-quality results, uncertainty and versioned configuration identity.
+- Evidence target: complete material/process genealogy, reproducible configuration, calibrated measurements, mass/energy balance closure, scale-up discrepancy accounting, failure/deviation retention, product-quality traceability and transition-readiness package.
+- Prime/partner: PARTNER/SUBCONTRACTOR today unless paired with an eligible process-technology owner capable of leading the chemical-process scope.
+- BAE configurations: limited direct capture value. A downstream defense-material qualification or supply-chain provenance insertion could become relevant if the process produces defense-relevant materials, but no BAE interest or role is assumed.
+
+## Forward-looking forecast
+WORLDSHEPHERD_FORECAST: DOE and defense industrial-base programs are converging on transition evidence that survives the move from lab formulation or simulation into pre-pilot/pilot production. Worldshepherd should treat production provenance, calibrated process evidence, machine-readable qualification records and simulation-to-process discrepancy accounting as reusable infrastructure across DOE critical-materials, DIBC, NAVAIR manufacturing/digital-engineering and future prime-led industrial-base programs.
+
+## Claims boundary
+- This record does not establish Worldshepherd chemical-process capability, DOE eligibility, award probability, pre-pilot facility access, process safety, environmental compliance, commercialization readiness, BAE interest or DOE acceptance.
+- Internal software/CI evidence cannot substitute for physical process data, facility evidence, partner validation or regulatory review.


### PR DESCRIPTION
Adds claims-controlled PRE Requirement Delta Records for three material DARPA Release 6 signals identified on 2026-09-07:

- DPA26BZ06-DV026 Influence Benchmarks for AI Systems — potential software-prime path, subject to SBIR eligibility and actual benchmark capability;
- DPA26TZ06-DV005 Fuel-Flexible Spacecraft Electric Propulsion — partner-only today because the Direct-to-Phase-II STTR requires prior calibrated vacuum-thrust and durability evidence;
- DPA26BZ06-DV023 Novel Radio Frequency Sensing Technologies — partner-only today because DARPA explicitly requires prior physical airborne sensing validation and states simulation alone is insufficient.

The records include horizons, gaps, experiment/evidence targets, and bounded BAE teaming configurations. No proposal submission, outreach, partnership claim, physical-performance claim, compliance claim, or maturity promotion is made.