### PR TITLE
NIST TEVV-Athlon: prepare non-proprietary public comment candidate

### DIFF
--- a/deployments/sara_verified_local_v1/fixtures/nist_tevv_athlon_public_comment_candidate_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/nist_tevv_athlon_public_comment_candidate_v1.json
@@ -1,0 +1,90 @@
+{
+  "schema": "ws-nist-tevv-athlon-public-comment-candidate-1",
+  "reference": {
+    "document": "NIST AI 200-2 ipd - The TEVV-Athlon Framework for Evaluating AI Systems",
+    "announcement_date": "2026-08-07",
+    "comment_deadline": "2026-10-06",
+    "source": "https://doi.org/10.6028/NIST.AI.200-2.ipd",
+    "nist_page": "https://www.nist.gov/artificial-intelligence/ai-research/tevv-athlon-framework-evaluating-ai-systems"
+  },
+  "submission_state": "PREPARED_NOT_SUBMITTED",
+  "submission_requires_explicit_human_approval": true,
+  "submitter_identity": "TO_BE_SUPPLIED_BY_HUMAN",
+  "proprietary_information_included": false,
+  "public_release_assumed_possible": true,
+  "implementation_basis": {
+    "scope": "Non-proprietary lessons from implementing a draft-informed TEVV planning/evidence contract for software, simulation, agentic, cyber-physical, and research-assurance workflows.",
+    "not_claimed": [
+      "NIST conformance",
+      "NIST endorsement",
+      "NIST certification",
+      "NIST approval",
+      "formal standards-body participation"
+    ]
+  },
+  "comment_themes": [
+    {
+      "id": "C1-STABLE-IDENTIFIERS",
+      "topic": "Stable identifiers and versioning for Blocks, Events, and Tools",
+      "observation": "Customized assessments become difficult to reproduce when concept labels are treated only as prose. Stable local identifiers plus explicit version or digest fields materially improve comparison, supersession, and replay.",
+      "suggestion": "Add guidance recommending stable identifiers and version/digest metadata for Blocks, Events, Tools, plans, and result artifacts, without prescribing one universal naming scheme.",
+      "nist_request_for_input_alignment": [2, 5, 6]
+    },
+    {
+      "id": "C2-EVIDENCE-PROVENANCE",
+      "topic": "Evidence provenance as a first-class TEVV property",
+      "observation": "A metric value alone is insufficient for high-assurance evaluation. Reviewers need to trace the measurement to source data, configuration, environment, software/model version, tool version, operator or automation context, and transformations.",
+      "suggestion": "Expand practical guidance so Events and Tools can emit provenance/lineage records alongside measurements, including immutable or digest-bound evidence references where appropriate.",
+      "nist_request_for_input_alignment": [3, 6]
+    },
+    {
+      "id": "C3-MEASUREMENT-VS-DECISION",
+      "topic": "Separate measurements, acceptance rules, and organizational decisions",
+      "observation": "A test-level PASS can be incorrectly propagated into a broader system-readiness decision. Likewise, a measurement can be useful evidence without satisfying an acceptance threshold.",
+      "suggestion": "Clarify that raw measurement, metric-specific acceptance, synthesized finding, and final decision are distinct artifacts or states and should not be implicitly promoted across those layers.",
+      "nist_request_for_input_alignment": [1, 3, 5]
+    },
+    {
+      "id": "C4-NEGATIVE-EVIDENCE",
+      "topic": "Retain negative, contradictory, and inconclusive evidence",
+      "observation": "Optimization pressure can cause failed, null, contradictory, or inconclusive trials to disappear from a final assessment even though they are often the most informative evidence for trustworthiness and distribution shift.",
+      "suggestion": "Recommend explicit retention and synthesis of negative evidence, contradictions, failed Events, null results, and unresolved questions rather than reporting only successful measurements.",
+      "nist_request_for_input_alignment": [2, 4, 6]
+    },
+    {
+      "id": "C5-REVIEW-SUPERSESSION",
+      "topic": "Review state, supersession, and stale evidence",
+      "observation": "Evidence can be valid when generated but later rejected, superseded, revoked, or made stale by configuration changes. A TEVV process needs a way to prevent such records from silently continuing to support decisions.",
+      "suggestion": "Add lifecycle guidance for review status, supersession/revocation, evidence freshness, and re-evaluation triggers after material system or environment changes.",
+      "nist_request_for_input_alignment": [2, 5, 6]
+    },
+    {
+      "id": "C6-EVIDENCE-SCOPE",
+      "topic": "Prevent cross-scope evidence promotion",
+      "observation": "Software or simulation evidence can validate software behavior while saying little about physical sensor accuracy, field performance, safety certification, clinical performance, facility integration, or other external properties.",
+      "suggestion": "Recommend labeling evidence scope (for example software, simulation, laboratory/physical, field/user, administrative) and explicitly prohibit unsupported promotion from one scope to another.",
+      "nist_request_for_input_alignment": [2, 3, 4]
+    },
+    {
+      "id": "C7-AGENTIC-EXECUTION-BOUNDARY",
+      "topic": "Agentic-system authorization and external-execution traces",
+      "observation": "For agentic systems, performance evaluation alone does not capture whether a system attempted or executed actions beyond its authorization boundary, which tools were invoked, or whether human approval requirements were obeyed.",
+      "suggestion": "For agentic-system examples, include Events/Blocks that measure proposed actions, authorization decisions, tool invocations, external side effects, human approvals, recovery behavior, and replayability.",
+      "nist_request_for_input_alignment": [2, 3, 4, 6]
+    },
+    {
+      "id": "C8-UNCERTAINTY-CALIBRATION",
+      "topic": "Uncertainty and calibration in synthesized findings",
+      "observation": "Point estimates can hide uncertainty, class imbalance, distribution shift, and disagreement between evaluators or tools.",
+      "suggestion": "Encourage uncertainty representation, calibration checks, confidence intervals or equivalent bounds when meaningful, and explicit recording of unresolved reviewer/tool disagreement in the Synthesize & Interrogate stage.",
+      "nist_request_for_input_alignment": [1, 2, 6]
+    }
+  ],
+  "proposed_closing": "The framework's extensibility is valuable because TEVV needs differ across statistical ML, multimodal models, agentic systems, and cyber-physical applications. The recommendations above aim to strengthen reproducibility and evidence custody while preserving the framework's intentionally customizable character.",
+  "claims_boundary": [
+    "This is a Worldshepherd-prepared public-comment candidate and has not been submitted to NIST.",
+    "No NIST response, engagement, acceptance, endorsement, or standards participation is claimed.",
+    "The candidate intentionally excludes proprietary technical details because NIST states comments may be publicly released and requests that comments not contain proprietary information.",
+    "Human review is required before any external submission."
+  ]
+}

