### PR TITLE
W-RMABM G2C vendor-neutral interface conformance

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_rmabm_interfaces.py
+++ b/deployments/sara_verified_local_v1/tests/test_rmabm_interfaces.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+
+from worldshepherd_sara.rmabm import run_synthetic_rmabm
+from worldshepherd_sara.rmabm_interfaces import (
+    InterfaceConformanceError,
+    normalize_interface_batch,
+    normalize_interface_record,
+)
+
+
+def _payload(text: str) -> tuple[str, str]:
+    raw = text.encode("utf-8")
+    return base64.b64encode(raw).decode("ascii"), hashlib.sha256(raw).hexdigest()
+
+
+def _alpha(*, observation_id: str = "IF-A", t_seconds: float = 15.0) -> dict:
+    payload_b64, digest = _payload(f"alpha|{observation_id}|{t_seconds}")
+    return {
+        "schema_version": "1.0",
+        "id": observation_id,
+        "sensor": "SYN-ALPHA-SENSOR",
+        "t_seconds": t_seconds,
+        "position": {"x": 10.0, "y": 10.0},
+        "confidence": 0.91,
+        "payload_b64": payload_b64,
+        "sha256": digest,
+    }
+
+
+def _beta(*, observation_id: str = "IF-B", t_seconds: float = 15.5) -> dict:
+    payload_b64, digest = _payload(f"beta|{observation_id}|{t_seconds}")
+    return {
+        "version": "2026.1",
+        "event": {
+            "key": observation_id,
+            "source": "SYN-BETA-SENSOR",
+            "seconds": t_seconds,
+        },
+        "coords": [10.3, 9.9],
+        "quality": {"score": 0.89},
+        "blob": {"b64": payload_b64, "digest_sha256": digest},
+    }
+
+
+def test_two_fictional_schemas_normalize_into_one_bounded_advisory_track():
+    observations = normalize_interface_batch(
+        [
+            ("synthetic_beta", _beta()),
+            ("synthetic_alpha", _alpha()),
+        ]
+    )
+    fixture = {
+        "scenario_id": "WS-RMABM-G2C-IFACE-001",
+        "scenario_time_seconds": 20.0,
+        "requested_action": "advisory_dissemination",
+        "human_authority": "identified-human-test-authority",
+        "max_spatial_distance": 2.0,
+        "max_time_delta_seconds": 3.0,
+        "policy": {
+            "min_track_confidence": 0.75,
+            "min_independent_sensors": 2,
+            "max_observation_age_seconds": 8.0,
+            "require_identified_human_authority": True,
+            "permitted_action": "advisory_dissemination",
+        },
+        "observations": [item.model_dump(mode="json") for item in observations],
+        "events": [],
+    }
+
+    result = run_synthetic_rmabm(fixture)
+    assert len(result.decisions) == 1
+    assert result.decisions[0].decision == "AUTHORIZED_ADVISORY"
+    assert set(result.decisions[0].source_sensor_ids) == {"SYN-ALPHA-SENSOR", "SYN-BETA-SENSOR"}
+
+
+def test_unknown_alpha_schema_version_is_rejected():
+    record = _alpha()
+    record["schema_version"] = "9.9"
+    with pytest.raises(InterfaceConformanceError, match="unsupported synthetic_alpha"):
+        normalize_interface_record(record, family="synthetic_alpha")
+
+
+def test_tampered_interface_payload_is_rejected_before_normalization():
+    record = _beta()
+    record["blob"]["b64"] = base64.b64encode(b"tampered-interface-payload").decode("ascii")
+    with pytest.raises(InterfaceConformanceError, match="payload digest mismatch"):
+        normalize_interface_record(record, family="synthetic_beta")
+
+
+def test_duplicate_ids_across_fictional_schema_families_are_rejected():
+    with pytest.raises(InterfaceConformanceError, match="globally unique"):
+        normalize_interface_batch(
+            [
+                ("synthetic_alpha", _alpha(observation_id="DUP")),
+                ("synthetic_beta", _beta(observation_id="DUP")),
+            ]
+        )
+
+
+def test_interface_batch_order_is_deterministic():
+    observations = normalize_interface_batch(
+        [
+            ("synthetic_beta", _beta(t_seconds=19.0)),
+            ("synthetic_alpha", _alpha(t_seconds=4.0)),
+        ]
+    )
+    assert [item.observation_id for item in observations] == ["IF-A", "IF-B"]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/rmabm_interfaces.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/rmabm_interfaces.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .rmabm import ProvenancedObservation
+
+
+class InterfaceConformanceError(ValueError):
+    """Raised when a synthetic external record cannot be safely normalized."""
+
+
+class NormalizedInterfaceRecord(BaseModel):
+    schema_family: Literal["synthetic_alpha", "synthetic_beta"]
+    schema_version: str = Field(min_length=1)
+    observation: ProvenancedObservation
+
+
+def _verify_payload(payload_b64: str, claimed_sha256: str) -> str:
+    try:
+        payload = base64.b64decode(payload_b64.encode("ascii"), validate=True)
+    except Exception as exc:  # noqa: BLE001 - normalize decoder errors
+        raise InterfaceConformanceError("payload is not valid base64") from exc
+
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != str(claimed_sha256).lower():
+        raise InterfaceConformanceError("payload digest mismatch")
+    return actual
+
+
+def _alpha(record: dict[str, Any]) -> NormalizedInterfaceRecord:
+    version = str(record.get("schema_version", ""))
+    if version != "1.0":
+        raise InterfaceConformanceError(f"unsupported synthetic_alpha schema_version={version!r}")
+    try:
+        payload_sha256 = _verify_payload(str(record["payload_b64"]), str(record["sha256"]))
+        position = record["position"]
+        observation = ProvenancedObservation(
+            observation_id=str(record["id"]),
+            sensor_id=str(record["sensor"]),
+            t_seconds=float(record["t_seconds"]),
+            x=float(position["x"]),
+            y=float(position["y"]),
+            confidence=float(record["confidence"]),
+            source_sha256=payload_sha256,
+            source_status="synthetic",
+        )
+    except InterfaceConformanceError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - convert heterogeneous schema failures
+        raise InterfaceConformanceError(f"invalid synthetic_alpha record: {exc}") from exc
+    return NormalizedInterfaceRecord(schema_family="synthetic_alpha", schema_version=version, observation=observation)
+
+
+def _beta(record: dict[str, Any]) -> NormalizedInterfaceRecord:
+    version = str(record.get("version", ""))
+    if version != "2026.1":
+        raise InterfaceConformanceError(f"unsupported synthetic_beta schema_version={version!r}")
+    try:
+        event = record["event"]
+        coords = record["coords"]
+        quality = record["quality"]
+        blob = record["blob"]
+        payload_sha256 = _verify_payload(str(blob["b64"]), str(blob["digest_sha256"]))
+        observation = ProvenancedObservation(
+            observation_id=str(event["key"]),
+            sensor_id=str(event["source"]),
+            t_seconds=float(event["seconds"]),
+            x=float(coords[0]),
+            y=float(coords[1]),
+            confidence=float(quality["score"]),
+            source_sha256=payload_sha256,
+            source_status="synthetic",
+        )
+    except InterfaceConformanceError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - convert heterogeneous schema failures
+        raise InterfaceConformanceError(f"invalid synthetic_beta record: {exc}") from exc
+    return NormalizedInterfaceRecord(schema_family="synthetic_beta", schema_version=version, observation=observation)
+
+
+def normalize_interface_record(
+    record: dict[str, Any], *, family: Literal["synthetic_alpha", "synthetic_beta"]
+) -> NormalizedInterfaceRecord:
+    """Normalize one vendor-neutral synthetic interface record.
+
+    The two schemas are deliberately fictional. They demonstrate interface-adapter
+    behavior only and do not model or disclose any BAE, SDA, SSC, Rocket Lab, or
+    other vendor proprietary interface.
+    """
+    if family == "synthetic_alpha":
+        return _alpha(record)
+    if family == "synthetic_beta":
+        return _beta(record)
+    raise InterfaceConformanceError(f"unsupported interface family={family!r}")
+
+
+def normalize_interface_batch(records: list[tuple[str, dict[str, Any]]]) -> list[ProvenancedObservation]:
+    normalized = [
+        normalize_interface_record(record, family=family).observation
+        for family, record in records
+    ]
+    observation_ids = [item.observation_id for item in normalized]
+    if len(set(observation_ids)) != len(observation_ids):
+        raise InterfaceConformanceError("normalized observation identifiers must be globally unique")
+    return sorted(normalized, key=lambda item: (item.t_seconds, item.observation_id))

