### PR TITLE
NAVSEA MBSE v2: current-main falsifiable Phase I baseline

### DIFF
--- a/deployments/sara_verified_local_v1/fixtures/mbse_legacy_perturbed_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/mbse_legacy_perturbed_v1.json
@@ -1,0 +1,67 @@
+{
+  "fixture_id": "WS-MBSE-SYNTH-PERTURBED-001",
+  "classification": "UNCLASSIFIED_SYNTHETIC_FIXTURE",
+  "claims_boundary": [
+    "Synthetic adversarial corpus only.",
+    "Designed to expose brittleness in the deterministic rules baseline.",
+    "Not derived from AEGIS, Navy, export-controlled, CUI, or classified technical data.",
+    "Failure on this fixture is retained as negative evidence and does not establish production capability."
+  ],
+  "ground_truth": {
+    "nodes": [
+      {"id": "power_bus", "type": "subsystem", "name": "Power Distribution"},
+      {"id": "sensor_a", "type": "sensor", "name": "Sensor A"},
+      {"id": "processor_a", "type": "compute", "name": "Mission Processor"},
+      {"id": "display_a", "type": "hmi", "name": "Operator Display"},
+      {"id": "service_track", "type": "software_service", "name": "Track Service"}
+    ],
+    "edges": [
+      {"source": "power_bus", "target": "sensor_a", "relation": "powers"},
+      {"source": "power_bus", "target": "processor_a", "relation": "powers"},
+      {"source": "sensor_a", "target": "processor_a", "relation": "ethernet_data"},
+      {"source": "processor_a", "target": "service_track", "relation": "hosts"},
+      {"source": "service_track", "target": "display_a", "relation": "publishes_track_data"}
+    ]
+  },
+  "legacy_artifacts": [
+    {
+      "artifact_id": "doc-101",
+      "kind": "technical_manual_excerpt",
+      "content": "28-volt DC feed: Power Distribution -> Sensor A. Sensor A publishes observation traffic via Ethernet toward Mission Processor.",
+      "expected_support": ["power_bus->sensor_a:powers", "sensor_a->processor_a:ethernet_data"]
+    },
+    {
+      "artifact_id": "bom-101",
+      "kind": "hardware_bom",
+      "rows": [
+        {"item": "Sensor A", "part": "SYN-SA-001"},
+        {"item": "Mission Processor", "part": "SYN-MP-001"},
+        {"item": "Operator Display", "part": "SYN-DIS-001"}
+      ]
+    },
+    {
+      "artifact_id": "net-101",
+      "kind": "network_configuration",
+      "rows": [
+        {"host": "Mission Processor", "service": "Track Service", "protocol": "TCP", "port": 4500},
+        {"consumer": "Operator Display", "service": "Track Service"}
+      ]
+    },
+    {
+      "artifact_id": "cable-101",
+      "kind": "cable_record",
+      "rows": [
+        {"from": "Power Distribution", "to": "Mission Processor", "purpose": "primary electrical feed"}
+      ]
+    }
+  ],
+  "scoring": {
+    "entity_precision_target": 0.95,
+    "entity_recall_target": 0.95,
+    "relationship_precision_target": 0.90,
+    "relationship_recall_target": 0.90,
+    "unsupported_inference_target": 0.0,
+    "expected_baseline_result": "FAIL",
+    "notes": "The baseline is expected to miss paraphrased power/Ethernet relations. This is deliberate negative evidence motivating AI/ML and richer document understanding."
+  }
+}

