### PR TITLE
PRIME-TEVV: bind qualification evidence into explicit TEVV measurements

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_tevv_qualification_bridge.py
+++ b/deployments/sara_verified_local_v1/tests/test_tevv_qualification_bridge.py
@@ -1,0 +1,260 @@
+import copy
+
+import pytest
+
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    EvidenceScope,
+    ForecastHorizon,
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ResultStatus,
+    ReviewRecord,
+    ReviewStatus,
+    SourceRecord,
+    SourceStatus,
+    SupersessionRecord,
+    SupersessionState,
+)
+from worldshepherd_sara.tevv_athlon import (
+    MetrologyBlock,
+    TEVVEvent,
+    TEVVTool,
+    ToolCategory,
+    make_tevv_plan,
+)
+from worldshepherd_sara.tevv_qualification_bridge import (
+    QualificationTEVVBinding,
+    compile_tevv_qualification_bundle,
+    qualification_measurements,
+    verify_tevv_qualification_bundle,
+)
+
+
+REQ_ID = "PRE-RD-2026-9001"
+QE_ID = "WS-QE-2026-9001"
+
+
+def _requirement() -> RequirementDeltaRecord:
+    return RequirementDeltaRecord(
+        requirement_delta_id=REQ_ID,
+        demand_class=DemandClass.CONFIRMED_DEMAND,
+        source=SourceRecord(
+            title="Synthetic governed requirement",
+            agency="Worldshepherd internal test",
+            url="https://example.invalid/tevv-bridge-test",
+            solicitation_or_topic="TEST-TEVV-BRIDGE",
+            source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED,
+            retrieved_utc="2026-09-08T17:30:00Z",
+        ),
+        statement="Bound qualification evidence must remain attributable when routed into PRIME-TEVV.",
+        recurrence="Synthetic regression fixture",
+        forecast_horizon=ForecastHorizon.D0_90,
+        affected_lanes=["PRIME-TEVV", "PVK", "PRE"],
+        existing_capability=["digest-bound qualification records"],
+        capability_status=[CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        missing_capability=["typed TEVV handoff"],
+        experiment_or_demonstration_needed=["software regression test"],
+        evidence_target=["explicit Event/Block/Tool binding"],
+        claims_boundary=["Synthetic software test does not establish external or physical validation."],
+    )
+
+
+def _plan(*, physical: bool = False):
+    return make_tevv_plan(
+        system_id="SARA-TEST",
+        evaluation_goal="Measure blocked prohibited actions with attributable evidence.",
+        decision_use="Internal software readiness only.",
+        operational_context="Synthetic CI fixture.",
+        stakeholders=["CRE1AWS", "SSPADAWANZZ"],
+        lifecycle_stages=["test"],
+        system_attributes=["authorization", "evidence lineage"],
+        blocks=[
+            MetrologyBlock(
+                block_id="B-AUTH",
+                name="Unauthorized action blocking",
+                definition="Fraction of prohibited actions prevented by policy.",
+                evidence_required=["attempt", "policy decision", "execution state"],
+                acceptance_rule="Declared separately by the governed test campaign.",
+            )
+        ],
+        tools=[
+            TEVVTool(
+                tool_id="T-POLICY",
+                name="Policy trace comparator",
+                category=ToolCategory.MODEL_TESTING,
+                description="Compares attempted actions with policy and execution traces.",
+                version_or_digest="sha256:" + "a" * 64,
+            )
+        ],
+        events=[
+            TEVVEvent(
+                event_id="E-PROHIBITED",
+                name="Prohibited-action campaign",
+                description="Exercise known prohibited requests in a synthetic environment.",
+                block_ids=["B-AUTH"],
+                tool_ids=["T-POLICY"],
+                expected_evidence=["policy trace", "execution trace"],
+                adversarial=True,
+                physical_execution_required=physical,
+            )
+        ],
+    )
+
+
+def _evidence(
+    *,
+    review_status: ReviewStatus = ReviewStatus.ACCEPTED,
+    supersession_state: SupersessionState = SupersessionState.CURRENT,
+    evidence_scope: EvidenceScope = EvidenceScope.SOFTWARE,
+    metrics=None,
+    negative_evidence=None,
+    requirement_id: str = REQ_ID,
+) -> QualificationEvidenceRecord:
+    review = ReviewRecord(
+        status=review_status,
+        reviewer="test-reviewer" if review_status is not ReviewStatus.UNREVIEWED else None,
+        reviewed_utc="2026-09-08T17:31:00Z" if review_status is not ReviewStatus.UNREVIEWED else None,
+    )
+    supersession = SupersessionRecord(
+        state=supersession_state,
+        superseded_by=("WS-QE-2026-9999" if supersession_state is SupersessionState.SUPERSEDED else None),
+    )
+    return QualificationEvidenceRecord(
+        qualification_id=QE_ID,
+        requirement_id=requirement_id,
+        test_id="TEST-TEVV-BRIDGE-1",
+        evidence_scope=evidence_scope,
+        capability_status=(
+            CapabilityStatus.REQUIRES_LAB_VALIDATION
+            if evidence_scope is EvidenceScope.PHYSICAL
+            else CapabilityStatus.IMPLEMENTED_IN_SOFTWARE
+        ),
+        environment_digest="sha256:" + "b" * 64,
+        configuration_digest="sha256:" + "c" * 64,
+        inputs=[{"fixture": "synthetic"}],
+        outputs=[{"blocked": 10, "attempted": 10}],
+        metrics=(metrics if metrics is not None else [{"name": "blocked_fraction", "value": 1.0, "units": "fraction"}]),
+        uncertainty=[{"kind": "counting", "note": "synthetic exact fixture"}],
+        result=ResultStatus.PASS,
+        rationale="Synthetic policy test passed its own qualification rule.",
+        negative_evidence=(negative_evidence if negative_evidence is not None else [{"case": "none observed in fixture"}]),
+        software_commit="deadbeef",
+        executed_utc="2026-09-08T17:32:00Z",
+        operator="pytest",
+        physical_validation_performed=False,
+        review=review,
+        supersession=supersession,
+    )
+
+
+def _binding(**overrides) -> QualificationTEVVBinding:
+    payload = {
+        "binding_id": "WS-TEVV-BIND-auth-1",
+        "qualification_id": QE_ID,
+        "metric_index": 0,
+        "event_id": "E-PROHIBITED",
+        "block_id": "B-AUTH",
+        "tool_id": "T-POLICY",
+    }
+    payload.update(overrides)
+    return QualificationTEVVBinding(**payload)
+
+
+def test_compile_bridge_preserves_provenance_negative_evidence_and_no_auto_acceptance():
+    requirement = _requirement()
+    plan = _plan()
+    evidence = _evidence()
+    bundle = compile_tevv_qualification_bundle(requirement, plan, [evidence], [_binding()])
+
+    assert verify_tevv_qualification_bundle(bundle) is True
+    assert bundle["capture_ready_source"] is True
+    assert bundle["human_review_pending"] is False
+    assert bundle["physical_validation_claimed"] is False
+    assert bundle["external_execution_claimed"] is False
+    assert bundle["nist_conformance_claimed"] is False
+    assert bundle["negative_evidence"][0]["qualification_id"] == QE_ID
+
+    measurement = bundle["measurement_candidates"][0]
+    assert measurement["metric"] == "blocked_fraction"
+    assert measurement["value"] == 1.0
+    assert measurement["passed_acceptance_rule"] is None
+    assert QE_ID in measurement["source_refs"]
+    assert evidence.environment_digest in measurement["source_refs"]
+    assert evidence.configuration_digest in measurement["source_refs"]
+
+
+def test_unreviewed_evidence_is_retained_but_marked_pending():
+    bundle = compile_tevv_qualification_bundle(
+        _requirement(), _plan(), [_evidence(review_status=ReviewStatus.UNREVIEWED)], [_binding()]
+    )
+    assert bundle["human_review_pending"] is True
+    assert bundle["unreviewed_qualification_ids"] == [QE_ID]
+
+
+def test_requirement_id_mismatch_fails_closed():
+    with pytest.raises(ValueError, match="does not match"):
+        compile_tevv_qualification_bundle(
+            _requirement(),
+            _plan(),
+            [_evidence(requirement_id="PRE-RD-2026-9002")],
+            [_binding()],
+        )
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        _evidence(review_status=ReviewStatus.REJECTED),
+        _evidence(supersession_state=SupersessionState.SUPERSEDED),
+        _evidence(supersession_state=SupersessionState.REVOKED),
+    ],
+)
+def test_rejected_superseded_or_revoked_evidence_cannot_be_bound(record):
+    with pytest.raises(ValueError):
+        qualification_measurements(_plan(), [record], [_binding()])
+
+
+def test_binding_must_resolve_to_event_block_tool_membership():
+    with pytest.raises(ValueError, match="unknown Block"):
+        qualification_measurements(
+            _plan(), [_evidence()], [_binding(block_id="B-NOT-IN-PLAN")]
+        )
+
+
+def test_metric_requires_explicit_value():
+    with pytest.raises(ValueError, match="explicit value"):
+        qualification_measurements(
+            _plan(), [_evidence(metrics=[{"name": "blocked_fraction"}])], [_binding()]
+        )
+
+
+def test_physical_scope_never_auto_promotes_physical_validation():
+    bundle = compile_tevv_qualification_bundle(
+        _requirement(),
+        _plan(physical=True),
+        [_evidence(evidence_scope=EvidenceScope.PHYSICAL)],
+        [_binding()],
+    )
+    assert bundle["physical_scope_present"] is True
+    assert bundle["physical_validation_claimed"] is False
+    assert bundle["evidence_index"][0]["physical_validation_performed"] is False
+
+
+def test_metric_level_acceptance_can_be_carried_only_when_explicit():
+    measurements = qualification_measurements(
+        _plan(),
+        [_evidence(metrics=[{"name": "blocked_fraction", "value": 1.0, "passed_acceptance_rule": True}])],
+        [_binding()],
+    )
+    assert measurements[0].passed_acceptance_rule is True
+
+
+def test_bundle_digest_detects_tamper():
+    bundle = compile_tevv_qualification_bundle(
+        _requirement(), _plan(), [_evidence()], [_binding()]
+    )
+    tampered = copy.deepcopy(bundle)
+    tampered["measurement_candidates"][0]["value"] = 0.0
+    assert verify_tevv_qualification_bundle(tampered) is False

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/tevv_qualification_bridge.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/tevv_qualification_bridge.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .qualification import (
+    QualificationEvidenceRecord,
+    RequirementDeltaRecord,
+    ReviewStatus,
+    SupersessionState,
+    canonical_digest,
+)
+from .tevv_athlon import TEVVAthlonPlan, TEVVMeasurement, plan_digest, validate_measurements
+
+
+class QualificationTEVVBinding(BaseModel):
+    """Explicitly bind one qualification metric to one TEVV Event/Block/Tool tuple.
+
+    The bridge intentionally refuses implicit semantic matching. A human or a
+    separately governed workflow must choose which qualification metric is
+    evidence for which TEVV measurement concept.
+    """
+
+    binding_id: str = Field(pattern=r"^WS-TEVV-BIND-[0-9a-zA-Z._-]+$")
+    qualification_id: str = Field(pattern=r"^WS-QE-[0-9]{4}-[0-9]{4,}$")
+    metric_index: int = Field(ge=0)
+    event_id: str = Field(min_length=1)
+    block_id: str = Field(min_length=1)
+    tool_id: str = Field(min_length=1)
+    metric_name_override: str | None = None
+
+
+def _metric_parts(metric: dict[str, Any], binding: QualificationTEVVBinding) -> tuple[str, Any, str | None, Any | None, bool | None]:
+    name = binding.metric_name_override or metric.get("name") or metric.get("metric") or metric.get("id")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(
+            f"qualification metric {binding.qualification_id}[{binding.metric_index}] requires a name/metric/id or metric_name_override"
+        )
+    if "value" not in metric:
+        raise ValueError(
+            f"qualification metric {binding.qualification_id}[{binding.metric_index}] requires an explicit value"
+        )
+    units = metric.get("units")
+    if units is not None and not isinstance(units, str):
+        raise ValueError("metric units must be a string when provided")
+    passed = metric.get("passed_acceptance_rule")
+    if passed is not None and not isinstance(passed, bool):
+        raise ValueError("passed_acceptance_rule must be boolean when provided")
+    return name.strip(), metric["value"], units, metric.get("uncertainty"), passed
+
+
+def qualification_measurements(
+    plan: TEVVAthlonPlan,
+    evidence: list[QualificationEvidenceRecord],
+    bindings: list[QualificationTEVVBinding],
+) -> list[TEVVMeasurement]:
+    """Create TEVV measurement candidates from explicitly bound qualification metrics.
+
+    This function does not infer acceptance from a qualification record's PASS
+    status, does not promote review state, and does not claim physical or
+    external validation. Event/Block/Tool membership is revalidated against the
+    supplied TEVV plan before returning measurements.
+    """
+
+    by_id: dict[str, QualificationEvidenceRecord] = {}
+    for record in evidence:
+        if record.qualification_id in by_id:
+            raise ValueError(f"duplicate qualification evidence ID: {record.qualification_id}")
+        by_id[record.qualification_id] = record
+
+    seen_binding_ids: set[str] = set()
+    seen_coordinates: set[tuple[str, int, str, str, str]] = set()
+    measurements: list[TEVVMeasurement] = []
+
+    for binding in bindings:
+        if binding.binding_id in seen_binding_ids:
+            raise ValueError(f"duplicate TEVV binding ID: {binding.binding_id}")
+        seen_binding_ids.add(binding.binding_id)
+
+        coordinate = (
+            binding.qualification_id,
+            binding.metric_index,
+            binding.event_id,
+            binding.block_id,
+            binding.tool_id,
+        )
+        if coordinate in seen_coordinates:
+            raise ValueError(f"duplicate qualification-to-TEVV coordinate: {coordinate}")
+        seen_coordinates.add(coordinate)
+
+        record = by_id.get(binding.qualification_id)
+        if record is None:
+            raise ValueError(f"binding references unknown qualification evidence: {binding.qualification_id}")
+        if record.supersession.state is not SupersessionState.CURRENT:
+            raise ValueError(
+                f"qualification evidence {record.qualification_id} is not CURRENT: {record.supersession.state.value}"
+            )
+        if record.review.status is ReviewStatus.REJECTED:
+            raise ValueError(f"qualification evidence {record.qualification_id} was rejected in review")
+        if binding.metric_index >= len(record.metrics):
+            raise ValueError(
+                f"qualification metric index out of range for {record.qualification_id}: {binding.metric_index}"
+            )
+
+        metric = record.metrics[binding.metric_index]
+        if not isinstance(metric, dict):
+            raise ValueError("qualification metrics must be mappings")
+        name, value, units, metric_uncertainty, passed = _metric_parts(metric, binding)
+        uncertainty: Any | None = metric_uncertainty
+        if uncertainty is None and record.uncertainty:
+            uncertainty = record.uncertainty
+
+        source_refs = [
+            record.qualification_id,
+            record.environment_digest,
+            record.configuration_digest,
+        ]
+        if record.software_commit:
+            source_refs.append(record.software_commit)
+
+        measurements.append(
+            TEVVMeasurement(
+                measurement_id=f"{binding.binding_id}-M",
+                event_id=binding.event_id,
+                block_id=binding.block_id,
+                tool_id=binding.tool_id,
+                metric=name,
+                value=value,
+                units=units,
+                source_refs=source_refs,
+                uncertainty=uncertainty,
+                passed_acceptance_rule=passed,
+            )
+        )
+
+    validate_measurements(plan, measurements)
+    return measurements
+
+
+def compile_tevv_qualification_bundle(
+    requirement: RequirementDeltaRecord,
+    plan: TEVVAthlonPlan,
+    evidence: list[QualificationEvidenceRecord],
+    bindings: list[QualificationTEVVBinding],
+) -> dict[str, Any]:
+    """Compile a digest-bound PRE/PVK -> PRIME-TEVV handoff artifact.
+
+    The bundle is an evidence handoff, not a TEVV decision or an authorization
+    to execute. It retains negative evidence and review state, and it never
+    upgrades software/simulation evidence into physical validation.
+    """
+
+    for record in evidence:
+        if record.requirement_id != requirement.requirement_delta_id:
+            raise ValueError(
+                f"qualification evidence {record.qualification_id} requirement_id {record.requirement_id!r} "
+                f"does not match {requirement.requirement_delta_id!r}"
+            )
+
+    measurements = qualification_measurements(plan, evidence, bindings)
+    evidence_index = [
+        {
+            "qualification_id": record.qualification_id,
+            "record_digest": canonical_digest(record),
+            "result": record.result.value,
+            "evidence_scope": record.evidence_scope.value,
+            "capability_status": record.capability_status.value,
+            "review_status": record.review.status.value,
+            "supersession_state": record.supersession.state.value,
+            "physical_validation_performed": record.physical_validation_performed,
+        }
+        for record in evidence
+    ]
+    negative_evidence = [
+        {
+            "qualification_id": record.qualification_id,
+            "items": record.negative_evidence,
+        }
+        for record in evidence
+        if record.negative_evidence
+    ]
+    unreviewed = [
+        record.qualification_id
+        for record in evidence
+        if record.review.status is ReviewStatus.UNREVIEWED
+    ]
+    physical_scope_present = any(
+        record.evidence_scope.value == "PHYSICAL" for record in evidence
+    ) or any(event.physical_execution_required for event in plan.events)
+
+    bundle: dict[str, Any] = {
+        "schema": "ws-prime-tevv-qualification-bridge-1",
+        "requirement_id": requirement.requirement_delta_id,
+        "requirement_digest": canonical_digest(requirement),
+        "plan_id": plan.plan_id,
+        "plan_digest": plan_digest(plan),
+        "capture_ready_source": requirement.capture_ready(),
+        "measurement_candidates": [item.model_dump(mode="json") for item in measurements],
+        "evidence_index": evidence_index,
+        "negative_evidence": negative_evidence,
+        "unreviewed_qualification_ids": unreviewed,
+        "human_review_pending": bool(unreviewed),
+        "physical_scope_present": physical_scope_present,
+        "physical_validation_claimed": False,
+        "external_execution_claimed": False,
+        "nist_conformance_claimed": False,
+        "claims_boundary": [
+            "This artifact binds existing qualification evidence to a PRIME-TEVV plan; it is not itself a TEVV decision.",
+            "Qualification PASS status is not automatically converted into a TEVV acceptance-rule pass.",
+            "Software or simulation evidence cannot establish physical validation, field performance, certification, accreditation, partner validation, or operational authority.",
+            "Use of the NIST AI 200-2 initial public draft structure does not establish NIST conformance, endorsement, certification, or approval.",
+            *requirement.claims_boundary,
+        ],
+    }
+    bundle["bundle_digest"] = canonical_digest(bundle)
+    return bundle
+
+
+def verify_tevv_qualification_bundle(bundle: dict[str, Any]) -> bool:
+    payload = dict(bundle)
+    claimed = payload.pop("bundle_digest", None)
+    return isinstance(claimed, str) and claimed == canonical_digest(payload)


