### PR TITLE
PRIME-TEVV: add NIST TEVV-Athlon evidence contract and cross-lane templates

### DIFF
--- a/deployments/sara_verified_local_v1/fixtures/prime_tevv_cross_lane_templates_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/prime_tevv_cross_lane_templates_v1.json
@@ -1,0 +1,204 @@
+{
+  "schema": "ws-prime-tevv-cross-lane-templates-1",
+  "reference": {
+    "document": "NIST AI 200-2 ipd - The TEVV-Athlon Framework for Evaluating AI Systems",
+    "status": "INITIAL_PUBLIC_DRAFT_AUGUST_2026",
+    "comment_deadline": "2026-10-06",
+    "source": "https://doi.org/10.6028/NIST.AI.200-2.ipd",
+    "stages": [
+      "Articulate & Organize",
+      "Define & Construct",
+      "Apply & Measure",
+      "Synthesize & Interrogate"
+    ]
+  },
+  "alignment_boundary": [
+    "These are Worldshepherd templates informed by the NIST initial public draft, not a claim of NIST conformance, certification, accreditation, approval, or endorsement.",
+    "The NIST draft is subject to revision; Worldshepherd mappings must be rechecked when the document changes or becomes final.",
+    "Each domain must define its own Metrology Blocks, Events, Toolbox, evidence, operational context, and decision use; cross-domain reuse cannot erase domain-specific risks.",
+    "TEVV evidence may support an internal decision but cannot substitute for physical, regulatory, clinical, classified, flight, or facility validation where those are required."
+  ],
+  "templates": [
+    {
+      "lane": "SARA_AGENT_GOVERNANCE",
+      "system": "SARA governed agent workflow",
+      "goal": "Measure whether bounded agents obey authorization and preserve attributable evidence under adversarial and degraded conditions.",
+      "decision_use": "Advance, hold, or restrict an agent workflow deployment boundary.",
+      "blocks": [
+        {
+          "name": "Unauthorized action blocking",
+          "evidence": ["proposed action", "policy decision", "execution state"],
+          "example_metric": "blocked_prohibited_actions / prohibited_action_attempts"
+        },
+        {
+          "name": "Evidence lineage completeness",
+          "evidence": ["source lineage", "policy lineage", "configuration/version lineage"],
+          "example_metric": "complete_lineage_records / evaluated_records"
+        },
+        {
+          "name": "Recovery behavior",
+          "evidence": ["fault injection", "degraded mode", "recovery trace"],
+          "example_metric": "policy_compliant_recoveries / recovery_scenarios"
+        }
+      ],
+      "events": ["prohibited-action campaign", "policy-service outage", "evidence tamper injection", "recovery/replay campaign"],
+      "toolbox": ["synthetic fault injector", "audit verifier", "policy trace comparator", "human review"],
+      "physical_validation_required": false
+    },
+    {
+      "lane": "NAVSEA_MBSE_EXTRACTION",
+      "system": "Legacy-document-to-model extraction pipeline",
+      "goal": "Measure correctness, unsupported inference, provenance, robustness to paraphrase/layout variation, and human correction burden.",
+      "decision_use": "Determine whether an extraction method may advance from deterministic baseline to AI/ML and later Cameo integration testing.",
+      "blocks": [
+        {
+          "name": "Entity reconstruction",
+          "evidence": ["ground truth entities", "predicted entities"],
+          "example_metric": "precision and recall"
+        },
+        {
+          "name": "Relationship reconstruction",
+          "evidence": ["ground truth relationships", "predicted relationships"],
+          "example_metric": "precision and recall"
+        },
+        {
+          "name": "Unsupported inference",
+          "evidence": ["predictions without source support"],
+          "example_metric": "unsupported_relationship_fraction"
+        },
+        {
+          "name": "Human correction burden",
+          "evidence": ["correction actions", "elapsed review time"],
+          "example_metric": "corrections and reviewer-minutes per model element"
+        }
+      ],
+      "events": ["canonical synthetic corpus", "paraphrase challenge", "conflicting-artifact challenge", "held-out corpus", "future Cameo round-trip"],
+      "toolbox": ["ground-truth scorer", "provenance verifier", "adversarial fixture generator", "future Cameo OpenAPI verifier"],
+      "physical_validation_required": false
+    },
+    {
+      "lane": "RF_CLASSIFICATION_FUTURE",
+      "system": "Future Worldshepherd RF classification pipeline",
+      "goal": "Measure classification/anomaly performance, interpretability, calibration, CPU footprint, distribution-shift robustness, and update safety before any D2P2 maturity claim.",
+      "decision_use": "Determine whether the classifier has sufficient evidence for a future recurring spectrum opportunity.",
+      "blocks": [
+        {
+          "name": "Held-out classification performance",
+          "evidence": ["frozen test labels", "predictions"],
+          "example_metric": "class-balanced accuracy, precision, recall"
+        },
+        {
+          "name": "Unknown/anomaly detection",
+          "evidence": ["novel-signal challenge set", "confidence scores"],
+          "example_metric": "AUROC/AUPRC plus false-alarm rate"
+        },
+        {
+          "name": "CPU resource footprint",
+          "evidence": ["CPU model", "latency", "memory", "throughput"],
+          "example_metric": "latency and memory at declared load"
+        },
+        {
+          "name": "Explanation stability",
+          "evidence": ["feature/evidence attribution under perturbation"],
+          "example_metric": "attribution stability with error cases retained"
+        }
+      ],
+      "events": ["clean held-out benchmark", "low-SNR challenge", "frequency-shift challenge", "novel-signal challenge", "continual-update regression"],
+      "toolbox": ["public lawful RF corpus", "CPU benchmark harness", "calibration scorer", "interpretability checker"],
+      "physical_validation_required": false,
+      "current_capability_status": "NOT_IMPLEMENTED_OR_VALIDATED"
+    },
+    {
+      "lane": "APNT_PARTNER_INTEGRATION",
+      "system": "Worldshepherd APNT mission-assurance layer around partner sensor hardware",
+      "goal": "Measure whether source confidence, timing lineage, degraded-mode transitions, policy gates, and replay remain correct under injected navigation faults.",
+      "decision_use": "Determine readiness for partner hardware-in-the-loop testing; never infer physical IMU accuracy from software-only results.",
+      "blocks": [
+        {
+          "name": "Source confidence consistency",
+          "evidence": ["sensor error state", "declared confidence", "fusion decision"],
+          "example_metric": "inconsistency detection rate"
+        },
+        {
+          "name": "Unsafe recovery blocking",
+          "evidence": ["fault state", "proposed recovery", "policy result"],
+          "example_metric": "unsafe recovery blocked fraction"
+        },
+        {
+          "name": "Replay determinism",
+          "evidence": ["input event stream", "replayed terminal state"],
+          "example_metric": "identical terminal-state fraction"
+        }
+      ],
+      "events": ["GNSS degradation", "IMU bias/drift injection", "link loss", "source disagreement", "recovery/reentry"],
+      "toolbox": ["synthetic six-DOF error-state generator", "SARA replay", "ECHO provenance verifier", "policy trace comparator"],
+      "physical_validation_required": true,
+      "physical_validation_scope": "Partner-developed sensor and platform performance"
+    },
+    {
+      "lane": "QVOS_STRONG_FIELD_INFERENCE",
+      "system": "QVOS experiment-assurance and inference layer",
+      "goal": "Measure false-promotion resistance, signal-recovery behavior, uncertainty propagation, and provenance before facility integration.",
+      "decision_use": "Determine whether the analysis stack may advance from synthetic data to facility-specific interface work.",
+      "blocks": [
+        {
+          "name": "False discovery resistance",
+          "evidence": ["null and systematic-only trials", "inference output"],
+          "example_metric": "false promotion rate"
+        },
+        {
+          "name": "Blind signal recovery",
+          "evidence": ["hidden synthetic injections", "estimated hypothesis and parameters"],
+          "example_metric": "recovery rate and parameter error"
+        },
+        {
+          "name": "Uncertainty propagation",
+          "evidence": ["input uncertainty", "posterior/prediction uncertainty"],
+          "example_metric": "coverage/calibration"
+        },
+        {
+          "name": "Shot provenance completeness",
+          "evidence": ["laser", "beam", "detector", "calibration", "analysis lineage"],
+          "example_metric": "complete shot-evidence fraction"
+        }
+      ],
+      "events": ["QED-only blind campaign", "instrument-systematic campaign", "synthetic BSM residual injection", "timing/polarization/intensity transformation campaign"],
+      "toolbox": ["PVK models", "blind generator", "RED-QED adversary", "provenance verifier", "statistical model comparison"],
+      "physical_validation_required": true,
+      "physical_validation_scope": "Actual strong-field measurements and facility integration"
+    },
+    {
+      "lane": "AUTONOMOUS_LAB_ASSURANCE",
+      "system": "Worldshepherd assurance plane for autonomous experimentation",
+      "goal": "Measure whether AI-directed experimental iteration remains auditable, bounded, replayable, and resistant to false scientific promotion.",
+      "decision_use": "Determine whether the assurance layer adds measurable scientific trust without unacceptable experiment-cycle overhead.",
+      "blocks": [
+        {
+          "name": "Experiment decision lineage",
+          "evidence": ["hypothesis", "selected experiment", "authorization", "configuration"],
+          "example_metric": "complete decision-lineage fraction"
+        },
+        {
+          "name": "False promotion rate",
+          "evidence": ["known null/systematic trials", "claim state"],
+          "example_metric": "incorrect claim promotions / challenge trials"
+        },
+        {
+          "name": "Governance overhead",
+          "evidence": ["baseline cycle latency", "assured cycle latency"],
+          "example_metric": "absolute and relative cycle-time overhead"
+        }
+      ],
+      "events": ["instrument drift", "conflicting measurement", "unsafe request", "false anomaly", "model mismatch", "missing metadata"],
+      "toolbox": ["synthetic lab", "SARA", "ECHO", "PRIME", "PVK", "WS-OMEGA", "human reviewer"],
+      "physical_validation_required": true,
+      "physical_validation_scope": "Any claim about real laboratory throughput, instruments, or scientific outcomes"
+    }
+  ],
+  "public_comment_state": {
+    "draft_comment_prepared": false,
+    "comment_submitted": false,
+    "proprietary_information_allowed": false,
+    "note": "NIST states comments may be publicly released and requests that comments not contain proprietary information."
+  }
+}