--- a/deployments/sara_verified_local_v1/fixtures/navsea_mbse_capture_gate_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/navsea_mbse_capture_gate_v1.json
@@ -1,0 +1,103 @@
+{
+  "schema": "ws-navsea-mbse-capture-gate-1",
+  "topic": {
+    "id": "DON26BX05-NP003",
+    "title": "NAVSEA Open Topic for Model-Based Systems Engineering (MBSE) Acceleration via Artificial Intelligence or Machine Learning Data Ingestion",
+    "open_date": "2026-08-26",
+    "close_date": "2026-09-23T12:00:00-04:00",
+    "phase_i_type": "CONCEPT_FEASIBILITY_ANALYSIS_AND_MODELING",
+    "source_urls": [
+      "https://www.sbir.gov/topics/12921",
+      "https://navysbir.com/n26_5/DON26BX05-NP003.htm",
+      "https://www.dodsbirsttr.mil/submissions/solicitation-documents/active-solicitations"
+    ],
+    "controlling_source_note": "DSIP/DoW solicitation and amendments control. SBIR.gov and NavySBIR copies must be rechecked before submission."
+  },
+  "capture_state": {
+    "phase_i_prime_position": "CONDITIONAL_CANDIDATE_PENDING_ADMIN_ELIGIBILITY",
+    "phase_ii_position": "NO_GO_UNTIL_SECURITY_AND_CAMEO_GATES_VERIFIED",
+    "partner_lane": "HIGH_PRIORITY_FOR_CAMEO_AND_CLASSIFIED_TRANSITION",
+    "dsip_registration_status": "UNVERIFIED_IN_CONNECTED_RECORDS",
+    "sbir_small_business_eligibility": "UNVERIFIED",
+    "us_owned_operated_no_foreign_influence": "UNVERIFIED",
+    "facility_clearance_path": "UNVERIFIED",
+    "personnel_clearance_path": "UNVERIFIED",
+    "cmmc_level_2_self_status": "NOT_ASSESSED",
+    "cameo_license_environment_access": "UNVERIFIED",
+    "cameo_openapi_integration": "NOT_IMPLEMENTED",
+    "proposal_submitted": false
+  },
+  "requirement_mapping": [
+    {
+      "requirement": "Ingest heterogeneous legacy technical artifacts and reconstruct model entities/relationships",
+      "current_evidence": "Synthetic legacy corpus with ground truth plus deterministic rules baseline",
+      "status": "PARTIAL_INTERNAL_SOFTWARE_EVIDENCE",
+      "gap": "No images/OCR corpus, no large heterogeneous held-out corpus, no AEGIS/Navy data, and no AI/ML generalization evidence"
+    },
+    {
+      "requirement": "High degree of accuracy with minimal manual model validation",
+      "current_evidence": "Precision/recall targets exist on synthetic corpus; adversarial paraphrase fixture intentionally exposes deterministic baseline brittleness",
+      "status": "REQUIRES_AI_ML_AND_HELD_OUT_VALIDATION",
+      "gap": "Need preregistered held-out corpus, error taxonomy, confidence calibration, unsupported-inference rate, and correction burden measurement"
+    },
+    {
+      "requirement": "Direct conversion into Cameo MagicDraw SysML models",
+      "current_evidence": "2026x Cameo/SysML documentation confirms supported OpenAPI and SysML OpenAPI classes exist",
+      "status": "SUPPORTED_INTEGRATION_PATH_NOT_IMPLEMENTED",
+      "gap": "Need licensed Cameo environment, version target, OpenAPI adapter, model creation tests, round-trip validation, and Government environment compatibility"
+    },
+    {
+      "requirement": "Support cyber assessment, configuration, interfaces, reliability, testing, and certification use cases",
+      "current_evidence": "Worldshepherd evidence graph, provenance, configuration custody, MBSE synthetic graph, and qualification framework",
+      "status": "PARTIAL_SOFTWARE_FOUNDATION",
+      "gap": "No operational Navy model, cyber authorization evidence, certification evidence, or government SME validation"
+    },
+    {
+      "requirement": "Phase II classified transition capability",
+      "current_evidence": "None established",
+      "status": "HARD_EXTERNAL_GATE",
+      "gap": "U.S.-ownership/foreign-influence determination, facility and personnel clearance path, classified safeguarding, and DCSA/NAVSEA requirements"
+    }
+  ],
+  "phase_i_measurement_plan": [
+    "Establish a heterogeneous unclassified/synthetic legacy corpus with technical prose, BOMs, interface tables, network configuration, cable records, drawings represented through structured surrogates, and deliberately conflicting artifacts.",
+    "Freeze training/development and held-out test partitions before model tuning.",
+    "Benchmark the deterministic rules baseline and retain its failures as negative evidence.",
+    "Develop AI/ML extraction only if it demonstrably improves held-out entity and relationship precision/recall without increasing unsupported inference beyond the preregistered ceiling.",
+    "Attach source-level provenance and confidence to every generated element and relationship.",
+    "Measure human correction burden rather than claiming no-human-input from synthetic accuracy alone.",
+    "Implement a Cameo OpenAPI adapter only in a licensed compatible environment and validate created SysML elements by machine and human inspection.",
+    "Perform round-trip/reopen validation in Cameo and preserve import warnings, rejected elements, and semantic mismatches as evidence.",
+    "Keep all Phase I work unclassified unless the Government explicitly provides and authorizes a different environment."
+  ],
+  "go_no_go_metrics": {
+    "held_out_entity_precision_min": 0.95,
+    "held_out_entity_recall_min": 0.95,
+    "held_out_relationship_precision_min": 0.90,
+    "held_out_relationship_recall_min": 0.90,
+    "unsupported_relationship_fraction_max": 0.01,
+    "source_provenance_completeness_min": 0.99,
+    "cameo_round_trip_semantic_match_min": 0.98,
+    "manual_correction_burden_target": "MEASURE_AND_MINIMIZE_NOT_PRECLAIM_ZERO",
+    "metric_status": "INTERNAL_PHASE_I_TARGETS_NOT_GOVERNMENT_ACCEPTANCE_THRESHOLDS"
+  },
+  "q_and_a_candidate": {
+    "deadline_from_topic_copy": "2026-09-09T12:00:00-04:00",
+    "dsip_access_required": true,
+    "dsip_access_verified": false,
+    "submitted": false,
+    "questions": [
+      "May Phase I feasibility be performed entirely with unclassified synthetic/public legacy-system data, with classified access and facility/personnel clearance becoming an advanced-phase gate rather than a Phase I prerequisite?",
+      "Which Cameo/MagicDraw and SysML version should offerors target for Phase I interface design, and is a supported MagicDraw OpenAPI/SysML plugin adapter an acceptable direct-conversion architecture for the required Cameo environment?",
+      "For the requirement of high-accuracy automated model generation with minimal human input, does NAVSEA have preferred quantitative Phase II evaluation measures for element/relationship correctness, unsupported inference, and manual correction burden?"
+    ]
+  },
+  "claims_boundary": [
+    "No AEGIS, Navy, CUI, export-controlled, or classified data has been ingested or evaluated.",
+    "No Cameo/MagicDraw interoperability is currently claimed.",
+    "The deterministic baseline is not AI/ML and is not proposed as the final topic solution.",
+    "Passing a synthetic fixture does not establish general legacy-document reconstruction accuracy.",
+    "Phase II security eligibility and clearance capability are not established.",
+    "No CMMC assessment, certification, proposal submission, Navy endorsement, partner interest, award probability, or government validation is claimed."
+  ]
+}