### PR DESCRIPTION
## Summary

Adds the first typed PRE/PVK -> PRIME-TEVV handoff.

### Bridge behavior
- Every TEVV measurement candidate requires an explicit binding to one qualification record, metric index, Event, Block, and Tool.
- Qualification records must match the supplied PRE requirement.
- Rejected, superseded, and revoked evidence fail closed.
- Unreviewed evidence may be retained for analysis but is explicitly marked `human_review_pending`.
- Qualification-level `PASS` is **not** converted into TEVV metric acceptance; `passed_acceptance_rule` is carried only when explicitly present on the bound metric.
- Negative evidence, environment/configuration digests, software commit, evidence scope, review state, and qualification result remain attributable.
- Event/Block/Tool membership is revalidated against the TEVV plan.

### Physical/external boundary
The bridge may record that physical scope is present, but it always emits `physical_validation_claimed=false`, `external_execution_claimed=false`, and `nist_conformance_claimed=false`. Software/simulation evidence cannot be promoted into field, facility, partner, certification, or physical claims by this bridge.

### Regression coverage
Tests cover valid provenance, negative-evidence retention, unreviewed evidence, requirement mismatch, rejected/superseded/revoked evidence, invalid Event/Block/Tool bindings, missing metric values, explicit-vs-inferred acceptance, physical-scope non-promotion, and digest tamper detection.

Draft only. Merge only after protected CI is green on the exact head and any review findings are dispositioned.