### PR TITLE
Add WS-NSB v0.6 executable G0/G1 benchmark

### DIFF
--- a/.github/workflows/ws-nsb-v0-6.yml
+++ b/.github/workflows/ws-nsb-v0-6.yml
@@ -1,0 +1,63 @@
+name: WS-NSB v0.6 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_benchmark.py'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v0-6.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_benchmark.py'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v0-6.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  nsb-g0-g1:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Run WS-NSB unit gate
+        run: python -m pytest -q tests/test_nsb_benchmark.py
+
+      - name: Run CLI smoke and report verification
+        run: |
+          command -v ws-nsb-benchmark
+          ws-nsb-benchmark --help >/dev/null
+          mkdir -p nsb_ci_artifacts
+          ws-nsb-benchmark --resolutions 8,12,16 --output nsb_ci_artifacts/ws_nsb_v0_6.json
+          ws-nsb-benchmark --verify nsb_ci_artifacts/ws_nsb_v0_6.json | grep -Fx VALID
+
+      - name: Upload hash-bound WS-NSB report
+        uses: actions/upload-artifact@v4
+        with:
+          name: ws-nsb-v0-6-report
+          path: deployments/sara_verified_local_v1/nsb_ci_artifacts/ws_nsb_v0_6.json
+          if-no-files-found: error