--- a/deployments/sara_verified_local_v1/tests/test_nist_tevv_athlon_public_comment_candidate.py
+++ b/deployments/sara_verified_local_v1/tests/test_nist_tevv_athlon_public_comment_candidate.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "nist_tevv_athlon_public_comment_candidate_v1.json"
+
+
+def _payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_comment_candidate_is_prepared_but_not_submitted():
+    payload = _payload()
+    assert payload["submission_state"] == "PREPARED_NOT_SUBMITTED"
+    assert payload["submission_requires_explicit_human_approval"] is True
+    assert payload["submitter_identity"] == "TO_BE_SUPPLIED_BY_HUMAN"
+
+
+def test_candidate_preserves_public_release_and_nonproprietary_boundary():
+    payload = _payload()
+    assert payload["proprietary_information_included"] is False
+    assert payload["public_release_assumed_possible"] is True
+    boundary = " ".join(payload["claims_boundary"]).lower()
+    assert "has not been submitted" in boundary
+    assert "proprietary" in boundary
+    assert "human review" in boundary
+
+
+def test_reference_and_deadline_match_current_draft_state():
+    payload = _payload()
+    reference = payload["reference"]
+    assert reference["document"].startswith("NIST AI 200-2 ipd")
+    assert reference["comment_deadline"] == "2026-10-06"
+    assert reference["source"] == "https://doi.org/10.6028/NIST.AI.200-2.ipd"
+
+
+def test_comment_covers_core_evidence_governance_gaps():
+    payload = _payload()
+    themes = {item["id"]: item for item in payload["comment_themes"]}
+    expected = {
+        "C1-STABLE-IDENTIFIERS",
+        "C2-EVIDENCE-PROVENANCE",
+        "C3-MEASUREMENT-VS-DECISION",
+        "C4-NEGATIVE-EVIDENCE",
+        "C5-REVIEW-SUPERSESSION",
+        "C6-EVIDENCE-SCOPE",
+        "C7-AGENTIC-EXECUTION-BOUNDARY",
+        "C8-UNCERTAINTY-CALIBRATION",
+    }
+    assert expected == set(themes)
+    assert all(item["nist_request_for_input_alignment"] for item in themes.values())
+
+
+def test_candidate_does_not_claim_nist_status():
+    payload = _payload()
+    not_claimed = {item.lower() for item in payload["implementation_basis"]["not_claimed"]}
+    assert "nist conformance" in not_claimed
+    assert "nist endorsement" in not_claimed
+    assert "nist certification" in not_claimed
+    assert "nist approval" in not_claimed


### PR DESCRIPTION
Superseded by PR #121. PR #117 contained the first prepared-not-submitted NIST TEVV-Athlon comment candidate but was based on a mainline predating the merged PRIME-TEVV qualification bridge, MBSE TEVV campaign, APNT NIST gap baseline, and APNT v2 evidence contract. PR #121 rebuilds the public-safe candidate on current `main` and adds generalized implementation observations without proprietary detail. No NIST submission occurred from PR #117; no protection bypass or stale merge is being used.