### PR TITLE
WS-QE-2026-EMB-002: programmable boundary robustness falsification gate

### DIFF
--- a/deployments/sara_verified_local_v1/docs/WS_QE_2026_EMB_002.md
+++ b/deployments/sara_verified_local_v1/docs/WS_QE_2026_EMB_002.md
@@ -1,0 +1,75 @@
+# WS-QE-2026-EMB-002 — Programmable Boundary Robustness Falsification Gate
+
+## Purpose
+
+EMB-002 tests whether the bounded synthetic behavior observed in `WS-QE-2026-EMB-001` survives a declared parameter sweep and bounded deterministic perturbations. It is a falsification gate, not a capability-promotion exercise.
+
+The EMB-001 implementation is reused as the inner nominal model and is not modified by this experiment.
+
+## Nominal sweep
+
+The nominal sweep contains 36 cases:
+
+- tile counts: `6`, `8`, `12`
+- tile spacing: `0.25`, `0.35`, `0.50` wavelengths
+- target/preserve angle pairs:
+  - `-30 / +20` degrees
+  - `-10 / +30` degrees
+  - `+20 / -20` degrees
+  - `+40 / -10` degrees
+
+For each case, the EMB-001 benchmark is executed with the target angle also used as the generic null-test angle. A case is counted as passing only when EMB-001's pre-existing behavior gate passes **and** the passive target reference is not ratio-degenerate (`< 1e-6`). Ratio-degenerate cases remain in the denominator and are recorded as failures because arbitrarily large ratios against a near-zero reference are not reliable evidence of general improvement.
+
+## Perturbation sweep
+
+A fixed 8-tile, 0.5-wavelength, +20-degree coherent reference is subjected to deterministic hash-derived perturbations:
+
+- seeds: `7`, `19`, `43`
+- phase error bounds: `5`, `15`, `30` degrees
+- amplitude error bounds: `0.05`, `0.15`
+
+The 18 perturbed states are renormalized to the same total element-power proxy as the reference. This isolates distribution/phase sensitivity from trivial modeled-power changes.
+
+## Thermal severity sweep
+
+The same reference state is evaluated at normalized severity multipliers:
+
+- `0.25`
+- `0.50`
+- `1.00`
+- `1.50`
+
+Severity scales EMB-001's deterministic phase-edge drift and edge-amplitude derating. Thermal cases are **not** power-renormalized because modeled derating is intentionally allowed to reduce the element-power proxy.
+
+## Predeclared robustness gate
+
+`ROBUSTNESS_SUPPORTED_WITHIN_SURROGATE` is permitted only when all of the following hold:
+
+1. nominal pass fraction is at least `0.90`;
+2. ratio-degenerate fraction is no more than `0.05`;
+3. the minimum bounded perturbation target-retention fraction is at least `0.90`;
+4. thermal target retention is monotonic non-increasing as severity rises; and
+5. every bounded phase/amplitude perturbation retains equal modeled power after normalization.
+
+If any condition fails, the result is `NO_ROBUSTNESS_PROMOTION`. The thresholds are part of the experiment contract and must not be relaxed after observing the sweep merely to obtain a positive result.
+
+## Evidence custody
+
+`ws-programmable-boundary-robustness --output <path>` writes canonical JSON and prints its SHA-256 digest. `--verify <path>` reconstructs the model and validates the digest. The report includes every nominal, perturbation, and thermal case so adverse conditions cannot be silently removed from aggregate evidence.
+
+## Claims boundary
+
+This experiment remains `SIMULATED_ONLY`.
+
+It does **not** establish or model:
+
+- full-wave Maxwell behavior;
+- mutual impedance or calibrated scattering;
+- measured or qualified material properties;
+- broadband behavior or the source document's proposed spectral range;
+- laboratory or coupon validation;
+- stealth or cloaking performance;
+- flight performance; or
+- operational performance.
+
+A positive robustness result would mean only that the synthetic EMB-001 surrogate survived the declared software sweep. A negative result is retained as useful disconfirming evidence and does not reduce or erase the narrower EMB-001 result.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -34,6 +34,7 @@ ws-human-triage-ledger = "worldshepherd_sara.human_triage_cli:main"
 ws-intake-minimum-ledger = "worldshepherd_sara.intake_minimum_cli:main"
 ws-prime-basis-ablation = "worldshepherd_sara.prime_basis_ablation_cli:main"
 ws-programmable-boundary-benchmark = "worldshepherd_sara.programmable_boundary_benchmark_cli:main"