--- a/deployments/sara_verified_local_v1/docs/WS_NSB_V0_6_EXECUTABLE_BENCHMARK.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NSB_V0_6_EXECUTABLE_BENCHMARK.md
@@ -1,0 +1,171 @@
+# WS-NSB v0.6 — Executable G0/G1 Instrumentation Benchmark
+
+## Purpose
+
+WS-NSB v0.6 is a deterministic, evidence-governed software benchmark for two precursor gates:
+
+- **G0_INSTRUMENTATION** — verify second-order central-difference curl/divergence instrumentation against manufactured analytic fields.
+- **G1_SCALING** — verify that the benchmark's log-slope instrumentation recovers explicitly supplied asymptotic power laws.
+
+It is intentionally **not** a Navier–Stokes time integrator, an MHD solver, a plasma solver, or a physical experiment.
+
+## Claims boundary
+
+A passing v0.6 report supports only the statement that the implemented diagnostic operators and synthetic scaling instrumentation behave as specified for this benchmark.
+
+It does **not** establish any of the following:
+
+- finite-time Navier–Stokes blowup reproduction;
+- correctness or independent acceptance of any external mathematical proof;
+- magnetic or electromagnetic vortex stabilization;
+- MHD or plasma control capability;
+- laboratory validation;
+- propulsion, shielding, stealth, or cloaking effects;
+- operational capability.
+
+The report model therefore fails closed if any such flag is promoted, and its capability status is fixed to `SIMULATED_ONLY`.
+
+## Manufactured G0 fields
+
+The velocity field is the unit ABC Beltrami flow
+
+```text
+u = (sin(z) + cos(y),
+     sin(x) + cos(z),
+     sin(y) + cos(x))
+```
+
+which satisfies analytically
+
+```text
+div(u) = 0
+curl(u) = u
+```
+
+The magnetic test field is
+
+```text
+B = (sin(y), sin(z), sin(x))
+```
+
+with `div(B) = 0`.
+
+A separate field
+
+```text
+F = (sin(x), sin(y), sin(z))
+```
+
+has exact divergence
+
+```text
+div(F) = cos(x) + cos(y) + cos(z)
+```
+
+and is used to measure divergence-operator error rather than relying only on zero-divergence cancellation.
+
+The normalized manufactured current proxy is the analytic curl of B,
+
+```text
+J = (-cos(z), -cos(x), -cos(y))
+```
+
+and the benchmark evaluates the curl of the Lorentz proxy `J x B` only as an instrumentation diagnostic. It is not an MHD solution.
+
+## G0 acceptance
+
+The default resolutions are `8,16,32`. For successive grid refinements the benchmark estimates
+
+```text
+p = log(error_coarse / error_fine) / log(h_coarse / h_fine)
+```
+
+for both curl/vorticity error and known-divergence error.
+
+G0 passes only if every observed order lies in the provisional second-order acceptance band
+
+```text
+1.8 <= p <= 2.2
+```
+
+This is an engineering test tolerance, not a physical constant.
+
+## G1 scaling instrumentation
+
+For `tau = 1 - t` and default `h = 0.005`, v0.6 synthesizes exact power-law data for the declared exponents
+
+```text
+radial length      ~ tau^(1/2)
+axial length       ~ tau^(1/2 - h)
+peak velocity      ~ tau^(-1/2 - h)
+core energy        ~ tau^(1/2 - 3h)
+angular Reynolds   ~ tau^(-h)
+```
+
+The benchmark then independently re-estimates each exponent with log-linear regression. G1 passes when the maximum absolute slope error is at most `1e-10`.
+
+This gate validates the **measurement pipeline for declared scaling laws**. Because the same declared laws generate the synthetic values, a G1 pass is not evidence that a PDE solution exhibits those laws.
+
+## Cancellation conditioning and verification escalation
+
+The module exposes the scalar diagnostic
+
+```text
+kappa = sum(abs(F_i)) / (abs(sum(F_i)) + epsilon)
+```
+
+with provisional escalation policy:
+
+```text
+kappa < 10        -> NORMAL
+10 <= kappa < 100 -> REFINE_TIMESTEP
+100 <= kappa < 1000 -> REFINE_TIMESTEP_AND_MESH
+kappa >= 1000     -> REQUIRE_INDEPENDENT_SOLVER
+```
+
+The scalar form is a precursor policy primitive. A future PDE implementation should extend it to normed vector/tensor residuals with uncertainty propagation.
+
+## Control outcome classifier
+
+A separate helper classifies a positive baseline stretching metric and a controlled value as:
+
+- `SUPPRESSION`
+- `NEUTRAL`
+- `AMPLIFICATION`
+- `REDIRECTION`
+
+The default neutral band is 5 percent. This classifier does not itself perform control or establish electromagnetic authority.
+
+## Running
+
+From `deployments/sara_verified_local_v1` after installation:
+
+```bash
+ws-nsb-benchmark
+```
+
+Write a hash-bound report:
+
+```bash
+ws-nsb-benchmark --output artifacts/ws_nsb_v0_6.json
+```
+
+Verify a previously generated report:
+
+```bash
+ws-nsb-benchmark --verify artifacts/ws_nsb_v0_6.json
+```
+
+Alternative resolutions and h exponent:
+
+```bash
+ws-nsb-benchmark --resolutions 8,12,16 --h-exponent 0.005
+```
+
+## Evidence custody
+
+Every generated report includes a canonical SHA-256 digest computed with the existing Worldshepherd qualification utility. Tampering with a report after generation causes verification failure.
+
+## Next gate
+
+The next implementation stage is **WS-NSB v0.7 / G2**, which should add an actual incompressible PDE time-integration benchmark plus grid/time-step convergence. That stage must remain separate from any claim of singularity reproduction. MHD coupling belongs to a later gate after the hydrodynamic solver is independently validated.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -34,6 +34,7 @@ ws-human-triage-ledger = "worldshepherd_sara.human_triage_cli:main"
 ws-intake-minimum-ledger = "worldshepherd_sara.intake_minimum_cli:main"
 ws-prime-basis-ablation = "worldshepherd_sara.prime_basis_ablation_cli:main"
 ws-programmable-boundary-benchmark = "worldshepherd_sara.programmable_boundary_benchmark_cli:main"
+ws-nsb-benchmark = "worldshepherd_sara.nsb_benchmark_cli:main"
 ws-omega-recursion = "worldshepherd_sara.recursive_discovery_cli:main"
 
 [tool.setuptools]

