### PR TITLE
APNT v2: define evidence input contract before changing detection logic

### DIFF
--- a/deployments/sara_verified_local_v1/fixtures/apnt_v2_input_evidence_contract_v1.json
+++ b/deployments/sara_verified_local_v1/fixtures/apnt_v2_input_evidence_contract_v1.json
@@ -1,0 +1,65 @@
+{
+  "schema": "ws-apnt-v2-input-evidence-contract-1",
+  "status": "DRAFT_INTERFACE_CONTRACT_NOT_IMPLEMENTED",
+  "purpose": "Define the minimum additional evidence categories required before revising the bounded APNT-awareness decision logic to address preserved NIST-profile-derived blind spots.",
+  "claims_boundary": [
+    "This contract does not implement detection, navigation, sensor fusion, anti-spoofing, timing integrity, or physical PNT resilience.",
+    "Thresholds and residual models must be justified by separately reviewed simulation, partner, laboratory, manufacturer, standards, or field evidence; they are not invented by this contract.",
+    "No source is considered independent merely because it has a different source_id or technology label.",
+    "Missing or invalid provenance must reduce trust or force explicit unknown state in a future design; this contract does not decide the operational response.",
+    "Physical sensor accuracy, integrity, susceptibility, common-mode behavior, and recovery thresholds require physical/partner validation."
+  ],
+  "evidence_categories": [
+    {
+      "category": "SOURCE_IDENTITY_AND_PROVENANCE",
+      "required_fields": ["source_id", "source_type", "provenance_state", "configuration_digest", "data_freshness_state", "time_basis_id"],
+      "allowed_unknowns": true,
+      "future_use": "Prevent a nominal confidence score from overriding missing lineage/configuration/freshness evidence."
+    },
+    {
+      "category": "SOURCE_HEALTH_AND_DECLARED_CONFIDENCE",
+      "required_fields": ["health", "declared_confidence"],
+      "allowed_unknowns": true,
+      "future_use": "Retain the existing bounded health/confidence awareness signal without treating it as sufficient evidence by itself."
+    },
+    {
+      "category": "CROSS_SOURCE_CONSISTENCY",
+      "required_fields": ["comparison_id", "source_ids", "observable_family", "residual_value", "residual_units", "threshold_reference", "comparison_validity_state"],
+      "allowed_unknowns": true,
+      "future_use": "Expose disagreements that may indicate bad data, modeling error, drift, manipulation, or loss of source independence; no cause is inferred from disagreement alone."
+    },
+    {
+      "category": "TIMING_INTEGRITY",
+      "required_fields": ["time_basis_id", "offset_value", "offset_units", "drift_value", "drift_units", "threshold_reference", "measurement_validity_state"],
+      "allowed_unknowns": true,
+      "future_use": "Permit timing degradation to be evaluated independently of position/navigation health."
+    },
+    {
+      "category": "DEPENDENCY_AND_INDEPENDENCE",
+      "required_fields": ["dependency_graph_digest", "source_ids", "shared_dependency_ids", "independence_assessment_state", "assessment_evidence_refs"],
+      "allowed_unknowns": true,
+      "future_use": "Prevent multiple apparently healthy sources with a shared upstream dependency from being treated as automatically independent corroboration."
+    },
+    {
+      "category": "RECOVERY_AND_REENTRY",
+      "required_fields": ["candidate_source_id", "pre_failure_state_ref", "recovery_evidence_refs", "reentry_threshold_reference", "cross_validation_state", "human_review_state"],
+      "allowed_unknowns": true,
+      "future_use": "Require explicit evidence before a previously degraded/untrusted source is considered for re-entry."
+    }
+  ],
+  "future_decision_invariants": [
+    "Do not infer manipulation merely from disagreement; distinguish anomaly detection from cause attribution.",
+    "Do not infer source independence from source count or source labels.",
+    "Do not silently replace missing evidence with nominal values.",
+    "Do not derive physical thresholds from synthetic fixture convenience values.",
+    "Do not execute recovery actions automatically; PRIME/human authorization boundaries remain separate.",
+    "Retain the original bounded v1 decision as a comparison baseline during any v2 TEVV campaign."
+  ],
+  "required_preimplementation_reviews": [
+    "field-by-field privacy/security/export-control review before any real platform data",
+    "source/threshold provenance review",
+    "failure-mode and common-cause analysis",
+    "TEVV plan defining false-positive/false-negative and unknown-state behavior",
+    "partner/laboratory review for any physical-source integrity assertion"
+  ]
+}