+ws-programmable-boundary-robustness = "worldshepherd_sara.programmable_boundary_robustness_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark.py
@@ -5,6 +5,9 @@ import pytest
 from worldshepherd_sara.programmable_boundary_benchmark import (
     BoundaryControlMode,
     ProgrammableBoundaryBenchmarkReport,
+    _apply_thermal_drift,
+    _at_angle,
+    _coherent_weights,
     run_programmable_boundary_benchmark,
     verify_programmable_boundary_benchmark_report,
 )
@@ -138,3 +141,23 @@ def test_invalid_geometry_and_angles_fail_closed():
         run_programmable_boundary_benchmark(tile_spacing_wavelengths=0.75)
     with pytest.raises(ValueError):
         run_programmable_boundary_benchmark(coherent_target_angle_degrees=80.0)
+
+
+def test_common_reference_preserves_amplitude_only_thermal_derating():
+    tile_count = 8
+    spacing = 0.5
+    target_angle = 20.0
+    coherent = _coherent_weights(
+        angle_degrees=target_angle,
+        tile_count=tile_count,
+        spacing=spacing,
+    )
+    amplitude_only_drift = _apply_thermal_drift(
+        coherent,
+        phase_edge_radians=0.0,
+        edge_amplitude_derating=0.25,
+    )
+    reference = _at_angle(coherent, angle=target_angle, spacing=spacing)
+    degraded = _at_angle(amplitude_only_drift, angle=target_angle, spacing=spacing)
+    assert reference == pytest.approx(1.0)
+    assert degraded < reference

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_benchmark_cli.py
@@ -34,3 +34,22 @@ def test_cli_rejects_tampered_report(tmp_path, capsys):
 
     assert main(["--verify", str(output)]) == 1
     assert capsys.readouterr().out.strip() == "INVALID"