--- a/docs/golden_dome/GD-04D_G2C_INTERFACE_CONFORMANCE_SPEC.md
+++ b/docs/golden_dome/GD-04D_G2C_INTERFACE_CONFORMANCE_SPEC.md
@@ -1,0 +1,45 @@
+# GD-04D — W-RMABM G2C Vendor-Neutral Interface Conformance Specification
+
+**Status:** INTERNAL G2 INCREMENT / SYNTHETIC ONLY / NO PROPRIETARY INTERFACES
+
+## Objective
+Demonstrate that W-RMABM can place heterogeneous synthetic records behind a common provenance and policy boundary without assuming or reverse-engineering any government or vendor interface.
+
+## Synthetic interface families
+Two intentionally fictional schemas are used:
+- `synthetic_alpha` version `1.0`
+- `synthetic_beta` version `2026.1`
+
+They encode the same minimal abstract information using different field structures: source/event identity, timestamp, two-dimensional synthetic coordinates, confidence, payload bytes, and claimed SHA-256.
+
+These schema names and structures are Worldshepherd test fixtures only. They do not model BAE Systems, Space Development Agency, Space Systems Command, Rocket Lab, Amazon, Lockheed Martin, Northrop Grumman, York Space Systems, or any other real organization’s proprietary interface.
+
+## Conformance boundary
+Before a record can enter the synthetic mission-assurance pipeline, the adapter must:
+1. recognize an explicitly supported fictional schema/version;
+2. decode the source payload;
+3. recompute and verify its SHA-256;
+4. validate and normalize required fields;
+5. preserve source identity;
+6. reject duplicate normalized observation identifiers;
+7. emit a standard `ProvenancedObservation` object.
+
+The resulting observations can then use the already bounded W-RMABM quality, provenance, human-authorization, replay, and advisory-only controls.
+
+## G2C acceptance criteria
+- Alpha and Beta records representing compatible synthetic observations normalize into the common model and can satisfy the existing two-source advisory policy.
+- Unsupported schema versions are rejected.
+- Payload tampering is rejected before normalization.
+- Duplicate observation identities across schema families are rejected.
+- Batch normalization order is deterministic.
+- No operational targeting, fire-control, weapon-cueing, launch, interceptor, or engagement functionality is introduced.
+
+## Files
+- `deployments/sara_verified_local_v1/worldshepherd_sara/rmabm_interfaces.py`
+- `deployments/sara_verified_local_v1/tests/test_rmabm_interfaces.py`
+
+## External-validation path
+A G4 evaluator could replace either fictional adapter with an evaluator-approved, unclassified surrogate schema while retaining the common governance core. That substitution—not this synthetic adapter test—would provide evidence of real interface compatibility.
+
+## Claims boundary
+Passing this test supports only the claim that Worldshepherd can normalize and provenance-check two heterogeneous fictional schemas under internal CI. It does not establish compatibility with any actual Space Force, SDA, BAE, Rocket Lab, or other operational interface.