--- a/deployments/sara_verified_local_v1/tests/test_apnt_v2_input_evidence_contract.py
+++ b/deployments/sara_verified_local_v1/tests/test_apnt_v2_input_evidence_contract.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "apnt_v2_input_evidence_contract_v1.json"
+
+
+def _payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_contract_is_draft_and_does_not_claim_implementation():
+    payload = _payload()
+    assert payload["status"] == "DRAFT_INTERFACE_CONTRACT_NOT_IMPLEMENTED"
+    boundary = " ".join(payload["claims_boundary"]).lower()
+    assert "does not implement detection" in boundary
+    assert "physical" in boundary
+
+
+def test_contract_covers_all_preserved_blind_spot_evidence_categories():
+    payload = _payload()
+    categories = {item["category"] for item in payload["evidence_categories"]}
+    assert categories == {
+        "SOURCE_IDENTITY_AND_PROVENANCE",
+        "SOURCE_HEALTH_AND_DECLARED_CONFIDENCE",
+        "CROSS_SOURCE_CONSISTENCY",
+        "TIMING_INTEGRITY",
+        "DEPENDENCY_AND_INDEPENDENCE",
+        "RECOVERY_AND_REENTRY",
+    }
+
+
+def test_thresholds_require_references_instead_of_embedded_fixture_constants():
+    payload = _payload()
+    by_category = {item["category"]: item for item in payload["evidence_categories"]}
+    assert "threshold_reference" in by_category["CROSS_SOURCE_CONSISTENCY"]["required_fields"]
+    assert "threshold_reference" in by_category["TIMING_INTEGRITY"]["required_fields"]
+    assert "reentry_threshold_reference" in by_category["RECOVERY_AND_REENTRY"]["required_fields"]
+    serialized = json.dumps(payload).lower()
+    assert "thresholds and residual models must be justified" in serialized
+
+
+def test_future_invariants_preserve_unknowns_cause_separation_and_human_authority():
+    payload = _payload()
+    invariants = " ".join(payload["future_decision_invariants"]).lower()
+    assert "do not infer manipulation" in invariants
+    assert "do not infer source independence" in invariants
+    assert "missing evidence" in invariants
+    assert "do not execute recovery actions automatically" in invariants
+    assert "v1 decision" in invariants
+
+
+def test_real_data_and_physical_assertions_require_separate_review():
+    reviews = " ".join(_payload()["required_preimplementation_reviews"]).lower()
+    assert "privacy/security/export-control" in reviews
+    assert "failure-mode" in reviews
+    assert "tevv" in reviews
+    assert "partner/laboratory" in reviews


### PR DESCRIPTION
## Summary

Defines the minimum evidence categories required before modifying the bounded APNT-awareness demonstrator to address the four preserved NIST-profile-derived blind spots now merged in main.

### Required evidence categories
- source identity, provenance, configuration, freshness, and time basis;
- source health and declared confidence;
- cross-source consistency/residual evidence with referenced thresholds;
- timing-integrity evidence independent of position/navigation health;
- dependency/independence graph evidence, including shared upstream dependencies;
- recovery/re-entry evidence with referenced thresholds and human review state.

### Design invariants
- disagreement may indicate an anomaly but cannot itself establish manipulation;
- multiple sources are not assumed independent from their count or labels;
- missing evidence is never silently replaced with nominal values;
- physical thresholds are not invented from synthetic fixtures;
- recovery actions remain proposals behind PRIME/human authorization;
- the existing v1 demonstrator remains the comparison baseline in future TEVV.

### Claims boundary
`DRAFT_INTERFACE_CONTRACT_NOT_IMPLEMENTED`. This PR does not implement anti-spoofing, timing integrity, navigation, sensor fusion, physical PNT resilience, or new operational thresholds. Physical/source-integrity assertions remain partner/lab/field validation gates.

Draft only. Merge only after protected CI is green on the exact head.