+
+
+def test_cli_rejects_unknown_and_missing_signed_fields(tmp_path, capsys):
+    output = tmp_path / "programmable-boundary.json"
+    assert main(["--output", str(output)]) == 0
+    capsys.readouterr()
+    original = json.loads(output.read_text(encoding="utf-8"))
+
+    with_unknown = dict(original)
+    with_unknown["unsigned_extra"] = "must invalidate the raw digest"
+    output.write_text(json.dumps(with_unknown), encoding="utf-8")
+    assert main(["--verify", str(output)]) == 1
+    assert capsys.readouterr().out.strip() == "INVALID"
+
+    with_missing_default = dict(original)
+    del with_missing_default["benchmark_version"]
+    output.write_text(json.dumps(with_missing_default), encoding="utf-8")
+    assert main(["--verify", str(output)]) == 1
+    assert capsys.readouterr().out.strip() == "INVALID"

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_robustness.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_robustness.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from worldshepherd_sara.programmable_boundary_robustness import (
+    ProgrammableBoundaryRobustnessReport,
+    RobustnessOutcome,
+    run_programmable_boundary_robustness,
+    verify_programmable_boundary_robustness_report,
+)
+
+
+def test_robustness_report_is_deterministic_and_hash_bound():
+    first = run_programmable_boundary_robustness()
+    second = run_programmable_boundary_robustness()
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+    assert first.report_digest == second.report_digest
+    assert first.report_digest and first.report_digest.startswith("sha256:")
+    assert verify_programmable_boundary_robustness_report(first)
+
+
+def test_nominal_sweep_preserves_adverse_cases_and_blocks_promotion():
+    report = run_programmable_boundary_robustness()
+    summary = report.summary
+    assert summary.nominal_case_count == 36
+    assert summary.nominal_pass_count < summary.nominal_case_count
+    assert summary.nominal_pass_fraction < report.gate.minimum_nominal_pass_fraction
+    assert summary.ratio_degenerate_count > 0
+    assert summary.ratio_degenerate_fraction > report.gate.maximum_ratio_degenerate_fraction
+    assert "NOMINAL_PASS_FRACTION" in summary.failed_gate_conditions
+    assert "RATIO_DEGENERATE_FRACTION" in summary.failed_gate_conditions
+    assert summary.outcome == RobustnessOutcome.NO_ROBUSTNESS_PROMOTION
+    assert any(not case.case_passed for case in report.nominal_cases)
+    assert any(case.ratio_degenerate_reference for case in report.nominal_cases)
+    assert any("COHERENT_GAIN_THRESHOLD" in case.failure_reasons for case in report.nominal_cases)
+
+
+def test_nominal_sweep_covers_declared_geometry_envelope():
+    report = run_programmable_boundary_robustness()
+    assert {case.tile_count for case in report.nominal_cases} == {6, 8, 12}
+    assert {case.tile_spacing_wavelengths for case in report.nominal_cases} == {0.25, 0.35, 0.5}
+    assert {case.target_angle_degrees for case in report.nominal_cases} == {-30.0, -10.0, 20.0, 40.0}
+    assert all(-60.0 <= case.preserve_angle_degrees <= 60.0 for case in report.nominal_cases)
+
+
+def test_bounded_perturbations_hold_equal_power_without_erasing_failures():
+    report = run_programmable_boundary_robustness()
+    assert report.summary.perturbation_case_count == 18
+    assert all(case.equal_power_after_normalization for case in report.perturbation_cases)
+    assert all(abs(case.total_element_power_proxy - 8.0) <= 1e-10 for case in report.perturbation_cases)
+    assert report.summary.perturbation_minimum_retention_fraction >= 0.90
+    assert "PERTURBATION_RETENTION" not in report.summary.failed_gate_conditions
+
+
+def test_thermal_severity_degrades_monotonically_in_surrogate():
+    report = run_programmable_boundary_robustness()
+    assert report.summary.thermal_case_count == 4
+    retentions = [case.target_retention_fraction for case in report.thermal_cases]
+    assert retentions == sorted(retentions, reverse=True)
+    assert report.summary.thermal_retention_monotonic_nonincreasing is True
+    assert "THERMAL_MONOTONICITY" not in report.summary.failed_gate_conditions
+
+
+def test_claims_boundary_remains_simulation_only():
+    report = run_programmable_boundary_robustness()
+    payload = report.model_dump(mode="json")
+    assert payload["capability_status"] == "SIMULATED_ONLY"
+    assert payload["laboratory_validation_performed"] is False
+    assert payload["full_wave_validation_performed"] is False
+    assert payload["measured_material_properties_used"] is False
+    assert payload["broadband_validation_performed"] is False
+    assert payload["stealth_or_cloaking_validated"] is False
+    assert payload["operational_validation_performed"] is False
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "laboratory_validation_performed",
+        "full_wave_validation_performed",
+        "measured_material_properties_used",
+        "broadband_validation_performed",
+        "stealth_or_cloaking_validated",
+        "operational_validation_performed",
+    ],
+)
+def test_report_rejects_physical_or_operational_promotion_flags(field):
+    report = run_programmable_boundary_robustness()
+    payload = report.model_dump(mode="json")
+    payload[field] = True
+    with pytest.raises(ValidationError):
+        ProgrammableBoundaryRobustnessReport.model_validate(payload)
+
+
+def test_tamper_breaks_digest_verification():
+    report = run_programmable_boundary_robustness()
+    payload = report.model_dump(mode="json")
+    payload["summary"]["nominal_pass_count"] += 1
+    tampered = ProgrammableBoundaryRobustnessReport.model_validate(payload)
+    assert not verify_programmable_boundary_robustness_report(tampered)