--- a/deployments/sara_verified_local_v1/tests/test_mbse_baseline.py
+++ b/deployments/sara_verified_local_v1/tests/test_mbse_baseline.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from worldshepherd_sara.mbse_baseline import (
+    extract_legacy_model,
+    meets_fixture_targets,
+    score_against_ground_truth,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((ROOT / "fixtures" / name).read_text(encoding="utf-8"))
+
+
+def test_baseline_meets_original_synthetic_fixture_targets():
+    fixture = _fixture("mbse_legacy_fixture_v1.json")
+    model = extract_legacy_model(fixture)
+    metrics = score_against_ground_truth(model, fixture)
+
+    assert model["ai_ml_claimed"] is False
+    assert model["cameo_magicdraw_interoperability_claimed"] is False
+    assert meets_fixture_targets(metrics, fixture) is True
+    assert metrics["unsupported_inference_count"] == 0
+    assert all(entity["source_refs"] for entity in model["entities"])
+    assert all(rel["source_ref"] for rel in model["relationships"])
+
+
+def test_perturbed_fixture_is_retained_as_disconfirming_evidence():
+    fixture = _fixture("mbse_legacy_perturbed_v1.json")
+    model = extract_legacy_model(fixture)
+    metrics = score_against_ground_truth(model, fixture)
+
+    assert fixture["scoring"]["expected_baseline_result"] == "FAIL"
+    assert meets_fixture_targets(metrics, fixture) is False
+    assert metrics["relationship_recall"] < fixture["scoring"]["relationship_recall_target"]
+    assert metrics["missed_relationship_count"] >= 1
+
+
+def test_baseline_never_claims_ai_or_cameo_interoperability():
+    fixture = _fixture("mbse_legacy_fixture_v1.json")
+    model = extract_legacy_model(fixture)
+    assert model["generator"] == "deterministic_rules_baseline"
+    assert model["ai_ml_claimed"] is False
+    assert model["cameo_magicdraw_interoperability_claimed"] is False

--- a/deployments/sara_verified_local_v1/tests/test_navsea_mbse_capture_gate.py
+++ b/deployments/sara_verified_local_v1/tests/test_navsea_mbse_capture_gate.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "navsea_mbse_capture_gate_v1.json"
+
+
+def _payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_phase_i_and_phase_ii_positions_are_separate():
+    payload = _payload()
+    state = payload["capture_state"]
+    assert state["phase_i_prime_position"] == "CONDITIONAL_CANDIDATE_PENDING_ADMIN_ELIGIBILITY"
+    assert state["phase_ii_position"] == "NO_GO_UNTIL_SECURITY_AND_CAMEO_GATES_VERIFIED"
+    assert state["proposal_submitted"] is False
+
+
+def test_security_and_cameo_gaps_fail_closed():
+    state = _payload()["capture_state"]
+    assert state["dsip_registration_status"] == "UNVERIFIED_IN_CONNECTED_RECORDS"
+    assert state["facility_clearance_path"] == "UNVERIFIED"
+    assert state["personnel_clearance_path"] == "UNVERIFIED"
+    assert state["cmmc_level_2_self_status"] == "NOT_ASSESSED"
+    assert state["cameo_openapi_integration"] == "NOT_IMPLEMENTED"
+
+
+def test_q_and_a_is_prepared_but_not_claimed_submitted():
+    qa = _payload()["q_and_a_candidate"]
+    assert qa["dsip_access_required"] is True
+    assert qa["dsip_access_verified"] is False
+    assert qa["submitted"] is False
+    assert len(qa["questions"]) == 3
+
+
+def test_phase_i_metrics_are_internal_targets_only():
+    metrics = _payload()["go_no_go_metrics"]
+    assert metrics["metric_status"] == "INTERNAL_PHASE_I_TARGETS_NOT_GOVERNMENT_ACCEPTANCE_THRESHOLDS"
+    assert metrics["unsupported_relationship_fraction_max"] <= 0.01
+    assert metrics["source_provenance_completeness_min"] >= 0.99
+
+
+def test_claims_boundary_rejects_current_cameo_and_government_validation_claims():
+    boundary = " ".join(_payload()["claims_boundary"]).lower()
+    for required in (
+        "no cameo/magicdraw interoperability is currently claimed",
+        "no aegis, navy, cui, export-controlled, or classified data",
+        "passing a synthetic fixture does not establish general legacy-document reconstruction accuracy",
+        "phase ii security eligibility and clearance capability are not established",
+        "no cmmc assessment",
+    ):
+        assert required in boundary

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/mbse_baseline.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/mbse_baseline.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MBSEEntity:
+    name: str
+    entity_type: str
+    source_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MBSERelationship:
+    source: str
+    target: str
+    relation: str
+    source_ref: str
+
+
+def _clean_name(value: str) -> str:
+    value = re.sub(r"\s+", " ", value.strip())
+    value = re.sub(r"\s+subsystem$", "", value, flags=re.IGNORECASE)
+    return value.strip(" .,:;")
+
+
+def _key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", _clean_name(value).lower()).strip("_")
+
+
+def infer_entity_type(name: str) -> str:
+    lowered = name.lower()
+    if "sensor" in lowered:
+        return "sensor"
+    if "processor" in lowered or "computer" in lowered or "compute" in lowered:
+        return "compute"
+    if "display" in lowered or "console" in lowered or "hmi" in lowered:
+        return "hmi"
+    if "service" in lowered or "daemon" in lowered:
+        return "software_service"
+    if "distribution" in lowered or "subsystem" in lowered or "power" in lowered:
+        return "subsystem"
+    return "unknown"
+
+
+def _add_entity(store: dict[str, MBSEEntity], name: str, source_ref: str) -> None:
+    clean = _clean_name(name)
+    if not clean:
+        return
+    key = _key(clean)
+    current = store.get(key)
+    refs = set(current.source_refs if current else ())
+    refs.add(source_ref)
+    entity_type = (
+        current.entity_type
+        if current and current.entity_type != "unknown"
+        else infer_entity_type(clean)
+    )
+    store[key] = MBSEEntity(
+        name=clean,
+        entity_type=entity_type,
+        source_refs=tuple(sorted(refs)),
+    )
+
+
+def extract_legacy_model(fixture: dict[str, Any]) -> dict[str, Any]:
+    """Extract a small evidence-linked model from the synthetic legacy corpus.
+
+    This is deliberately a deterministic rules baseline, not an AI/ML model and
+    not a Cameo/MagicDraw exporter. It exists to create a falsifiable minimum
+    benchmark that future AI/ML ingestion must outperform on held-out corpora.
+    """
+
+    entities: dict[str, MBSEEntity] = {}
+    relationships: list[MBSERelationship] = []
+
+    for artifact in fixture.get("legacy_artifacts", []):
+        artifact_id = str(artifact.get("artifact_id", "unknown"))
+        kind = artifact.get("kind")
+
+        if kind == "hardware_bom":
+            for row in artifact.get("rows", []):
+                item = row.get("item")
+                if item:
+                    _add_entity(entities, str(item), artifact_id)
+
+        elif kind == "network_configuration":
+            for row in artifact.get("rows", []):
+                host = row.get("host")
+                service = row.get("service")
+                consumer = row.get("consumer")
+                if host:
+                    _add_entity(entities, str(host), artifact_id)
+                if service:
+                    _add_entity(entities, str(service), artifact_id)
+                if consumer:
+                    _add_entity(entities, str(consumer), artifact_id)
+                if host and service:
+                    relationships.append(
+                        MBSERelationship(str(host), str(service), "hosts", artifact_id)
+                    )
+                if consumer and service:
+                    relationships.append(
+                        MBSERelationship(
+                            str(service), str(consumer), "publishes_track_data", artifact_id
+                        )
+                    )
+
+        elif kind == "cable_record":
+            for row in artifact.get("rows", []):
+                source = row.get("from")
+                target = row.get("to")
+                purpose = str(row.get("purpose", ""))
+                if source:
+                    _add_entity(entities, str(source), artifact_id)
+                if target:
+                    _add_entity(entities, str(target), artifact_id)
+                if source and target and (
+                    "vdc" in purpose.lower() or "power" in purpose.lower()
+                ):
+                    relationships.append(
+                        MBSERelationship(str(source), str(target), "powers", artifact_id)
+                    )
+
+        elif kind == "technical_manual_excerpt":
+            text = str(artifact.get("content", ""))
+            manual_subject: str | None = None
+            power_match = re.search(
+                r"(?P<target>[A-Z][A-Za-z0-9 ]+?)\s+receives\s+[^.]*?\s+from\s+the\s+"
+                r"(?P<source>[A-Z][A-Za-z0-9 ]+?)(?:\s+subsystem)?\s+and\s+",
+                text,
+            )
+            if power_match:
+                source = _clean_name(power_match.group("source"))
+                target = _clean_name(power_match.group("target"))
+                manual_subject = target
+                _add_entity(entities, source, artifact_id)
+                _add_entity(entities, target, artifact_id)
+                relationships.append(
+                    MBSERelationship(source, target, "powers", artifact_id)
+                )
+
+            if manual_subject:
+                ethernet_match = re.search(
+                    r"(?:forwards|sends)\s+[^.]*?\s+to\s+(?:the\s+)?"
+                    r"(?P<target>[A-Z][A-Za-z0-9 ]+?)\s+over\s+Ethernet",
+                    text,
+                )
+                if ethernet_match:
+                    target = _clean_name(ethernet_match.group("target"))
+                    _add_entity(entities, manual_subject, artifact_id)
+                    _add_entity(entities, target, artifact_id)
+                    relationships.append(
+                        MBSERelationship(
+                            manual_subject, target, "ethernet_data", artifact_id
+                        )
+                    )
+
+    unique_relationships: dict[tuple[str, str, str], MBSERelationship] = {}
+    for rel in relationships:
+        unique_relationships[(_key(rel.source), _key(rel.target), rel.relation)] = (
+            MBSERelationship(
+                _clean_name(rel.source),
+                _clean_name(rel.target),
+                rel.relation,
+                rel.source_ref,
+            )
+        )
+
+    return {
+        "schema": "ws-mbse-baseline-model-1",
+        "generator": "deterministic_rules_baseline",
+        "ai_ml_claimed": False,
+        "cameo_magicdraw_interoperability_claimed": False,
+        "entities": [
+            {
+                "name": entity.name,
+                "entity_type": entity.entity_type,
+                "source_refs": list(entity.source_refs),
+            }
+            for entity in sorted(entities.values(), key=lambda item: _key(item.name))
+        ],
+        "relationships": [
+            {
+                "source": rel.source,
+                "target": rel.target,
+                "relation": rel.relation,
+                "source_ref": rel.source_ref,
+            }
+            for rel in sorted(
+                unique_relationships.values(),
+                key=lambda item: (_key(item.source), _key(item.target), item.relation),
+            )
+        ],
+    }
+
+
+def _prf(predicted: set[Any], expected: set[Any]) -> tuple[float, float]:
+    if not predicted:
+        precision = 1.0 if not expected else 0.0
+    else:
+        precision = len(predicted & expected) / len(predicted)
+    recall = 1.0 if not expected else len(predicted & expected) / len(expected)
+    return precision, recall
+
+
+def score_against_ground_truth(
+    model: dict[str, Any], fixture: dict[str, Any]
+) -> dict[str, float | int]:
+    expected_entities = {
+        (_key(str(node["name"])), str(node["type"]))
+        for node in fixture.get("ground_truth", {}).get("nodes", [])
+    }
+    predicted_entities = {
+        (_key(str(entity["name"])), str(entity["entity_type"]))
+        for entity in model.get("entities", [])
+    }
+
+    id_to_name = {
+        str(node["id"]): str(node["name"])
+        for node in fixture.get("ground_truth", {}).get("nodes", [])
+    }
+    expected_relationships = {
+        (
+            _key(id_to_name[str(edge["source"])]),
+            _key(id_to_name[str(edge["target"])]),
+            str(edge["relation"]),
+        )
+        for edge in fixture.get("ground_truth", {}).get("edges", [])
+    }
+    predicted_relationships = {
+        (_key(str(rel["source"])), _key(str(rel["target"])), str(rel["relation"]))
+        for rel in model.get("relationships", [])
+    }
+
+    entity_precision, entity_recall = _prf(predicted_entities, expected_entities)
+    relationship_precision, relationship_recall = _prf(
+        predicted_relationships, expected_relationships
+    )
+    unsupported = len(predicted_relationships - expected_relationships)
+    missed = len(expected_relationships - predicted_relationships)
+
+    return {
+        "entity_precision": round(entity_precision, 6),
+        "entity_recall": round(entity_recall, 6),
+        "relationship_precision": round(relationship_precision, 6),
+        "relationship_recall": round(relationship_recall, 6),
+        "unsupported_inference_count": unsupported,
+        "missed_relationship_count": missed,
+    }
+
+
+def meets_fixture_targets(
+    metrics: dict[str, float | int], fixture: dict[str, Any]
+) -> bool:
+    targets = fixture.get("scoring", {})
+    return bool(
+        float(metrics["entity_precision"])
+        >= float(targets.get("entity_precision_target", 1.0))
+        and float(metrics["entity_recall"])
+        >= float(targets.get("entity_recall_target", 1.0))
+        and float(metrics["relationship_precision"])
+        >= float(targets.get("relationship_precision_target", 1.0))
+        and float(metrics["relationship_recall"])
+        >= float(targets.get("relationship_recall_target", 1.0))
+        and int(metrics["unsupported_inference_count"])
+        <= int(targets.get("unsupported_inference_target", 0))
+    )


### PR DESCRIPTION
## Summary

Recreates the corrected NAVSEA MBSE Phase I baseline on current `main` after PR #102 passed all seven workflows but became stale when the RF no-go gate entered mainline.

### Preserved implementation
- deterministic source-linked legacy-document baseline, explicitly not AI/ML;
- original synthetic corpus must pass its declared precision/recall thresholds;
- adversarial paraphrase corpus must remain a failing negative-evidence case;
- corrected grammatical-subject attribution fixes the previously observed spurious entity/wrong relationship without relaxing test thresholds;
- Phase I/Phase II capture and security gates remain fail-closed;
- Cameo OpenAPI remains an integration path, not implemented interoperability;
- three DSIP Q&A candidates remain prepared but unsubmitted.

### Current capture position
- Phase I: `CONDITIONAL_CANDIDATE_PENDING_ADMIN_ELIGIBILITY`
- Phase II: `NO_GO_UNTIL_SECURITY_AND_CAMEO_GATES_VERIFIED`
- DSIP access, SBIR small-business eligibility, U.S.-ownership/foreign-influence status, facility/personnel clearance path, CMMC L2 self-assessment, and Cameo environment access remain unverified/not established as recorded.

### Claims boundary
No Navy/AEGIS/CUI/classified ingestion, Cameo interoperability, CMMC conformity, government validation, submission, or award probability is claimed.

Merge only when protected CI is green on this exact current-main integration context.