--- a/docs/golden_dome/GD-07_SPACE_DATA_NETWORK_CAPTURE_LANE.md
+++ b/docs/golden_dome/GD-07_SPACE_DATA_NETWORK_CAPTURE_LANE.md
@@ -1,0 +1,62 @@
+# GD-07 — Space Data Network (SDN) Capture Lane
+
+**Status:** PUBLIC-SOURCE CAPTURE ANALYSIS / REVERIFY BEFORE EXTERNAL USE
+
+## Why this lane matters
+The U.S. Space Force Space Systems Command (SSC) is building the Space Data Network (SDN) as a resilient, open, multi-vendor communications architecture. Public SSC statements emphasize standardized interfaces, digital models, security protocols, onboarding new providers, multi-vendor integration, and repeatable test baselines.
+
+Those requirements provide a plausible non-hardware evaluation lane for Worldshepherd's bounded mission-assurance capabilities: provenance, configuration/interface evidence, deterministic replay, policy/human authorization, fault traceability, and integration assurance.
+
+## Authoritative public anchors
+### May 26, 2026 — SDN Backbone
+SSC announced a $2.29B Firm-Fixed-Price OTA delivery order to SpaceX for the SDN Backbone, with a fully operational prototype capability required by the end of 2027. SSC stated that the recently established SDN consortium would expand its participants and work across vendors on a unified network architecture and advanced communications demonstrations.
+
+Source: https://www.ssc.spaceforce.mil/Newsroom/Article-Display/Article/4501527/us-space-force-advances-space-data-network-backbone-for-global-warfighter-conne
+
+### August 13, 2026 — five multi-vendor integration awards
+SSC announced complementary fixed-price contracts and OTA agreements valued at $12M per company to five companies: Amazon LEO for Government, Lockheed Martin, Northrop Grumman, Rocket Lab, and York Space Systems.
+
+The first $10M portion supports six-to-nine-month prototypes demonstrating multi-vendor interconnectivity across the SDN Backbone. The second $2M OTA portion supports six-month Space Exchange Point satellite work. SSC described physical, electrical, and data-interface standards, digital models, and security protocols as part of the onboarding/integration strategy.
+
+Source: https://www.ssc.spaceforce.mil/Newsroom/Article-Display/Article/4572417/space-force-invests-in-resilient-multi-vendor-architecture-to-build-next-gen-sp
+
+## Worldshepherd insertion boundary
+**Pursue:**
+- interface-conformance evidence and adapter governance;
+- source/configuration/result provenance;
+- deterministic replay of integration tests;
+- stale/conflicting-source handling;
+- controlled degraded-state/fault-injection evidence;
+- policy/human-authorization auditability;
+- digital-thread consistency and test-evidence export;
+- onboarding evidence for heterogeneous providers.
+
+**Do not claim/pursue without separate evidence:**
+- optical-terminal hardware performance;
+- flight-qualified satellite-bus capability;
+- SDN routing performance;
+- operational network control;
+- government-standard interface compatibility;
+- Space Force/SSC validation or consortium membership.
+
+## Strongest initial evaluation hypothesis
+Use the W-RMABM G2 interface-conformance harness as a neutral integration-assurance demonstration. Ask an authorized evaluator to provide or approve an **unclassified surrogate interface schema**. Replace one fictional adapter with that surrogate and measure:
+1. conformance/rejection behavior;
+2. provenance completeness;
+3. deterministic replay;
+4. fault/staleness traceability;
+5. adapter-isolation behavior;
+6. governance overhead and latency.
+
+This would test the value proposition without requiring operational mission data or proprietary network protocols.
+
+## Public routing hypothesis
+SSC publicly identifies the U.S. Space Force Front Door as a one-stop portal for commercial companies with tested or emerging space technologies and separately lists its Small Business Office and Space Enterprise Consortium among partnership routes. Use those public channels to seek correct routing before assuming that the SDN consortium is directly open to unsolicited membership.
+
+Source: https://www.ssc.spaceforce.mil/About-Us/Partner-With-Us
+
+## Priority effect
+SDN should be ranked alongside BAE Epoch 2 and SDA STEC as a Tier-1 external-validation lane because it explicitly emphasizes multi-vendor integration and standardized interfaces. Among the five announced SDN integration awardees, partner screening should prioritize complementarity and verified intake route rather than contract value alone.
+
+## Claims boundary
+This document is a capture hypothesis derived from public program information. It does not establish Worldshepherd participation in SDN, an SSC relationship, consortium membership, supplier status, operational compatibility, or government validation.


### PR DESCRIPTION
## Purpose
Extend the clean W-RMABM G2B baseline with vendor-neutral synthetic interface normalization and a public-source Space Data Network capture lane.

## Added technical evidence
- two deliberately fictional schema families normalize into the common `ProvenancedObservation` model;
- payload bytes are SHA-256 verified before normalization;
- unsupported schema versions are rejected;
- duplicate normalized observation IDs are rejected;
- heterogeneous records normalize deterministically and can use the existing human-authorized advisory-only policy boundary.

## Public capture update
GD-07 maps the August 2026 Space Force Space Data Network multi-vendor/open-interface program to a bounded Worldshepherd integration-assurance hypothesis. It does not claim SDN compatibility, consortium membership, supplier status, or government validation.

## Claims boundary
No actual BAE, SDA, SSC, Rocket Lab, Space Force, or other vendor/government proprietary interface is modeled. No targeting, fire control, weapon cueing, launch, interceptor, or engagement functionality is introduced.

## Review target
Draft PR into `golden-dome-rmabm-g2b`, preserving PR #109 as the clean provenance/scale evidence baseline.