--- a/deployments/sara_verified_local_v1/tests/test_programmable_boundary_robustness_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_programmable_boundary_robustness_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+from worldshepherd_sara.programmable_boundary_robustness_cli import main
+
+
+def test_cli_exports_and_verifies_robustness_report(tmp_path, capsys):
+    output = tmp_path / "programmable-boundary-robustness.json"
+    assert main(["--output", str(output)]) == 0
+    digest = capsys.readouterr().out.strip()
+    assert digest.startswith("sha256:")
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["qualification_id"] == "WS-QE-2026-EMB-002"
+    assert payload["capability_status"] == "SIMULATED_ONLY"
+    assert payload["summary"]["outcome"] == "NO_ROBUSTNESS_PROMOTION"
+    assert payload["summary"]["nominal_case_count"] == 36
+    assert payload["laboratory_validation_performed"] is False
+    assert payload["operational_validation_performed"] is False
+
+    assert main(["--verify", str(output)]) == 0
+    assert capsys.readouterr().out.strip() == "VALID"
+
+
+def test_cli_rejects_tampered_robustness_report(tmp_path, capsys):
+    output = tmp_path / "programmable-boundary-robustness.json"
+    assert main(["--output", str(output)]) == 0
+    capsys.readouterr()
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    payload["gate"]["minimum_nominal_pass_fraction"] = 0.50
+    output.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert main(["--verify", str(output)]) == 1
+    assert capsys.readouterr().out.strip() == "INVALID"

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark.py
@@ -238,7 +238,9 @@ def _pattern(
     angles: tuple[float, ...],
     spacing: float,
 ) -> tuple[float, ...]:
-    normalization = max(1e-15, sum(abs(weight) for weight in weights))
+    # Use the passive/equal-power aperture as the common reference. Self-normalizing
+    # each scenario would erase modeled amplitude derating from the reported field.
+    normalization = max(1e-15, float(len(weights)))
     return tuple(
         abs(
             _field(
@@ -261,7 +263,8 @@ def _at_angle(
     angle: float,
     spacing: float,
 ) -> float:
-    normalization = max(1e-15, sum(abs(weight) for weight in weights))
+    # Keep a fixed aperture reference across passive, controlled, and thermal cases.
+    normalization = max(1e-15, float(len(weights)))
     return abs(
         _field(
             weights,
@@ -485,3 +488,14 @@ def verify_programmable_boundary_benchmark_report(
 ) -> bool:
     expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
     return report.report_digest == expected
+
+
+def verify_programmable_boundary_benchmark_payload(payload: object) -> bool:
+    """Verify the exact raw JSON payload before any lossy model parsing."""
+    if not isinstance(payload, dict):
+        return False
+    unsigned_payload = dict(payload)
+    provided_digest = unsigned_payload.pop("report_digest", None)
+    return isinstance(provided_digest, str) and provided_digest == canonical_digest(
+        unsigned_payload
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_benchmark_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .programmable_boundary_benchmark import (
     ProgrammableBoundaryBenchmarkReport,
     run_programmable_boundary_benchmark,
+    verify_programmable_boundary_benchmark_payload,
     verify_programmable_boundary_benchmark_report,
 )
 
@@ -35,9 +36,14 @@ def _serialize(report: ProgrammableBoundaryBenchmarkReport) -> str:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     if args.verify is not None:
-        payload = json.loads(args.verify.read_text(encoding="utf-8"))
-        report = ProgrammableBoundaryBenchmarkReport.model_validate(payload)
-        if not verify_programmable_boundary_benchmark_report(report):
+        try:
+            payload = json.loads(args.verify.read_text(encoding="utf-8"))
+            if not verify_programmable_boundary_benchmark_payload(payload):
+                raise ValueError("raw report digest mismatch")
+            report = ProgrammableBoundaryBenchmarkReport.model_validate(payload)
+            if not verify_programmable_boundary_benchmark_report(report):
+                raise ValueError("validated report digest mismatch")
+        except (OSError, TypeError, ValueError):
             print("INVALID")
             return 1
         print("VALID")

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_robustness.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_robustness.py
@@ -298,7 +298,7 @@ def run_programmable_boundary_robustness() -> ProgrammableBoundaryRobustnessRepo
     thermal_retentions = tuple(case.target_retention_fraction for case in thermal)
     thermal_monotonic = all(
         later <= earlier + 1e-12
-        for earlier, later in zip(thermal_retentions, thermal_retentions[1:], strict=True)
+        for earlier, later in zip(thermal_retentions, thermal_retentions[1:])
     )
 
     failed: list[str] = []

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_robustness.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_robustness.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import cmath
+import hashlib
+import math
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+from .programmable_boundary_benchmark import (
+    _apply_thermal_drift,
+    _at_angle,
+    _coherent_weights,
+    _normalize_design_power,
+    _power_proxy,
+    run_programmable_boundary_benchmark,
+)
+from .qualification import CapabilityStatus, canonical_digest
+
+
+class RobustnessOutcome(str, Enum):
+    ROBUSTNESS_SUPPORTED_WITHIN_SURROGATE = "ROBUSTNESS_SUPPORTED_WITHIN_SURROGATE"
+    NO_ROBUSTNESS_PROMOTION = "NO_ROBUSTNESS_PROMOTION"
+    INCONCLUSIVE = "INCONCLUSIVE"
+
+
+class NominalRobustnessCase(BaseModel):
+    case_id: str
+    tile_count: int = Field(ge=4)
+    tile_spacing_wavelengths: float = Field(gt=0.0, le=0.5)
+    target_angle_degrees: float
+    preserve_angle_degrees: float
+    passive_reference_field: float = Field(ge=0.0)
+    coherent_gain_over_passive: float = Field(ge=0.0)
+    null_suppression_ratio_vs_passive: float = Field(ge=0.0)
+    null_preserve_fraction: float = Field(ge=0.0)
+    thermal_target_retention_fraction: float = Field(ge=0.0)
+    equal_power_design_controls: bool
+    embedded_benchmark_behavior_observed: bool
+    ratio_degenerate_reference: bool
+    case_passed: bool
+    failure_reasons: tuple[str, ...]
+
+
+class PerturbationRobustnessCase(BaseModel):
+    case_id: str
+    seed: int
+    phase_error_limit_degrees: float = Field(ge=0.0)
+    amplitude_error_fraction: float = Field(ge=0.0, lt=1.0)
+    target_retention_fraction: float = Field(ge=0.0)
+    total_element_power_proxy: float = Field(gt=0.0)
+    equal_power_after_normalization: bool
+
+
+class ThermalSeverityCase(BaseModel):
+    severity: float = Field(gt=0.0)
+    target_retention_fraction: float = Field(ge=0.0)
+    total_element_power_proxy: float = Field(gt=0.0)
+
+
+class RobustnessGate(BaseModel):
+    minimum_nominal_pass_fraction: float = 0.90
+    maximum_ratio_degenerate_fraction: float = 0.05
+    minimum_perturbation_retention_fraction: float = 0.90
+    require_monotonic_thermal_degradation: bool = True
+
+
+class RobustnessSummary(BaseModel):
+    nominal_case_count: int = Field(gt=0)
+    nominal_pass_count: int = Field(ge=0)
+    nominal_pass_fraction: float = Field(ge=0.0, le=1.0)
+    ratio_degenerate_count: int = Field(ge=0)
+    ratio_degenerate_fraction: float = Field(ge=0.0, le=1.0)
+    perturbation_case_count: int = Field(gt=0)
+    perturbation_minimum_retention_fraction: float = Field(ge=0.0)
+    thermal_case_count: int = Field(gt=0)
+    thermal_retention_monotonic_nonincreasing: bool
+    failed_gate_conditions: tuple[str, ...]
+    outcome: RobustnessOutcome
+
+
+class ProgrammableBoundaryRobustnessReport(BaseModel):
+    qualification_id: str = "WS-QE-2026-EMB-002"
+    robustness_version: str = "0.1"
+    nominal_cases: tuple[NominalRobustnessCase, ...]
+    perturbation_cases: tuple[PerturbationRobustnessCase, ...]
+    thermal_cases: tuple[ThermalSeverityCase, ...]
+    gate: RobustnessGate
+    summary: RobustnessSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    laboratory_validation_performed: bool = False
+    full_wave_validation_performed: bool = False
+    measured_material_properties_used: bool = False
+    broadband_validation_performed: bool = False
+    stealth_or_cloaking_validated: bool = False
+    operational_validation_performed: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "This robustness gate reuses the EMB-001 synthetic scalar array-factor surrogate only.",
+        "Sweep success or failure does not establish Maxwell/full-wave, measured-material, scattering, broadband, stealth, cloaking, flight, or operational performance.",
+        "Ratio-degenerate passive references are recorded as failures rather than converted into evidence of improvement.",
+        "NO_ROBUSTNESS_PROMOTION is a valid scientific outcome and must not be relaxed by changing thresholds after observation.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "ProgrammableBoundaryRobustnessReport":
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("EMB-002 must remain SIMULATED_ONLY")
+        prohibited = (
+            self.laboratory_validation_performed,
+            self.full_wave_validation_performed,
+            self.measured_material_properties_used,
+            self.broadband_validation_performed,
+            self.stealth_or_cloaking_validated,
+            self.operational_validation_performed,
+        )
+        if any(prohibited):
+            raise ValueError("EMB-002 cannot promote physical/full-wave/operational claims")
+        return self
+
+
+def _unit_interval(seed: int, tile_index: int, channel: str) -> float:
+    payload = f"{seed}:{tile_index}:{channel}".encode("utf-8")
+    raw = hashlib.sha256(payload).digest()
+    return int.from_bytes(raw[:8], "big") / float((1 << 64) - 1)
+
+
+def _perturb_equal_power(
+    weights: tuple[complex, ...],
+    *,
+    seed: int,
+    phase_error_limit_degrees: float,
+    amplitude_error_fraction: float,
+) -> tuple[complex, ...]:
+    perturbed: list[complex] = []
+    phase_limit = math.radians(phase_error_limit_degrees)
+    for index, weight in enumerate(weights):
+        phase_error = (2.0 * _unit_interval(seed, index, "phase") - 1.0) * phase_limit
+        amplitude_error = (
+            (2.0 * _unit_interval(seed, index, "amplitude") - 1.0)
+            * amplitude_error_fraction
+        )
+        perturbed.append(weight * (1.0 + amplitude_error) * cmath.exp(1j * phase_error))
+    return _normalize_design_power(tuple(perturbed), len(weights))
+
+
+def _nominal_cases() -> tuple[NominalRobustnessCase, ...]:
+    geometry_pairs = (
+        (-30.0, 20.0),
+        (-10.0, 30.0),
+        (20.0, -20.0),
+        (40.0, -10.0),
+    )
+    cases: list[NominalRobustnessCase] = []
+    for tile_count in (6, 8, 12):
+        for spacing in (0.25, 0.35, 0.50):
+            for target_angle, preserve_angle in geometry_pairs:
+                benchmark = run_programmable_boundary_benchmark(
+                    tile_count=tile_count,
+                    tile_spacing_wavelengths=spacing,
+                    coherent_target_angle_degrees=target_angle,
+                    null_angle_degrees=target_angle,
+                    preserve_angle_degrees=preserve_angle,
+                )
+                by_id = {scenario.scenario_id: scenario for scenario in benchmark.scenarios}
+                passive_reference = by_id["passive_reference"].target_normalized_field or 0.0
+                ratio_degenerate = passive_reference < 1e-6
+                summary = benchmark.summary
+                reasons: list[str] = []
+                if ratio_degenerate:
+                    reasons.append("PASSIVE_RATIO_DEGENERATE")
+                if not summary.equal_power_design_controls:
+                    reasons.append("UNEQUAL_DESIGN_POWER")
+                if summary.coherent_gain_over_passive <= 1.5:
+                    reasons.append("COHERENT_GAIN_THRESHOLD")
+                if summary.null_suppression_ratio_vs_passive >= 1e-6:
+                    reasons.append("NULL_SUPPRESSION_THRESHOLD")
+                if summary.null_preserve_fraction <= 0.75:
+                    reasons.append("PRESERVE_FRACTION_THRESHOLD")
+                if summary.thermal_target_retention_fraction >= 0.98:
+                    reasons.append("THERMAL_SENSITIVITY_THRESHOLD")
+                case_passed = summary.expected_control_behavior_observed and not ratio_degenerate
+                cases.append(
+                    NominalRobustnessCase(
+                        case_id=(
+                            f"n{tile_count}-d{spacing:.2f}-t{target_angle:+.0f}"
+                            f"-p{preserve_angle:+.0f}"
+                        ),
+                        tile_count=tile_count,
+                        tile_spacing_wavelengths=spacing,
+                        target_angle_degrees=target_angle,
+                        preserve_angle_degrees=preserve_angle,
+                        passive_reference_field=passive_reference,
+                        coherent_gain_over_passive=summary.coherent_gain_over_passive,
+                        null_suppression_ratio_vs_passive=(
+                            summary.null_suppression_ratio_vs_passive
+                        ),
+                        null_preserve_fraction=summary.null_preserve_fraction,
+                        thermal_target_retention_fraction=(
+                            summary.thermal_target_retention_fraction
+                        ),
+                        equal_power_design_controls=summary.equal_power_design_controls,
+                        embedded_benchmark_behavior_observed=(
+                            summary.expected_control_behavior_observed
+                        ),
+                        ratio_degenerate_reference=ratio_degenerate,
+                        case_passed=case_passed,
+                        failure_reasons=tuple(reasons),
+                    )
+                )
+    return tuple(cases)
+
+
+def _perturbation_cases() -> tuple[PerturbationRobustnessCase, ...]:
+    tile_count = 8
+    spacing = 0.5
+    target_angle = 20.0
+    reference = _coherent_weights(
+        angle_degrees=target_angle,
+        tile_count=tile_count,
+        spacing=spacing,
+    )
+    reference_field = _at_angle(reference, angle=target_angle, spacing=spacing)
+    cases: list[PerturbationRobustnessCase] = []
+    for seed in (7, 19, 43):
+        for phase_limit in (5.0, 15.0, 30.0):
+            for amplitude_fraction in (0.05, 0.15):
+                perturbed = _perturb_equal_power(
+                    reference,
+                    seed=seed,
+                    phase_error_limit_degrees=phase_limit,
+                    amplitude_error_fraction=amplitude_fraction,
+                )
+                power = _power_proxy(perturbed)
+                target_field = _at_angle(perturbed, angle=target_angle, spacing=spacing)
+                cases.append(
+                    PerturbationRobustnessCase(
+                        case_id=(
+                            f"seed{seed}-phase{phase_limit:.0f}"
+                            f"-amp{amplitude_fraction:.2f}"
+                        ),
+                        seed=seed,
+                        phase_error_limit_degrees=phase_limit,
+                        amplitude_error_fraction=amplitude_fraction,
+                        target_retention_fraction=(
+                            target_field / max(reference_field, 1e-15)
+                        ),
+                        total_element_power_proxy=power,
+                        equal_power_after_normalization=abs(power - tile_count) <= 1e-10,
+                    )
+                )
+    return tuple(cases)
+
+
+def _thermal_cases() -> tuple[ThermalSeverityCase, ...]:
+    tile_count = 8
+    spacing = 0.5
+    target_angle = 20.0
+    reference = _coherent_weights(
+        angle_degrees=target_angle,
+        tile_count=tile_count,
+        spacing=spacing,
+    )
+    reference_field = _at_angle(reference, angle=target_angle, spacing=spacing)
+    cases: list[ThermalSeverityCase] = []
+    for severity in (0.25, 0.50, 1.00, 1.50):
+        drifted = _apply_thermal_drift(
+            reference,
+            phase_edge_radians=0.8 * severity,
+            edge_amplitude_derating=0.12 * severity,
+        )
+        cases.append(
+            ThermalSeverityCase(
+                severity=severity,
+                target_retention_fraction=(
+                    _at_angle(drifted, angle=target_angle, spacing=spacing)
+                    / max(reference_field, 1e-15)
+                ),
+                total_element_power_proxy=_power_proxy(drifted),
+            )
+        )
+    return tuple(cases)
+
+
+def run_programmable_boundary_robustness() -> ProgrammableBoundaryRobustnessReport:
+    gate = RobustnessGate()
+    nominal = _nominal_cases()
+    perturbations = _perturbation_cases()
+    thermal = _thermal_cases()
+
+    nominal_pass_count = sum(case.case_passed for case in nominal)
+    nominal_pass_fraction = nominal_pass_count / len(nominal)
+    ratio_degenerate_count = sum(case.ratio_degenerate_reference for case in nominal)
+    ratio_degenerate_fraction = ratio_degenerate_count / len(nominal)
+    perturbation_minimum_retention = min(
+        case.target_retention_fraction for case in perturbations
+    )
+    thermal_retentions = tuple(case.target_retention_fraction for case in thermal)
+    thermal_monotonic = all(
+        later <= earlier + 1e-12
+        for earlier, later in zip(thermal_retentions, thermal_retentions[1:], strict=True)
+    )
+
+    failed: list[str] = []
+    if nominal_pass_fraction < gate.minimum_nominal_pass_fraction:
+        failed.append("NOMINAL_PASS_FRACTION")
+    if ratio_degenerate_fraction > gate.maximum_ratio_degenerate_fraction:
+        failed.append("RATIO_DEGENERATE_FRACTION")
+    if perturbation_minimum_retention < gate.minimum_perturbation_retention_fraction:
+        failed.append("PERTURBATION_RETENTION")
+    if gate.require_monotonic_thermal_degradation and not thermal_monotonic:
+        failed.append("THERMAL_MONOTONICITY")
+    if not all(case.equal_power_after_normalization for case in perturbations):
+        failed.append("PERTURBATION_POWER_NORMALIZATION")
+
+    outcome = (
+        RobustnessOutcome.ROBUSTNESS_SUPPORTED_WITHIN_SURROGATE
+        if not failed
+        else RobustnessOutcome.NO_ROBUSTNESS_PROMOTION
+    )
+    report = ProgrammableBoundaryRobustnessReport(
+        nominal_cases=nominal,
+        perturbation_cases=perturbations,
+        thermal_cases=thermal,
+        gate=gate,
+        summary=RobustnessSummary(
+            nominal_case_count=len(nominal),
+            nominal_pass_count=nominal_pass_count,
+            nominal_pass_fraction=nominal_pass_fraction,
+            ratio_degenerate_count=ratio_degenerate_count,
+            ratio_degenerate_fraction=ratio_degenerate_fraction,
+            perturbation_case_count=len(perturbations),
+            perturbation_minimum_retention_fraction=perturbation_minimum_retention,
+            thermal_case_count=len(thermal),
+            thermal_retention_monotonic_nonincreasing=thermal_monotonic,
+            failed_gate_conditions=tuple(failed),
+            outcome=outcome,
+        ),
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_programmable_boundary_robustness_report(
+    report: ProgrammableBoundaryRobustnessReport,
+) -> bool:
+    expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.report_digest == expected

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_robustness_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/programmable_boundary_robustness_cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .programmable_boundary_robustness import (
+    ProgrammableBoundaryRobustnessReport,
+    run_programmable_boundary_robustness,
+    verify_programmable_boundary_robustness_report,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the deterministic WS-QE-2026-EMB-002 programmable-boundary robustness falsification gate."
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _serialize(report: ProgrammableBoundaryRobustnessReport) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = ProgrammableBoundaryRobustnessReport.model_validate(payload)
+        if not verify_programmable_boundary_robustness_report(report):
+            print("INVALID")
+            return 1
+        print("VALID")
+        return 0
+
+    report = run_programmable_boundary_robustness()
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a second-stage robustness/falsification layer around the already-merged EMB-001 synthetic programmable-boundary benchmark without modifying EMB-001 itself.

### Nominal robustness sweep
- 36 cases across tile counts 6/8/12, spacings 0.25/0.35/0.50 wavelengths, and four target/preserve angle pairs
- reuses EMB-001 as the inner nominal model
- retains ratio-degenerate passive references as failures rather than turning near-zero denominators into artificial improvement evidence
- preserves per-case failure reasons

### Perturbation sweep
- 18 deterministic hash-derived phase/amplitude perturbation cases
- seeds 7/19/43
- phase bounds 5/15/30 degrees
- amplitude bounds 0.05/0.15
- equal modeled element-power normalization for fair comparison

### Thermal severity sweep
- severity multipliers 0.25/0.50/1.00/1.50
- records target retention and modeled power
- requires monotonic non-increasing target retention

### Predeclared promotion gate
`ROBUSTNESS_SUPPORTED_WITHIN_SURROGATE` is allowed only if all of the following hold:
1. nominal pass fraction >= 0.90
2. ratio-degenerate fraction <= 0.05
3. minimum bounded perturbation retention >= 0.90
4. thermal degradation is monotonic non-increasing
5. all normalized perturbation cases retain equal modeled power

Any failure produces `NO_ROBUSTNESS_PROMOTION`; thresholds are not to be relaxed after observing the result.

### Evidence and claims boundary
- canonical SHA-256 report binding and tamper verification
- `ws-programmable-boundary-robustness` export/verify CLI
- tests require adverse cases to remain in the evidence
- capability remains `SIMULATED_ONLY`
- no full-wave, material, broadband, laboratory, stealth/cloaking, flight, or operational validation is claimed

### Validation gate
Do not merge unless the complete protected unit/API, deployment, destructive recovery, rollback/TLS/resilience, evidence, and repository protection path is green on the exact reviewed head.