--- a/deployments/sara_verified_local_v1/tests/test_nsb_benchmark.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_benchmark.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.nsb_benchmark import (
+    ControlOutcome,
+    NSBBenchmarkReport,
+    VerificationEscalation,
+    cancellation_condition,
+    classify_control_outcome,
+    run_nsb_benchmark,
+    verification_escalation,
+    verify_nsb_benchmark_report,
+)
+from worldshepherd_sara.qualification import CapabilityStatus
+
+
+def test_default_benchmark_passes_g0_g1_without_physical_promotion():
+    report = run_nsb_benchmark()
+    assert report.summary.g0_passed is True
+    assert report.summary.g1_passed is True
+    assert report.summary.second_order_vorticity_convergence_observed is True
+    assert report.summary.second_order_divergence_convergence_observed is True
+    assert report.summary.scaling_instrumentation_passed is True
+    assert report.capability_status == CapabilityStatus.SIMULATED_ONLY
+    assert report.pde_time_integration_performed is False
+    assert report.navier_stokes_blowup_reproduced is False
+    assert report.mhd_solver_used is False
+    assert report.plasma_solver_used is False
+    assert report.laboratory_validation_performed is False
+    assert report.propulsion_effect_validated is False
+    assert report.shielding_effect_validated is False
+
+
+def test_manufactured_operators_show_second_order_convergence():
+    report = run_nsb_benchmark()
+    assert all(1.8 <= value <= 2.2 for value in report.summary.vorticity_observed_orders)
+    assert all(1.8 <= value <= 2.2 for value in report.summary.divergence_observed_orders)
+
+
+def test_scaling_instrumentation_recovers_declared_power_laws():
+    report = run_nsb_benchmark(h_exponent=0.005)
+    scaling = report.scaling
+    assert scaling.radial_length_slope == pytest.approx(scaling.target_radial_length_slope, abs=1e-12)
+    assert scaling.axial_length_slope == pytest.approx(scaling.target_axial_length_slope, abs=1e-12)
+    assert scaling.peak_velocity_slope == pytest.approx(scaling.target_peak_velocity_slope, abs=1e-12)
+    assert scaling.core_energy_slope == pytest.approx(scaling.target_core_energy_slope, abs=1e-12)
+    assert scaling.angular_reynolds_slope == pytest.approx(scaling.target_angular_reynolds_slope, abs=1e-12)
+    assert scaling.max_absolute_slope_error < 1e-12
+
+
+def test_divergence_free_manufactured_fields_and_nontrivial_diagnostics():
+    report = run_nsb_benchmark(resolutions=(8, 16, 32))
+    finest = report.diagnostics[-1]
+    assert finest.div_u_rms < 1e-12
+    assert finest.div_b_rms < 1e-12
+    assert finest.vortex_stretching_rms > 0.0
+    assert finest.em_vorticity_forcing_rms > 0.0
+
+
+def test_cancellation_condition_and_escalation_boundaries():
+    assert cancellation_condition((1.0, 2.0)) == pytest.approx(1.0)
+    high = cancellation_condition((1000.0, -999.0))
+    assert high > 1000.0
+    assert verification_escalation(9.999) == VerificationEscalation.NORMAL
+    assert verification_escalation(10.0) == VerificationEscalation.REFINE_TIMESTEP
+    assert verification_escalation(100.0) == VerificationEscalation.REFINE_TIMESTEP_AND_MESH
+    assert verification_escalation(1000.0) == VerificationEscalation.REQUIRE_INDEPENDENT_SOLVER
+
+
+def test_control_outcome_classification_is_fail_closed():
+    assert classify_control_outcome(100.0, 90.0) == ControlOutcome.SUPPRESSION
+    assert classify_control_outcome(100.0, 103.0) == ControlOutcome.NEUTRAL
+    assert classify_control_outcome(100.0, 110.0) == ControlOutcome.AMPLIFICATION
+    assert classify_control_outcome(100.0, 100.0, redirected=True) == ControlOutcome.REDIRECTION
+    with pytest.raises(ValueError):
+        classify_control_outcome(0.0, 0.0)
+
+
+def test_report_is_deterministic_hash_bound_and_tamper_detectable():
+    first = run_nsb_benchmark(resolutions=(8, 12, 16))
+    second = run_nsb_benchmark(resolutions=(8, 12, 16))
+    assert first == second
+    assert first.report_digest is not None
+    assert first.report_digest.startswith("sha256:")
+    assert verify_nsb_benchmark_report(first) is True
+
+    tampered = first.model_copy(update={"source_claim_status": "SETTLED_THEOREM"})
+    assert verify_nsb_benchmark_report(tampered) is False
+
+
+def test_fail_closed_model_rejects_unsupported_claim_promotion():
+    report = run_nsb_benchmark(resolutions=(8, 12, 16))
+    payload = report.model_dump(mode="json")
+    payload["navier_stokes_blowup_reproduced"] = True
+    with pytest.raises(ValueError):
+        NSBBenchmarkReport.model_validate(payload)
+
+    payload = report.model_dump(mode="json")
+    payload["capability_status"] = CapabilityStatus.PROVEN_INTERNALLY.value
+    with pytest.raises(ValueError):
+        NSBBenchmarkReport.model_validate(payload)
+
+
+def test_invalid_inputs_fail_closed():
+    with pytest.raises(ValueError):
+        run_nsb_benchmark(resolutions=(8, 16))
+    with pytest.raises(ValueError):
+        run_nsb_benchmark(resolutions=(16, 8, 32))
+    with pytest.raises(ValueError):
+        run_nsb_benchmark(resolutions=(8, 8, 16))
+    with pytest.raises(ValueError):
+        run_nsb_benchmark(h_exponent=0.01)
+    with pytest.raises(ValueError):
+        cancellation_condition(())
+    with pytest.raises(ValueError):
+        verification_escalation(-1.0)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Iterable
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import CapabilityStatus, canonical_digest
+
+
+Vec3 = tuple[float, float, float]
+VectorField = Callable[[float, float, float], Vec3]
+
+
+class NSBGate(str, Enum):
+    G0_INSTRUMENTATION = "G0_INSTRUMENTATION"
+    G1_SCALING = "G1_SCALING"
+
+
+class ControlOutcome(str, Enum):
+    SUPPRESSION = "SUPPRESSION"
+    NEUTRAL = "NEUTRAL"
+    AMPLIFICATION = "AMPLIFICATION"
+    REDIRECTION = "REDIRECTION"
+
+
+class VerificationEscalation(str, Enum):
+    NORMAL = "NORMAL"
+    REFINE_TIMESTEP = "REFINE_TIMESTEP"
+    REFINE_TIMESTEP_AND_MESH = "REFINE_TIMESTEP_AND_MESH"
+    REQUIRE_INDEPENDENT_SOLVER = "REQUIRE_INDEPENDENT_SOLVER"
+
+
+class ResolutionDiagnostic(BaseModel):
+    resolution: int = Field(ge=4)
+    spacing_radians: float = Field(gt=0.0)
+    vorticity_l2_error: float = Field(ge=0.0)
+    known_divergence_l2_error: float = Field(ge=0.0)
+    div_u_rms: float = Field(ge=0.0)
+    div_b_rms: float = Field(ge=0.0)
+    vortex_stretching_rms: float = Field(ge=0.0)
+    em_vorticity_forcing_rms: float = Field(ge=0.0)
+
+
+class ScalingDiagnostic(BaseModel):
+    h_exponent: float = Field(gt=0.0, lt=0.01)
+    radial_length_slope: float
+    axial_length_slope: float
+    peak_velocity_slope: float
+    core_energy_slope: float
+    angular_reynolds_slope: float
+    target_radial_length_slope: float
+    target_axial_length_slope: float
+    target_peak_velocity_slope: float
+    target_core_energy_slope: float
+    target_angular_reynolds_slope: float
+    max_absolute_slope_error: float = Field(ge=0.0)
+
+
+class NSBSummary(BaseModel):
+    vorticity_observed_orders: tuple[float, ...]
+    divergence_observed_orders: tuple[float, ...]
+    second_order_vorticity_convergence_observed: bool
+    second_order_divergence_convergence_observed: bool
+    scaling_instrumentation_passed: bool
+    g0_passed: bool
+    g1_passed: bool
+
+
+class NSBBenchmarkReport(BaseModel):
+    qualification_id: str = "WS-NSB-2026-001"
+    benchmark_version: str = "0.6"
+    gates: tuple[NSBGate, ...] = (
+        NSBGate.G0_INSTRUMENTATION,
+        NSBGate.G1_SCALING,
+    )
+    source_claim_status: str = "PUBLISHED_FORMALIZED_EXTERNAL_ACCEPTANCE_PENDING"
+    resolutions: tuple[int, ...]
+    diagnostics: tuple[ResolutionDiagnostic, ...]
+    scaling: ScalingDiagnostic
+    summary: NSBSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    pde_time_integration_performed: bool = False
+    navier_stokes_blowup_reproduced: bool = False
+    mhd_solver_used: bool = False
+    plasma_solver_used: bool = False
+    laboratory_validation_performed: bool = False
+    propulsion_effect_validated: bool = False
+    shielding_effect_validated: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "WS-NSB v0.6 validates manufactured differential operators and asymptotic-scaling instrumentation only.",
+        "No Navier-Stokes time integration or finite-time singularity reproduction is performed by this benchmark.",
+        "No MHD solver, plasma solver, laboratory experiment, propulsion effect, or shielding effect is represented.",
+        "A G0/G1 PASS is software evidence only and must not be promoted to a physical capability claim.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "NSBBenchmarkReport":
+        prohibited = (
+            self.pde_time_integration_performed,
+            self.navier_stokes_blowup_reproduced,
+            self.mhd_solver_used,
+            self.plasma_solver_used,
+            self.laboratory_validation_performed,
+            self.propulsion_effect_validated,
+            self.shielding_effect_validated,
+        )
+        if any(prohibited):
+            raise ValueError("WS-NSB v0.6 cannot promote PDE, singularity, MHD, plasma, laboratory, propulsion, or shielding claims")
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("WS-NSB v0.6 must remain SIMULATED_ONLY")
+        return self
+
+
+def _add(a: Vec3, b: Vec3) -> Vec3:
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def _sub(a: Vec3, b: Vec3) -> Vec3:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _scale(value: Vec3, factor: float) -> Vec3:
+    return (value[0] * factor, value[1] * factor, value[2] * factor)
+
+
+def _dot(a: Vec3, b: Vec3) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _cross(a: Vec3, b: Vec3) -> Vec3:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def _norm(value: Vec3) -> float:
+    return math.sqrt(_dot(value, value))
+
+
+def _rms(values: Iterable[float]) -> float:
+    collected = tuple(values)
+    if not collected:
+        raise ValueError("RMS requires at least one value")
+    return math.sqrt(sum(value * value for value in collected) / len(collected))
+
+
+def _partial(field: VectorField, axis: int, x: float, y: float, z: float, step: float) -> Vec3:
+    coordinates_plus = [x, y, z]
+    coordinates_minus = [x, y, z]
+    coordinates_plus[axis] += step
+    coordinates_minus[axis] -= step
+    plus = field(*coordinates_plus)
+    minus = field(*coordinates_minus)
+    return _scale(_sub(plus, minus), 1.0 / (2.0 * step))
+
+
+def divergence(field: VectorField, x: float, y: float, z: float, step: float) -> float:
+    dx = _partial(field, 0, x, y, z, step)
+    dy = _partial(field, 1, x, y, z, step)
+    dz = _partial(field, 2, x, y, z, step)
+    return dx[0] + dy[1] + dz[2]
+
+
+def curl(field: VectorField, x: float, y: float, z: float, step: float) -> Vec3:
+    dx = _partial(field, 0, x, y, z, step)
+    dy = _partial(field, 1, x, y, z, step)
+    dz = _partial(field, 2, x, y, z, step)
+    return (
+        dy[2] - dz[1],
+        dz[0] - dx[2],
+        dx[1] - dy[0],
+    )
+
+
+def strain_tensor(field: VectorField, x: float, y: float, z: float, step: float) -> tuple[Vec3, Vec3, Vec3]:
+    derivatives = (
+        _partial(field, 0, x, y, z, step),
+        _partial(field, 1, x, y, z, step),
+        _partial(field, 2, x, y, z, step),
+    )
+    return tuple(
+        tuple(0.5 * (derivatives[j][i] + derivatives[i][j]) for j in range(3))
+        for i in range(3)
+    )  # type: ignore[return-value]
+
+
+def _matvec(matrix: tuple[Vec3, Vec3, Vec3], vector: Vec3) -> Vec3:
+    return (
+        _dot(matrix[0], vector),
+        _dot(matrix[1], vector),
+        _dot(matrix[2], vector),
+    )
+
+
+def manufactured_velocity(x: float, y: float, z: float) -> Vec3:
+    """Unit ABC Beltrami flow: divergence-free and curl(u) = u exactly."""
+    return (
+        math.sin(z) + math.cos(y),
+        math.sin(x) + math.cos(z),
+        math.sin(y) + math.cos(x),
+    )
+
+
+def manufactured_magnetic_field(x: float, y: float, z: float) -> Vec3:
+    """Divergence-free manufactured magnetic field."""
+    return (math.sin(y), math.sin(z), math.sin(x))
+
+
+def manufactured_divergent_field(x: float, y: float, z: float) -> Vec3:
+    return (math.sin(x), math.sin(y), math.sin(z))
+
+
+def manufactured_divergent_field_exact_divergence(x: float, y: float, z: float) -> float:
+    return math.cos(x) + math.cos(y) + math.cos(z)
+
+
+def manufactured_current_density(x: float, y: float, z: float) -> Vec3:
+    """Analytic curl(B) for the manufactured magnetic field, with constants normalized to one."""
+    return (-math.cos(z), -math.cos(x), -math.cos(y))
+
+
+def manufactured_lorentz_proxy(x: float, y: float, z: float) -> Vec3:
+    return _cross(
+        manufactured_current_density(x, y, z),
+        manufactured_magnetic_field(x, y, z),
+    )
+
+
+def _grid_points(resolution: int) -> Iterable[tuple[float, float, float]]:
+    step = 2.0 * math.pi / resolution
+    for i in range(resolution):
+        x = i * step
+        for j in range(resolution):
+            y = j * step
+            for k in range(resolution):
+                yield x, y, k * step
+
+
+def _resolution_diagnostic(resolution: int) -> ResolutionDiagnostic:
+    step = 2.0 * math.pi / resolution
+    vorticity_errors: list[float] = []
+    divergence_errors: list[float] = []
+    div_u_values: list[float] = []
+    div_b_values: list[float] = []
+    stretching_values: list[float] = []
+    em_forcing_values: list[float] = []
+
+    for x, y, z in _grid_points(resolution):
+        numerical_vorticity = curl(manufactured_velocity, x, y, z, step)
+        exact_vorticity = manufactured_velocity(x, y, z)
+        vorticity_errors.append(_norm(_sub(numerical_vorticity, exact_vorticity)))
+
+        numerical_known_divergence = divergence(
+            manufactured_divergent_field,
+            x,
+            y,
+            z,
+            step,
+        )
+        exact_known_divergence = manufactured_divergent_field_exact_divergence(x, y, z)
+        divergence_errors.append(numerical_known_divergence - exact_known_divergence)
+
+        div_u_values.append(divergence(manufactured_velocity, x, y, z, step))
+        div_b_values.append(divergence(manufactured_magnetic_field, x, y, z, step))
+
+        strain = strain_tensor(manufactured_velocity, x, y, z, step)
+        stretching_values.append(_dot(numerical_vorticity, _matvec(strain, numerical_vorticity)))
+
+        em_curl = curl(manufactured_lorentz_proxy, x, y, z, step)
+        em_forcing_values.append(_norm(em_curl))
+
+    return ResolutionDiagnostic(
+        resolution=resolution,
+        spacing_radians=step,
+        vorticity_l2_error=_rms(vorticity_errors),
+        known_divergence_l2_error=_rms(divergence_errors),
+        div_u_rms=_rms(div_u_values),
+        div_b_rms=_rms(div_b_values),
+        vortex_stretching_rms=_rms(stretching_values),
+        em_vorticity_forcing_rms=_rms(em_forcing_values),
+    )
+
+
+def _observed_orders(
+    diagnostics: tuple[ResolutionDiagnostic, ...],
+    attribute: str,
+) -> tuple[float, ...]:
+    orders: list[float] = []
+    for coarse, fine in zip(diagnostics[:-1], diagnostics[1:], strict=True):
+        coarse_error = float(getattr(coarse, attribute))
+        fine_error = float(getattr(fine, attribute))
+        if coarse_error <= 0.0 or fine_error <= 0.0:
+            raise ValueError("convergence-order calculation requires positive errors")
+        ratio_h = coarse.spacing_radians / fine.spacing_radians
+        if ratio_h <= 1.0:
+            raise ValueError("diagnostics must progress from coarse to fine spacing")
+        orders.append(math.log(coarse_error / fine_error) / math.log(ratio_h))
+    return tuple(orders)
+
+
+def _log_slope(xs: tuple[float, ...], ys: tuple[float, ...]) -> float:
+    if len(xs) != len(ys) or len(xs) < 2:
+        raise ValueError("log-slope fit requires equal-length sequences with at least two points")
+    if any(value <= 0.0 for value in xs + ys):
+        raise ValueError("log-slope fit requires strictly positive values")
+    lx = tuple(math.log(value) for value in xs)
+    ly = tuple(math.log(value) for value in ys)
+    mean_x = sum(lx) / len(lx)
+    mean_y = sum(ly) / len(ly)
+    denominator = sum((value - mean_x) ** 2 for value in lx)
+    if denominator <= 0.0:
+        raise ValueError("degenerate log-slope input")
+    return sum((x - mean_x) * (y - mean_y) for x, y in zip(lx, ly, strict=True)) / denominator
+
+
+def _scaling_diagnostic(h_exponent: float) -> ScalingDiagnostic:
+    if not 0.0 < h_exponent < 0.01:
+        raise ValueError("h_exponent must satisfy 0 < h < 0.01")
+
+    tau = (0.1, 0.05, 0.02, 0.01, 0.005, 0.002, 0.001)
+    targets = {
+        "radial": 0.5,
+        "axial": 0.5 - h_exponent,
+        "velocity": -0.5 - h_exponent,
+        "energy": 0.5 - 3.0 * h_exponent,
+        "re_theta": -h_exponent,
+    }
+
+    radial = tuple(value ** targets["radial"] for value in tau)
+    axial = tuple(value ** targets["axial"] for value in tau)
+    velocity = tuple(value ** targets["velocity"] for value in tau)
+    energy = tuple(value ** targets["energy"] for value in tau)
+    re_theta = tuple(value ** targets["re_theta"] for value in tau)
+
+    measured = {
+        "radial": _log_slope(tau, radial),
+        "axial": _log_slope(tau, axial),
+        "velocity": _log_slope(tau, velocity),
+        "energy": _log_slope(tau, energy),
+        "re_theta": _log_slope(tau, re_theta),
+    }
+    max_error = max(abs(measured[key] - targets[key]) for key in targets)
+
+    return ScalingDiagnostic(
+        h_exponent=h_exponent,
+        radial_length_slope=measured["radial"],
+        axial_length_slope=measured["axial"],
+        peak_velocity_slope=measured["velocity"],
+        core_energy_slope=measured["energy"],
+        angular_reynolds_slope=measured["re_theta"],
+        target_radial_length_slope=targets["radial"],
+        target_axial_length_slope=targets["axial"],
+        target_peak_velocity_slope=targets["velocity"],
+        target_core_energy_slope=targets["energy"],
+        target_angular_reynolds_slope=targets["re_theta"],
+        max_absolute_slope_error=max_error,
+    )
+
+
+def cancellation_condition(terms: Iterable[float], *, epsilon: float = 1e-15) -> float:
+    """Scalar cancellation-conditioning proxy: sum(|Fi|) / (|sum(Fi)| + epsilon)."""
+    values = tuple(float(value) for value in terms)
+    if not values:
+        raise ValueError("at least one term is required")
+    if epsilon <= 0.0:
+        raise ValueError("epsilon must be positive")
+    return sum(abs(value) for value in values) / (abs(sum(values)) + epsilon)
+
+
+def verification_escalation(kappa_balance: float) -> VerificationEscalation:
+    if kappa_balance < 0.0 or not math.isfinite(kappa_balance):
+        raise ValueError("kappa_balance must be finite and non-negative")
+    if kappa_balance >= 1000.0:
+        return VerificationEscalation.REQUIRE_INDEPENDENT_SOLVER
+    if kappa_balance >= 100.0:
+        return VerificationEscalation.REFINE_TIMESTEP_AND_MESH
+    if kappa_balance >= 10.0:
+        return VerificationEscalation.REFINE_TIMESTEP
+    return VerificationEscalation.NORMAL
+
+
+def classify_control_outcome(
+    baseline_stretching: float,
+    controlled_stretching: float,
+    *,
+    neutral_fraction: float = 0.05,
+    redirected: bool = False,
+) -> ControlOutcome:
+    if baseline_stretching <= 0.0:
+        raise ValueError("baseline_stretching must be positive")
+    if controlled_stretching < 0.0:
+        raise ValueError("controlled_stretching must be non-negative")
+    if not 0.0 <= neutral_fraction < 1.0:
+        raise ValueError("neutral_fraction must be in [0, 1)")
+    if redirected:
+        return ControlOutcome.REDIRECTION
+    relative_change = (controlled_stretching - baseline_stretching) / baseline_stretching
+    if relative_change < -neutral_fraction:
+        return ControlOutcome.SUPPRESSION
+    if relative_change > neutral_fraction:
+        return ControlOutcome.AMPLIFICATION
+    return ControlOutcome.NEUTRAL
+
+
+def run_nsb_benchmark(
+    *,
+    resolutions: tuple[int, ...] = (8, 16, 32),
+    h_exponent: float = 0.005,
+) -> NSBBenchmarkReport:
+    if len(resolutions) < 3:
+        raise ValueError("at least three resolutions are required")
+    if tuple(sorted(set(resolutions))) != resolutions:
+        raise ValueError("resolutions must be strictly increasing and unique")
+    if any(value < 4 for value in resolutions):
+        raise ValueError("all resolutions must be >= 4")
+
+    diagnostics = tuple(_resolution_diagnostic(value) for value in resolutions)
+    vorticity_orders = _observed_orders(diagnostics, "vorticity_l2_error")
+    divergence_orders = _observed_orders(diagnostics, "known_divergence_l2_error")
+    second_order_vorticity = all(1.8 <= value <= 2.2 for value in vorticity_orders)
+    second_order_divergence = all(1.8 <= value <= 2.2 for value in divergence_orders)
+    scaling = _scaling_diagnostic(h_exponent)
+    scaling_pass = scaling.max_absolute_slope_error <= 1e-10
+
+    report = NSBBenchmarkReport(
+        resolutions=resolutions,
+        diagnostics=diagnostics,
+        scaling=scaling,
+        summary=NSBSummary(
+            vorticity_observed_orders=vorticity_orders,
+            divergence_observed_orders=divergence_orders,
+            second_order_vorticity_convergence_observed=second_order_vorticity,
+            second_order_divergence_convergence_observed=second_order_divergence,
+            scaling_instrumentation_passed=scaling_pass,
+            g0_passed=second_order_vorticity and second_order_divergence,
+            g1_passed=scaling_pass,
+        ),
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_nsb_benchmark_report(report: NSBBenchmarkReport) -> bool:
+    expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.report_digest == expected

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_benchmark_cli.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .nsb_benchmark import (
+    NSBBenchmarkReport,
+    run_nsb_benchmark,
+    verify_nsb_benchmark_report,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the deterministic WS-NSB v0.6 G0/G1 instrumentation benchmark."
+    )
+    parser.add_argument(
+        "--resolutions",
+        default="8,16,32",
+        help="comma-separated strictly increasing grid resolutions (default: 8,16,32)",
+    )
+    parser.add_argument("--h-exponent", type=float, default=0.005)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _parse_resolutions(value: str) -> tuple[int, ...]:
+    try:
+        resolutions = tuple(int(item.strip()) for item in value.split(",") if item.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("resolutions must be comma-separated integers") from exc
+    if not resolutions:
+        raise argparse.ArgumentTypeError("at least one resolution is required")
+    return resolutions
+
+
+def _serialize(report: NSBBenchmarkReport) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = NSBBenchmarkReport.model_validate(payload)
+        if not verify_nsb_benchmark_report(report):
+            print("INVALID")
+            return 1
+        print("VALID")
+        return 0
+
+    resolutions = _parse_resolutions(args.resolutions)
+    report = run_nsb_benchmark(
+        resolutions=resolutions,
+        h_exponent=args.h_exponent,
+    )
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a fail-closed, deterministic WS-NSB v0.6 precursor benchmark for the Navier–Stokes/extreme-gradient research lane.

### Included
- `worldshepherd_sara/nsb_benchmark.py`
  - manufactured G0 curl/divergence checks
  - second-order convergence measurement
  - synthetic G1 asymptotic log-slope instrumentation
  - cancellation-conditioning escalation policy
  - bounded control-outcome classifier
  - canonical SHA-256 report binding
- `worldshepherd_sara/nsb_benchmark_cli.py`
  - run, write, and verify reports
- `tests/test_nsb_benchmark.py`
  - nine fail-closed and deterministic tests
- `ws-nsb-benchmark` console entry point
- `docs/WS_NSB_V0_6_EXECUTABLE_BENCHMARK.md`

## Claims boundary

This PR deliberately does **not** implement or claim:
- Navier–Stokes PDE time integration or blowup reproduction
- MHD/plasma solving
- laboratory validation
- propulsion, shielding, stealth, or cloaking effects
- operational capability

`NSBBenchmarkReport` is fixed to `SIMULATED_ONLY` and rejects unsupported promotion flags.

## Gate intent

- **G0**: verify differential-operator instrumentation on manufactured analytic fields.
- **G1**: verify log-slope instrumentation on declared synthetic power laws.

A future G2 should introduce actual incompressible PDE time integration with separate grid/time-step convergence and remain distinct from any singularity claim.