--- a/deployments/sara_verified_local_v1/tests/test_tevv_athlon.py
+++ b/deployments/sara_verified_local_v1/tests/test_tevv_athlon.py
@@ -98,6 +98,12 @@ def test_every_block_requires_event_coverage():
             system_attributes=["valid"],
             blocks=[
                 MetrologyBlock(
+                    block_id="covered",
+                    name="Covered",
+                    definition="Block with event coverage.",
+                    evidence_required=["evidence"],
+                ),
+                MetrologyBlock(
                     block_id="orphan",
                     name="Orphan",
                     definition="Block without event coverage.",
@@ -117,7 +123,7 @@ def test_every_block_requires_event_coverage():
                     event_id="e",
                     name="Event",
                     description="Event",
-                    block_ids=["unknown"],
+                    block_ids=["covered"],
                     tool_ids=["t"],
                     expected_evidence=["evidence"],
                 )

--- a/deployments/sara_verified_local_v1/tests/test_tevv_athlon.py
+++ b/deployments/sara_verified_local_v1/tests/test_tevv_athlon.py
@@ -1,0 +1,188 @@
+import pytest
+
+from worldshepherd_sara.tevv_athlon import (
+    MetrologyBlock,
+    TEVVAthlonPlan,
+    TEVVEvent,
+    TEVVMeasurement,
+    TEVVStage,
+    TEVVTool,
+    ToolCategory,
+    make_tevv_plan,
+    make_tevv_result,
+    plan_digest,
+    verify_result_digest,
+)
+
+
+def _plan():
+    return make_tevv_plan(
+        system_id="SARA-AGENT-SYNTH",
+        evaluation_goal="Measure whether a governed agent blocks unauthorized actions and preserves evidence.",
+        decision_use="Decide whether the synthetic agent workflow may advance to a stricter integration test.",
+        operational_context="Unclassified synthetic workflow with no external consequential execution.",
+        stakeholders=["CRE1AWS", "SSPADAWANZZ", "independent_evaluator"],
+        lifecycle_stages=["Build", "Use", "Operate & Monitor"],
+        system_attributes=["safe", "valid_and_reliable", "accountable_and_transparent"],
+        blocks=[
+            MetrologyBlock(
+                block_id="unsafe_action_blocking",
+                name="Unsafe action blocking",
+                definition="Fraction of prohibited action proposals prevented from reaching execution.",
+                evidence_required=["action proposal", "policy decision", "execution state"],
+                trustworthiness_characteristics=["Safe"],
+                acceptance_rule="blocking_fraction == 1.0",
+            ),
+            MetrologyBlock(
+                block_id="evidence_lineage",
+                name="Evidence lineage completeness",
+                definition="Fraction of tested decisions with attributable source and policy lineage.",
+                evidence_required=["source refs", "policy refs", "event digest"],
+                trustworthiness_characteristics=["Accountable & Transparent"],
+                acceptance_rule="lineage_fraction >= 0.99",
+            ),
+        ],
+        tools=[
+            TEVVTool(
+                tool_id="fault_injector",
+                name="Synthetic prohibited-action injector",
+                category=ToolCategory.RED_TEAMING,
+                description="Injects bounded prohibited action proposals without performing them.",
+            ),
+            TEVVTool(
+                tool_id="audit_verifier",
+                name="Audit lineage verifier",
+                category=ToolCategory.MODEL_TESTING,
+                description="Checks source, policy, and event lineage fields.",
+            ),
+        ],
+        events=[
+            TEVVEvent(
+                event_id="prohibited_action_campaign",
+                name="Prohibited action campaign",
+                description="Present bounded prohibited actions and verify fail-closed policy behavior.",
+                block_ids=["unsafe_action_blocking", "evidence_lineage"],
+                tool_ids=["fault_injector", "audit_verifier"],
+                expected_evidence=["policy denials", "no execution", "audit records"],
+                adversarial=True,
+            )
+        ],
+    )
+
+
+def test_plan_preserves_nist_draft_stage_order_and_claims_boundary():
+    plan = _plan()
+    assert plan.stage_order == [
+        TEVVStage.ARTICULATE_ORGANIZE,
+        TEVVStage.DEFINE_CONSTRUCT,
+        TEVVStage.APPLY_MEASURE,
+        TEVVStage.SYNTHESIZE_INTERROGATE,
+    ]
+    assert plan.nist_conformance_claimed is False
+    assert plan.nist_endorsement_claimed is False
+    assert plan.certification_claimed is False
+    assert plan.external_execution_authorized is False
+    assert plan.physical_validation_claimed is False
+    assert plan_digest(plan).startswith("sha256:")
+
+
+def test_every_block_requires_event_coverage():
+    with pytest.raises(ValueError, match="every Metrology Block requires"):
+        make_tevv_plan(
+            system_id="broken",
+            evaluation_goal="broken plan",
+            decision_use="test",
+            operational_context="synthetic",
+            stakeholders=["tester"],
+            lifecycle_stages=["Build"],
+            system_attributes=["valid"],
+            blocks=[
+                MetrologyBlock(
+                    block_id="orphan",
+                    name="Orphan",
+                    definition="Block without event coverage.",
+                    evidence_required=["evidence"],
+                )
+            ],
+            tools=[
+                TEVVTool(
+                    tool_id="t",
+                    name="Tool",
+                    category=ToolCategory.OTHER,
+                    description="Tool",
+                )
+            ],
+            events=[
+                TEVVEvent(
+                    event_id="e",
+                    name="Event",
+                    description="Event",
+                    block_ids=["unknown"],
+                    tool_ids=["t"],
+                    expected_evidence=["evidence"],
+                )
+            ],
+        )
+
+
+def test_self_claimed_nist_conformance_and_execution_fail_closed():
+    plan = _plan()
+    payload = plan.model_dump(mode="json")
+    payload["nist_conformance_claimed"] = True
+    with pytest.raises(ValueError, match="NIST conformance"):
+        TEVVAthlonPlan.model_validate(payload)
+
+    payload = plan.model_dump(mode="json")
+    payload["external_execution_authorized"] = True
+    with pytest.raises(ValueError, match="self-authorize external execution"):
+        TEVVAthlonPlan.model_validate(payload)
+
+
+def test_result_measurements_are_bound_to_declared_event_block_and_tool():
+    plan = _plan()
+    measurements = [
+        TEVVMeasurement(
+            measurement_id="m1",
+            event_id="prohibited_action_campaign",
+            block_id="unsafe_action_blocking",
+            tool_id="fault_injector",
+            metric="blocking_fraction",
+            value=1.0,
+            source_refs=["audit:synthetic-001"],
+            passed_acceptance_rule=True,
+        ),
+        TEVVMeasurement(
+            measurement_id="m2",
+            event_id="prohibited_action_campaign",
+            block_id="evidence_lineage",
+            tool_id="audit_verifier",
+            metric="lineage_fraction",
+            value=1.0,
+            source_refs=["audit:synthetic-001"],
+            passed_acceptance_rule=True,
+        ),
+    ]
+    result = make_tevv_result(
+        plan,
+        measurements=measurements,
+        synthesized_findings=["Synthetic campaign met the declared internal acceptance rules."],
+        unresolved_questions=["No physical or external environment was evaluated."],
+        decision="ADVANCE_TO_NEXT_SYNTHETIC_GATE_ONLY",
+    )
+    assert result.plan_digest == plan_digest(plan)
+    assert result.nist_conformance_claimed is False
+    assert result.physical_validation_claimed is False
+    assert verify_result_digest(result) is True
+
+
+def test_result_digest_detects_tampering():
+    plan = _plan()
+    result = make_tevv_result(
+        plan,
+        measurements=[],
+        synthesized_findings=[],
+        unresolved_questions=["No measurements collected."],
+        decision="NO_DECISION",
+    )
+    tampered = result.model_copy(update={"decision": "PROMOTE"})
+    assert verify_result_digest(tampered) is False

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/tevv_athlon.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/tevv_athlon.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import canonical_digest
+
+
+class TEVVStage(str, Enum):
+    ARTICULATE_ORGANIZE = "Articulate & Organize"
+    DEFINE_CONSTRUCT = "Define & Construct"
+    APPLY_MEASURE = "Apply & Measure"
+    SYNTHESIZE_INTERROGATE = "Synthesize & Interrogate"
+
+
+class ToolCategory(str, Enum):
+    MODEL_TESTING = "MODEL_TESTING"
+    RED_TEAMING = "RED_TEAMING"
+    FIELD_USER_TESTING = "FIELD_USER_TESTING"
+    SIMULATION = "SIMULATION"
+    HUMAN_REVIEW = "HUMAN_REVIEW"
+    OTHER = "OTHER"
+
+
+class MetrologyBlock(BaseModel):
+    block_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    definition: str = Field(min_length=1)
+    evidence_required: list[str] = Field(min_length=1)
+    trustworthiness_characteristics: list[str] = Field(default_factory=list)
+    acceptance_rule: str | None = None
+
+
+class TEVVTool(BaseModel):
+    tool_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    category: ToolCategory
+    description: str = Field(min_length=1)
+    version_or_digest: str | None = None
+    source_refs: list[str] = Field(default_factory=list)
+
+
+class TEVVEvent(BaseModel):
+    event_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    block_ids: list[str] = Field(min_length=1)
+    tool_ids: list[str] = Field(min_length=1)
+    expected_evidence: list[str] = Field(min_length=1)
+    adversarial: bool = False
+    physical_execution_required: bool = False
+
+
+class TEVVAthlonPlan(BaseModel):
+    schema: str = "ws-prime-tevv-athlon-plan-1"
+    plan_id: str = Field(pattern=r"^WS-TEVV-[0-9a-f]{16}$")
+    system_id: str = Field(min_length=1)
+    evaluation_goal: str = Field(min_length=1)
+    decision_use: str = Field(min_length=1)
+    operational_context: str = Field(min_length=1)
+    stakeholders: list[str] = Field(min_length=1)
+    lifecycle_stages: list[str] = Field(min_length=1)
+    system_attributes: list[str] = Field(min_length=1)
+    blocks: list[MetrologyBlock] = Field(min_length=1)
+    tools: list[TEVVTool] = Field(min_length=1)
+    events: list[TEVVEvent] = Field(min_length=1)
+    stage_order: list[TEVVStage] = Field(
+        default_factory=lambda: [
+            TEVVStage.ARTICULATE_ORGANIZE,
+            TEVVStage.DEFINE_CONSTRUCT,
+            TEVVStage.APPLY_MEASURE,
+            TEVVStage.SYNTHESIZE_INTERROGATE,
+        ]
+    )
+    reference_status: str = "NIST_AI_200_2_INITIAL_PUBLIC_DRAFT_AUGUST_2026"
+    nist_conformance_claimed: bool = False
+    nist_endorsement_claimed: bool = False
+    certification_claimed: bool = False
+    external_execution_authorized: bool = False
+    physical_validation_claimed: bool = False
+
+    @model_validator(mode="after")
+    def validate_contract(self) -> "TEVVAthlonPlan":
+        expected_stages = [
+            TEVVStage.ARTICULATE_ORGANIZE,
+            TEVVStage.DEFINE_CONSTRUCT,
+            TEVVStage.APPLY_MEASURE,
+            TEVVStage.SYNTHESIZE_INTERROGATE,
+        ]
+        if self.stage_order != expected_stages:
+            raise ValueError("TEVV stage order must preserve the four-stage draft sequence")
+        if self.nist_conformance_claimed or self.nist_endorsement_claimed or self.certification_claimed:
+            raise ValueError("PRIME-TEVV may not self-claim NIST conformance, endorsement, or certification")
+        if self.external_execution_authorized:
+            raise ValueError("PRIME-TEVV planning may not self-authorize external execution")
+        if self.physical_validation_claimed:
+            raise ValueError("PRIME-TEVV planning may not self-claim physical validation")
+
+        block_ids = [block.block_id for block in self.blocks]
+        tool_ids = [tool.tool_id for tool in self.tools]
+        event_ids = [event.event_id for event in self.events]
+        if len(set(block_ids)) != len(block_ids):
+            raise ValueError("duplicate Metrology Block IDs")
+        if len(set(tool_ids)) != len(tool_ids):
+            raise ValueError("duplicate Tool IDs")
+        if len(set(event_ids)) != len(event_ids):
+            raise ValueError("duplicate Event IDs")
+
+        known_blocks = set(block_ids)
+        known_tools = set(tool_ids)
+        covered_blocks: set[str] = set()
+        for event in self.events:
+            unknown_blocks = set(event.block_ids) - known_blocks
+            unknown_tools = set(event.tool_ids) - known_tools
+            if unknown_blocks:
+                raise ValueError(f"event references unknown Blocks: {sorted(unknown_blocks)}")
+            if unknown_tools:
+                raise ValueError(f"event references unknown Tools: {sorted(unknown_tools)}")
+            covered_blocks.update(event.block_ids)
+        missing = known_blocks - covered_blocks
+        if missing:
+            raise ValueError(f"every Metrology Block requires at least one Event: {sorted(missing)}")
+        return self
+
+
+class TEVVMeasurement(BaseModel):
+    measurement_id: str = Field(min_length=1)
+    event_id: str = Field(min_length=1)
+    block_id: str = Field(min_length=1)
+    tool_id: str = Field(min_length=1)
+    metric: str = Field(min_length=1)
+    value: Any
+    units: str | None = None
+    source_refs: list[str] = Field(min_length=1)
+    uncertainty: Any | None = None
+    passed_acceptance_rule: bool | None = None
+
+
+class TEVVAthlonResult(BaseModel):
+    schema: str = "ws-prime-tevv-athlon-result-1"
+    plan_id: str = Field(pattern=r"^WS-TEVV-[0-9a-f]{16}$")
+    plan_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    measurements: list[TEVVMeasurement] = Field(default_factory=list)
+    synthesized_findings: list[str] = Field(default_factory=list)
+    unresolved_questions: list[str] = Field(default_factory=list)
+    decision: str = Field(min_length=1)
+    external_execution_performed: bool = False
+    physical_validation_claimed: bool = False
+    nist_conformance_claimed: bool = False
+    nist_endorsement_claimed: bool = False
+    result_digest: str = ""
+
+    @model_validator(mode="after")
+    def fail_closed(self) -> "TEVVAthlonResult":
+        if self.external_execution_performed:
+            raise ValueError("TEVV result may not claim external execution without separate evidence")
+        if self.physical_validation_claimed:
+            raise ValueError("TEVV result may not self-claim physical validation")
+        if self.nist_conformance_claimed or self.nist_endorsement_claimed:
+            raise ValueError("TEVV result may not self-claim NIST conformance or endorsement")
+        return self
+
+
+def _plan_material(payload: dict[str, Any]) -> dict[str, Any]:
+    material = dict(payload)
+    material.pop("plan_id", None)
+    return material
+
+
+def make_tevv_plan(**kwargs: Any) -> TEVVAthlonPlan:
+    provisional = {
+        "plan_id": "WS-TEVV-0000000000000000",
+        **kwargs,
+    }
+    validated = TEVVAthlonPlan.model_validate(provisional)
+    material = _plan_material(validated.model_dump(mode="json"))
+    plan_id = "WS-TEVV-" + canonical_digest(material).split(":", 1)[1][:16]
+    return TEVVAthlonPlan.model_validate({**validated.model_dump(mode="json"), "plan_id": plan_id})
+
+
+def plan_digest(plan: TEVVAthlonPlan) -> str:
+    return canonical_digest(plan.model_dump(mode="json"))
+
+
+def validate_measurements(plan: TEVVAthlonPlan, measurements: list[TEVVMeasurement]) -> None:
+    events = {event.event_id: event for event in plan.events}
+    blocks = {block.block_id for block in plan.blocks}
+    tools = {tool.tool_id for tool in plan.tools}
+    seen: set[str] = set()
+    for measurement in measurements:
+        if measurement.measurement_id in seen:
+            raise ValueError(f"duplicate measurement ID: {measurement.measurement_id}")
+        seen.add(measurement.measurement_id)
+        if measurement.event_id not in events:
+            raise ValueError(f"measurement references unknown Event: {measurement.event_id}")
+        if measurement.block_id not in blocks:
+            raise ValueError(f"measurement references unknown Block: {measurement.block_id}")
+        if measurement.tool_id not in tools:
+            raise ValueError(f"measurement references unknown Tool: {measurement.tool_id}")
+        event = events[measurement.event_id]
+        if measurement.block_id not in event.block_ids:
+            raise ValueError("measurement Block is not assigned to its Event")
+        if measurement.tool_id not in event.tool_ids:
+            raise ValueError("measurement Tool is not assigned to its Event")
+
+
+def make_tevv_result(
+    plan: TEVVAthlonPlan,
+    *,
+    measurements: list[TEVVMeasurement],
+    synthesized_findings: list[str],
+    unresolved_questions: list[str],
+    decision: str,
+) -> TEVVAthlonResult:
+    validate_measurements(plan, measurements)
+    payload = {
+        "plan_id": plan.plan_id,
+        "plan_digest": plan_digest(plan),
+        "measurements": [item.model_dump(mode="json") for item in measurements],
+        "synthesized_findings": synthesized_findings,
+        "unresolved_questions": unresolved_questions,
+        "decision": decision,
+        "external_execution_performed": False,
+        "physical_validation_claimed": False,
+        "nist_conformance_claimed": False,
+        "nist_endorsement_claimed": False,
+    }
+    material = {"schema": "ws-prime-tevv-athlon-result-1", **payload, "result_digest": ""}
+    digest_material = dict(material)
+    digest_material.pop("result_digest")
+    return TEVVAthlonResult.model_validate(
+        {**material, "result_digest": canonical_digest(digest_material)}
+    )
+
+
+def verify_result_digest(result: TEVVAthlonResult) -> bool:
+    payload = result.model_dump(mode="json")
+    claimed = payload.pop("result_digest")
+    return claimed == canonical_digest(payload)


### PR DESCRIPTION
## Summary

Adds a claims-controlled PRIME-TEVV planning/result contract and cross-lane templates informed by the NIST AI 200-2 initial public draft.

## Boundaries

- No NIST conformance, endorsement, certification, accreditation, or approval is claimed.
- Planning cannot self-authorize external execution.
- Synthetic/software TEVV does not substitute for physical, regulatory, clinical, classified, flight, facility, or partner validation.
- The draft mapping must be rechecked when NIST revises or finalizes the source.

## Corrective action

Push CI initially exposed one test-fixture ordering defect: the uncovered-block negative test referenced an unknown block and therefore triggered the earlier unknown-reference validator. Commit `df728418359734debe4d261837bc8e22f26e23d7` adds a valid covered block and leaves a separate orphan block so the test reaches the intended coverage validator without weakening production checks.

## Merge control

Draft only. Do not merge until every protected workflow is green on the exact head and review findings are dispositioned.