### PR TITLE
Add WS-NSB v1.1 G6 transient Hartmann energy-budget gate

### DIFF
--- a/.github/workflows/ws-nsb-v1-1-g6.yml
+++ b/.github/workflows/ws-nsb-v1-1-g6.yml
@@ -1,0 +1,62 @@
+name: WS-NSB v1.1 G6 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_1_G6_TRANSIENT_HARTMANN.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-1-g6.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_1_G6_TRANSIENT_HARTMANN.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-1-g6.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  g6-transient-hartmann:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and tests
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Run G6 test suite
+        run: python -m pytest tests/test_nsb_g6_transient_hartmann.py -q
+
+      - name: Execute and verify deterministic G6 report
+        run: |
+          rm -f ws_nsb_g6_report.json
+          ws-nsb-g6 --output ws_nsb_g6_report.json
+          ws-nsb-g6 --verify ws_nsb_g6_report.json
+
+      - name: Upload G6 evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ws-nsb-v1-1-g6-report
+          path: deployments/sara_verified_local_v1/ws_nsb_g6_report.json
+          if-no-files-found: error

--- a/deployments/sara_verified_local_v1/docs/WS_NSB_V1_1_G6_TRANSIENT_HARTMANN.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NSB_V1_1_G6_TRANSIENT_HARTMANN.md
@@ -1,0 +1,123 @@
+# WS-NSB v1.1 — G6 Transient Quasi-Static Hartmann Reference
+
+## Purpose
+
+G6 adds the first **time-dependent magnetic energy-budget gate** to the Worldshepherd Navier–Stokes Benchmark (WS-NSB) ladder.
+
+It follows the G5 steady quasi-static Hartmann reference and intentionally remains one-dimensional and reduced. The point is to verify the temporal treatment of the imposed-field magnetic damping term before any 2D/3D MHD, induction equation, plasma model, or adaptive electromagnetic controller is admitted into the primary validation chain.
+
+## Governing reference
+
+The normalized problem is
+
+\[
+\frac{\partial u}{\partial t}
+=
+\frac{\partial^2u}{\partial y^2}
+-Ha^2u+1,
+\qquad -1\le y\le1,
+\]
+
+with
+
+\[
+u(-1,t)=u(1,t)=0,\qquad u(y,0)=0.
+\]
+
+The forcing term is a fixed unit pressure-gradient normalization. The reduced electromagnetic contribution is the linear sink \(-Ha^2u\).
+
+The code uses Crank–Nicolson time integration and second-order centered finite differences in space.
+
+## Exact transient reference
+
+With \(x=(y+1)/2\), the constant forcing has the Dirichlet sine expansion
+
+\[
+1=\sum_{n\ {\rm odd}}\frac{4}{n\pi}\sin(n\pi x).
+\]
+
+Therefore
+
+\[
+u(y,t)
+=
+\sum_{n\ {\rm odd}}
+\frac{4}{n\pi}
+\frac{1-e^{-\lambda_n t}}{\lambda_n}
+\sin\left(\frac{n\pi(y+1)}{2}\right),
+\]
+
+where
+
+\[
+\lambda_n=\left(\frac{n\pi}{2}\right)^2+Ha^2.
+\]
+
+This supplies an independent analytical transient profile for error and convergence measurement.
+
+## Energy budget
+
+For the normalized reference,
+
+\[
+E(t)=\frac12\int_{-1}^{1}u^2\,dy
+\]
+
+obeys
+
+\[
+\frac{dE}{dt}
+=
+\underbrace{\int u\,dy}_{P_{\rm forcing}}
+-
+\underbrace{\int (\partial_yu)^2dy}_{D_\nu}
+-
+\underbrace{Ha^2\int u^2dy}_{D_{\rm EM}}.
+\]
+
+The Crank–Nicolson implementation records the forcing work, viscous dissipation, electromagnetic dissipation, and the absolute closure residual. This is the central G6 addition: the magnetic term must appear as a positive energy sink for nonzero \(Ha\), while the \(Ha=0\) control must produce zero electromagnetic dissipation.
+
+## Acceptance criteria
+
+The default gate requires:
+
+- spatial order at least 1.8 on grids 33/65/129 at \(Ha=2\);
+- temporal order at least 1.8 using \(\Delta t=0.08,0.04,0.02\);
+- finest spatial transient-profile L2 error no greater than \(10^{-5}\);
+- finest temporal L2 error no greater than \(5\times10^{-5}\);
+- cumulative discrete energy-budget closure residual no greater than \(10^{-10}\);
+- zero-field electromagnetic sink no greater than \(10^{-14}\);
+- positive electromagnetic dissipation for every nonzero-Hartmann sweep case;
+- exact +Ha/-Ha symmetry to within \(10^{-14}\) for this \(Ha^2\) reduced model;
+- monotonic centerline and mean-flow reduction as Hartmann number increases;
+- long-time consistency with the G5 steady analytical Hartmann profile to within \(10^{-5}\) L2.
+
+## Claims boundary
+
+**Classification: `SIMULATED_ONLY`.**
+
+A G6 pass establishes only that the repository's bounded transient **1D quasi-static Hartmann reference** meets its declared analytical, convergence, energy-budget, sign-control, and steady-limit checks.
+
+It does **not** establish:
+
+- a full MHD solver;
+- induction-equation capability;
+- 2D or 3D magnetofluid capability;
+- Hall-MHD, two-fluid, kinetic, or plasma capability;
+- adaptive electromagnetic flow control;
+- laboratory validation;
+- finite-time Navier–Stokes singularity reproduction;
+- propulsion, shielding, stealth, cloaking, or operational capability.
+
+Those remain separate future gates.
+
+## Evidence
+
+Run:
+
+```bash
+ws-nsb-g6 --output ws_nsb_g6_report.json
+ws-nsb-g6 --verify ws_nsb_g6_report.json
+```
+
+The report is deterministically bound through the repository `canonical_digest` mechanism. CI uploads the report as the `ws-nsb-v1-1-g6-report` artifact.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -39,6 +39,7 @@ ws-nsb-g2 = "worldshepherd_sara.nsb_g2_cli:main"
 ws-nsb-g3 = "worldshepherd_sara.nsb_g3_cli:main"
 ws-nsb-g4 = "worldshepherd_sara.nsb_g4_cli:main"
 ws-nsb-g5 = "worldshepherd_sara.nsb_g5_cli:main"
+ws-nsb-g6 = "worldshepherd_sara.nsb_g6_cli:main"
 ws-omega-recursion = "worldshepherd_sara.recursive_discovery_cli:main"
 
 [tool.setuptools]

--- a/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
@@ -40,8 +40,8 @@ def test_energy_budget_closes_and_magnetic_sink_is_controlled(report):
 def test_magnetic_damping_is_monotonic_in_reference_sweep(report):
     centerlines = [case.centerline_velocity for case in report.cases]
     means = [case.mean_velocity for case in report.cases]
-    assert all(b < a for a, b in zip(centerlines, centerlines[1:], strict=True))
-    assert all(b < a for a, b in zip(means, means[1:], strict=True))
+    assert all(b < a for a, b in zip(centerlines, centerlines[1:]))
+    assert all(b < a for a, b in zip(means, means[1:]))
 
 
 def test_field_sign_symmetry_and_steady_limit_pass(report):

--- a/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.nsb_g6_transient_hartmann import (
+    NSBG6Report,
+    integrate_transient_hartmann,
+    run_nsb_g6_benchmark,
+    transient_hartmann_exact_velocity,
+    verify_nsb_g6_report,
+)
+
+
+@pytest.fixture(scope="module")
+def report():
+    return run_nsb_g6_benchmark()
+
+
+def test_default_g6_gate_passes_and_digest_verifies(report):
+    assert report.acceptance.acceptance_pass is True
+    assert verify_nsb_g6_report(report) is True
+    assert report.report_digest is not None
+    assert report.report_digest.startswith("sha256:")
+
+
+def test_spatial_and_temporal_convergence_are_second_order(report):
+    assert min(report.convergence.spatial_orders) >= 1.8
+    assert min(report.convergence.temporal_orders) >= 1.8
+    assert report.convergence.spatial_errors[-1] <= 1e-5
+    assert report.convergence.temporal_errors[-1] <= 5e-5
+
+
+def test_energy_budget_closes_and_magnetic_sink_is_controlled(report):
+    assert report.acceptance.energy_budget_pass is True
+    assert report.cases[0].cumulative_em_dissipation == pytest.approx(0.0, abs=1e-14)
+    assert all(case.cumulative_em_dissipation > 1e-14 for case in report.cases[1:])
+    assert max(case.energy_budget_abs_residual for case in report.cases) <= 1e-10
+
+
+def test_magnetic_damping_is_monotonic_in_reference_sweep(report):
+    centerlines = [case.centerline_velocity for case in report.cases]
+    means = [case.mean_velocity for case in report.cases]
+    assert all(b < a for a, b in zip(centerlines, centerlines[1:], strict=True))
+    assert all(b < a for a, b in zip(means, means[1:], strict=True))
+
+
+def test_field_sign_symmetry_and_steady_limit_pass(report):
+    assert report.acceptance.field_sign_symmetry_l2 <= 1e-14
+    assert report.acceptance.steady_limit_l2 <= 1e-5
+
+
+def test_exact_transient_respects_initial_and_wall_conditions():
+    for ha in (0.0, 1.0, 5.0):
+        assert transient_hartmann_exact_velocity(0.25, ha, 0.0) == 0.0
+        assert transient_hartmann_exact_velocity(-1.0, ha, 0.2) == pytest.approx(0.0, abs=1e-14)
+        assert transient_hartmann_exact_velocity(1.0, ha, 0.2) == pytest.approx(0.0, abs=1e-14)
+
+
+def test_report_tampering_breaks_digest(report):
+    tampered = report.model_copy(update={"benchmark_version": "tampered"})
+    assert verify_nsb_g6_report(tampered) is False
+
+
+def test_claim_promotion_fails_closed(report):
+    payload = report.model_dump(mode="json")
+    payload["plasma_solved"] = True
+    with pytest.raises(ValueError):
+        NSBG6Report.model_validate(payload)
+
+
+def test_invalid_even_grid_is_rejected():
+    with pytest.raises(ValueError):
+        integrate_transient_hartmann(hartmann=2.0, grid_size=32, dt=0.01, final_time=0.1)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .nsb_g6_transient_hartmann import NSBG6Report, run_nsb_g6_benchmark, verify_nsb_g6_report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the bounded WS-NSB v1.1 G6 transient quasi-static Hartmann benchmark."
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _serialize(report: NSBG6Report) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = NSBG6Report.model_validate(payload)
+        if not verify_nsb_g6_report(report):
+            print("INVALID")
+            return 1
+        if not report.acceptance.acceptance_pass:
+            print("VALID-BUT-GATE-FAILED")
+            return 2
+        print("VALID")
+        return 0
+
+    report = run_nsb_g6_benchmark()
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0 if report.acceptance.acceptance_pass else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import math
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import CapabilityStatus, canonical_digest
+
+
+class TransientHartmannCaseResult(BaseModel):
+    case_id: str
+    hartmann: float = Field(ge=0.0)
+    grid_size: int = Field(ge=5)
+    requested_dt: float = Field(gt=0.0)
+    effective_dt: float = Field(gt=0.0)
+    final_time: float = Field(gt=0.0)
+    steps: int = Field(ge=1)
+    l2_velocity_error: float = Field(ge=0.0)
+    linf_velocity_error: float = Field(ge=0.0)
+    centerline_velocity: float
+    mean_velocity: float
+    kinetic_energy_final: float = Field(ge=0.0)
+    cumulative_forcing_work: float = Field(ge=0.0)
+    cumulative_viscous_dissipation: float = Field(ge=0.0)
+    cumulative_em_dissipation: float = Field(ge=0.0)
+    energy_budget_abs_residual: float = Field(ge=0.0)
+    max_step_energy_budget_abs_residual: float = Field(ge=0.0)
+
+
+class G6ConvergenceSummary(BaseModel):
+    spatial_hartmann: float = Field(gt=0.0)
+    spatial_grids: tuple[int, int, int]
+    spatial_errors: tuple[float, float, float]
+    spatial_orders: tuple[float, float]
+    spatial_order_floor: float = Field(gt=0.0)
+    temporal_hartmann: float = Field(gt=0.0)
+    temporal_grid_size: int = Field(ge=5)
+    temporal_dts: tuple[float, float, float]
+    temporal_errors: tuple[float, float, float]
+    temporal_orders: tuple[float, float]
+    temporal_order_floor: float = Field(gt=0.0)
+
+
+class G6AcceptanceSummary(BaseModel):
+    spatial_convergence_pass: bool
+    temporal_convergence_pass: bool
+    transient_profile_accuracy_pass: bool
+    energy_budget_pass: bool
+    zero_field_em_sink_pass: bool
+    field_sign_symmetry_pass: bool
+    monotonic_magnetic_damping_pass: bool
+    positive_em_dissipation_pass: bool
+    steady_limit_consistency_pass: bool
+    finest_spatial_l2_limit: float = Field(gt=0.0)
+    finest_temporal_l2_limit: float = Field(gt=0.0)
+    energy_budget_abs_residual_limit: float = Field(gt=0.0)
+    zero_field_em_sink_limit: float = Field(gt=0.0)
+    field_sign_symmetry_l2_limit: float = Field(gt=0.0)
+    steady_limit_l2_limit: float = Field(gt=0.0)
+    field_sign_symmetry_l2: float = Field(ge=0.0)
+    steady_limit_l2: float = Field(ge=0.0)
+    acceptance_pass: bool
+
+
+class NSBG6Report(BaseModel):
+    qualification_id: str = "WS-NSB-2026-G6-001"
+    benchmark_version: str = "1.1"
+    formulation: str = "transient 1D quasi-static Hartmann channel-flow reference"
+    normalized_equation: str = "du/dt = d2u/dy2 - Ha^2 u + 1 on y in [-1,1], u(+/-1,t)=0, u(y,0)=0"
+    numerical_method: str = "Crank-Nicolson second-order centered finite differences with tridiagonal solve"
+    exact_reference: str = "Dirichlet sine-series transient solution"
+    energy_identity: str = "Delta E = W_forcing - D_viscous - D_EM"
+    cases: tuple[TransientHartmannCaseResult, ...]
+    convergence: G6ConvergenceSummary
+    acceptance: G6AcceptanceSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    transient_quasi_static_hartmann_reference_solved: bool = True
+    discrete_energy_budget_checked: bool = True
+    zero_field_control_checked: bool = True
+    field_sign_symmetry_checked: bool = True
+    steady_g5_limit_checked: bool = True
+    full_mhd_solver_claimed: bool = False
+    induction_equation_solved: bool = False
+    two_or_three_dimensional_mhd_claimed: bool = False
+    hall_two_fluid_or_kinetic_solved: bool = False
+    plasma_solved: bool = False
+    adaptive_em_control_validated: bool = False
+    laboratory_validation_performed: bool = False
+    propulsion_or_shielding_validated: bool = False
+    operational_validation_performed: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "G6 solves only a transient 1D quasi-static Hartmann reference with an imposed-field linear damping term.",
+        "The magnetic contribution is validated as a bounded energy sink in this reduced reference; no induction equation or general MHD capability is established.",
+        "Cross-checking the long-time limit against the steady G5 analytical profile does not constitute independent external validation.",
+        "No Hall-MHD, two-fluid, kinetic, plasma, adaptive electromagnetic control, laboratory, propulsion, shielding, stealth, cloaking, or operational capability is established.",
+        "Passing G6 does not reproduce, validate, or refute any finite-time Navier-Stokes singularity construction.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "NSBG6Report":
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("WS-NSB v1.1 must remain SIMULATED_ONLY")
+        required = (
+            self.transient_quasi_static_hartmann_reference_solved,
+            self.discrete_energy_budget_checked,
+            self.zero_field_control_checked,
+            self.field_sign_symmetry_checked,
+            self.steady_g5_limit_checked,
+        )
+        if not all(required):
+            raise ValueError("G6 report must represent the complete bounded transient reference gate")
+        prohibited = (
+            self.full_mhd_solver_claimed,
+            self.induction_equation_solved,
+            self.two_or_three_dimensional_mhd_claimed,
+            self.hall_two_fluid_or_kinetic_solved,
+            self.plasma_solved,
+            self.adaptive_em_control_validated,
+            self.laboratory_validation_performed,
+            self.propulsion_or_shielding_validated,
+            self.operational_validation_performed,
+        )
+        if any(prohibited):
+            raise ValueError("WS-NSB v1.1 cannot promote unsupported MHD, plasma, physical, or operational claims")
+        return self
+
+
+def _require_grid(grid_size: int) -> None:
+    if grid_size < 5 or grid_size % 2 == 0:
+        raise ValueError("transient Hartmann reference requires an odd grid_size >= 5")
+
+
+def _solve_tridiagonal(
+    lower: list[float],
+    diagonal: list[float],
+    upper: list[float],
+    rhs: list[float],
+) -> list[float]:
+    size = len(diagonal)
+    if size == 0 or len(rhs) != size:
+        raise ValueError("invalid tridiagonal system")
+    c_prime = [0.0] * max(0, size - 1)
+    d_prime = [0.0] * size
+    if size > 1:
+        c_prime[0] = upper[0] / diagonal[0]
+    d_prime[0] = rhs[0] / diagonal[0]
+    for index in range(1, size):
+        denominator = diagonal[index] - lower[index - 1] * c_prime[index - 1]
+        if abs(denominator) <= 1e-15:
+            raise ValueError("degenerate transient Hartmann tridiagonal system")
+        if index < size - 1:
+            c_prime[index] = upper[index] / denominator
+        d_prime[index] = (rhs[index] - lower[index - 1] * d_prime[index - 1]) / denominator
+
+    solution = [0.0] * size
+    solution[-1] = d_prime[-1]
+    for index in range(size - 2, -1, -1):
+        solution[index] = d_prime[index] - c_prime[index] * solution[index + 1]
+    return solution
+
+
+def transient_hartmann_exact_velocity(
+    y: float,
+    hartmann: float,
+    time_value: float,
+    *,
+    series_terms: int = 256,
+) -> float:
+    if time_value < 0.0:
+        raise ValueError("time_value must be nonnegative")
+    if series_terms < 8:
+        raise ValueError("series_terms must be >= 8")
+    if time_value == 0.0:
+        return 0.0
+    ha = abs(hartmann)
+    x = 0.5 * (y + 1.0)
+    total = 0.0
+    for index in range(series_terms):
+        n = 2 * index + 1
+        eigenvalue = (0.5 * n * math.pi) ** 2 + ha * ha
+        forcing_coefficient = 4.0 / (n * math.pi)
+        transient_factor = 1.0 - math.exp(-eigenvalue * time_value)
+        total += (
+            forcing_coefficient
+            * transient_factor
+            * math.sin(n * math.pi * x)
+            / eigenvalue
+        )
+    return total
+
+
+def steady_hartmann_exact_velocity(y: float, hartmann: float) -> float:
+    ha = abs(hartmann)
+    if ha == 0.0:
+        return 0.5 * (1.0 - y * y)
+    return (1.0 - math.cosh(ha * y) / math.cosh(ha)) / (ha * ha)
+
+
+def _crank_nicolson_step(
+    velocity: list[float],
+    *,
+    hartmann: float,
+    dt: float,
+    dy: float,
+) -> list[float]:
+    ha = abs(hartmann)
+    interior = len(velocity) - 2
+    ratio = dt / (2.0 * dy * dy)
+    damping_half = 0.5 * dt * ha * ha
+
+    lower = [-ratio] * (interior - 1)
+    diagonal = [1.0 + 2.0 * ratio + damping_half] * interior
+    upper = [-ratio] * (interior - 1)
+    rhs: list[float] = []
+
+    for index in range(1, len(velocity) - 1):
+        rhs.append(
+            (1.0 - 2.0 * ratio - damping_half) * velocity[index]
+            + ratio * (velocity[index - 1] + velocity[index + 1])
+            + dt
+        )
+
+    interior_solution = _solve_tridiagonal(lower, diagonal, upper, rhs)
+    return [0.0, *interior_solution, 0.0]
+
+
+def _kinetic_energy(values: list[float], dy: float) -> float:
+    return 0.5 * dy * sum(value * value for value in values[1:-1])
+
+
+def _mean_velocity(values: list[float], dy: float) -> float:
+    integral = dy * (0.5 * values[0] + sum(values[1:-1]) + 0.5 * values[-1])
+    return integral / 2.0
+
+
+def _l2_difference(left: list[float], right: list[float]) -> float:
+    if len(left) != len(right):
+        raise ValueError("profile lengths must match")
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(left, right, strict=True)) / len(left))
+
+
+def _linf_difference(left: list[float], right: list[float]) -> float:
+    return max(abs(a - b) for a, b in zip(left, right, strict=True))
+
+
+def integrate_transient_hartmann(
+    *,
+    hartmann: float,
+    grid_size: int,
+    dt: float,
+    final_time: float,
+) -> tuple[list[float], float, int, dict[str, float]]:
+    _require_grid(grid_size)
+    if dt <= 0.0 or final_time <= 0.0:
+        raise ValueError("dt and final_time must be positive")
+
+    steps = max(1, round(final_time / dt))
+    effective_dt = final_time / steps
+    dy = 2.0 / (grid_size - 1)
+    velocity = [0.0] * grid_size
+
+    forcing_work = 0.0
+    viscous_dissipation = 0.0
+    em_dissipation = 0.0
+    max_step_residual = 0.0
+    initial_energy = _kinetic_energy(velocity, dy)
+
+    for _ in range(steps):
+        next_velocity = _crank_nicolson_step(
+            velocity,
+            hartmann=hartmann,
+            dt=effective_dt,
+            dy=dy,
+        )
+        midpoint = [
+            0.5 * (before + after)
+            for before, after in zip(velocity, next_velocity, strict=True)
+        ]
+        before_energy = _kinetic_energy(velocity, dy)
+        after_energy = _kinetic_energy(next_velocity, dy)
+        forcing_power = dy * sum(midpoint[1:-1])
+        viscous_power = sum(
+            (midpoint[index + 1] - midpoint[index]) ** 2
+            for index in range(grid_size - 1)
+        ) / dy
+        em_power = abs(hartmann) ** 2 * dy * sum(
+            value * value for value in midpoint[1:-1]
+        )
+        step_residual = abs(
+            (after_energy - before_energy)
+            - effective_dt * (forcing_power - viscous_power - em_power)
+        )
+        max_step_residual = max(max_step_residual, step_residual)
+        forcing_work += effective_dt * forcing_power
+        viscous_dissipation += effective_dt * viscous_power
+        em_dissipation += effective_dt * em_power
+        velocity = next_velocity
+
+    final_energy = _kinetic_energy(velocity, dy)
+    cumulative_residual = abs(
+        (final_energy - initial_energy)
+        - (forcing_work - viscous_dissipation - em_dissipation)
+    )
+    return velocity, effective_dt, steps, {
+        "kinetic_energy_final": final_energy,
+        "cumulative_forcing_work": forcing_work,
+        "cumulative_viscous_dissipation": viscous_dissipation,
+        "cumulative_em_dissipation": em_dissipation,
+        "energy_budget_abs_residual": cumulative_residual,
+        "max_step_energy_budget_abs_residual": max_step_residual,
+    }
+
+
+def _case_result(
+    *,
+    case_id: str,
+    hartmann: float,
+    grid_size: int,
+    dt: float,
+    final_time: float,
+) -> tuple[TransientHartmannCaseResult, list[float]]:
+    numerical, effective_dt, steps, budget = integrate_transient_hartmann(
+        hartmann=hartmann,
+        grid_size=grid_size,
+        dt=dt,
+        final_time=final_time,
+    )
+    dy = 2.0 / (grid_size - 1)
+    y = [-1.0 + index * dy for index in range(grid_size)]
+    exact = [
+        transient_hartmann_exact_velocity(value, hartmann, final_time)
+        for value in y
+    ]
+    center = grid_size // 2
+    return (
+        TransientHartmannCaseResult(
+            case_id=case_id,
+            hartmann=abs(hartmann),
+            grid_size=grid_size,
+            requested_dt=dt,
+            effective_dt=effective_dt,
+            final_time=final_time,
+            steps=steps,
+            l2_velocity_error=_l2_difference(numerical, exact),
+            linf_velocity_error=_linf_difference(numerical, exact),
+            centerline_velocity=numerical[center],
+            mean_velocity=_mean_velocity(numerical, dy),
+            **budget,
+        ),
+        numerical,
+    )
+
+
+def _observed_order(coarse_error: float, fine_error: float) -> float:
+    if coarse_error <= 0.0 or fine_error <= 0.0:
+        raise ValueError("convergence errors must be positive")
+    return math.log(coarse_error / fine_error) / math.log(2.0)
+
+
+def run_nsb_g6_benchmark(
+    *,
+    sweep_hartmann: tuple[float, ...] = (0.0, 0.5, 1.0, 2.0, 5.0, 10.0),
+    sweep_grid_size: int = 129,
+    sweep_dt: float = 0.002,
+    sweep_final_time: float = 0.2,
+    spatial_hartmann: float = 2.0,
+    spatial_grids: tuple[int, int, int] = (33, 65, 129),
+    spatial_dt: float = 0.0005,
+    spatial_final_time: float = 0.2,
+    temporal_hartmann: float = 2.0,
+    temporal_grid_size: int = 513,
+    temporal_dts: tuple[float, float, float] = (0.08, 0.04, 0.02),
+    temporal_final_time: float = 0.4,
+    spatial_order_floor: float = 1.8,
+    temporal_order_floor: float = 1.8,
+    finest_spatial_l2_limit: float = 1e-5,
+    finest_temporal_l2_limit: float = 5e-5,
+    energy_budget_abs_residual_limit: float = 1e-10,
+    zero_field_em_sink_limit: float = 1e-14,
+    field_sign_symmetry_l2_limit: float = 1e-14,
+    steady_limit_l2_limit: float = 1e-5,
+) -> NSBG6Report:
+    _require_grid(sweep_grid_size)
+    _require_grid(temporal_grid_size)
+    if not sweep_hartmann or sweep_hartmann[0] != 0.0 or tuple(sorted(sweep_hartmann)) != sweep_hartmann:
+        raise ValueError("sweep_hartmann must be sorted and begin with zero")
+    if any(value < 0.0 for value in sweep_hartmann):
+        raise ValueError("sweep_hartmann values must be nonnegative")
+    if spatial_grids[1] != 2 * spatial_grids[0] - 1 or spatial_grids[2] != 2 * spatial_grids[1] - 1:
+        raise ValueError("spatial grids must halve spacing exactly")
+    if not (temporal_dts[0] == 2.0 * temporal_dts[1] and temporal_dts[1] == 2.0 * temporal_dts[2]):
+        raise ValueError("temporal dts must halve exactly")
+
+    cases = tuple(
+        _case_result(
+            case_id=f"transient_ha_{value:g}",
+            hartmann=value,
+            grid_size=sweep_grid_size,
+            dt=sweep_dt,
+            final_time=sweep_final_time,
+        )[0]
+        for value in sweep_hartmann
+    )
+
+    spatial_cases = tuple(
+        _case_result(
+            case_id=f"spatial_ha_{spatial_hartmann:g}_n_{grid}",
+            hartmann=spatial_hartmann,
+            grid_size=grid,
+            dt=spatial_dt,
+            final_time=spatial_final_time,
+        )[0]
+        for grid in spatial_grids
+    )
+    spatial_errors = tuple(item.l2_velocity_error for item in spatial_cases)
+    spatial_orders = (
+        _observed_order(spatial_errors[0], spatial_errors[1]),
+        _observed_order(spatial_errors[1], spatial_errors[2]),
+    )
+
+    temporal_cases = tuple(
+        _case_result(
+            case_id=f"temporal_ha_{temporal_hartmann:g}_dt_{dt:g}",
+            hartmann=temporal_hartmann,
+            grid_size=temporal_grid_size,
+            dt=dt,
+            final_time=temporal_final_time,
+        )[0]
+        for dt in temporal_dts
+    )
+    temporal_errors = tuple(item.l2_velocity_error for item in temporal_cases)
+    temporal_orders = (
+        _observed_order(temporal_errors[0], temporal_errors[1]),
+        _observed_order(temporal_errors[1], temporal_errors[2]),
+    )
+
+    _, positive = _case_result(
+        case_id="sign_positive",
+        hartmann=spatial_hartmann,
+        grid_size=sweep_grid_size,
+        dt=sweep_dt,
+        final_time=sweep_final_time,
+    )
+    _, negative = _case_result(
+        case_id="sign_negative",
+        hartmann=-spatial_hartmann,
+        grid_size=sweep_grid_size,
+        dt=sweep_dt,
+        final_time=sweep_final_time,
+    )
+    sign_symmetry_l2 = _l2_difference(positive, negative)
+
+    long_time, _, _, _ = integrate_transient_hartmann(
+        hartmann=spatial_hartmann,
+        grid_size=sweep_grid_size,
+        dt=0.01,
+        final_time=3.0,
+    )
+    dy = 2.0 / (sweep_grid_size - 1)
+    y = [-1.0 + index * dy for index in range(sweep_grid_size)]
+    steady_exact = [
+        steady_hartmann_exact_velocity(value, spatial_hartmann)
+        for value in y
+    ]
+    steady_limit_l2 = _l2_difference(long_time, steady_exact)
+
+    centerlines = tuple(case.centerline_velocity for case in cases)
+    means = tuple(case.mean_velocity for case in cases)
+    monotonic = all(
+        centerlines[index + 1] < centerlines[index]
+        and means[index + 1] < means[index]
+        for index in range(len(cases) - 1)
+    )
+
+    zero_field = cases[0]
+    spatial_pass = (
+        min(spatial_orders) >= spatial_order_floor
+        and spatial_errors[-1] <= finest_spatial_l2_limit
+    )
+    temporal_pass = (
+        min(temporal_orders) >= temporal_order_floor
+        and temporal_errors[-1] <= finest_temporal_l2_limit
+    )
+    profile_accuracy_pass = max(case.l2_velocity_error for case in cases) <= finest_spatial_l2_limit
+    all_budget_cases = (*cases, *spatial_cases, *temporal_cases)
+    energy_budget_pass = max(
+        case.energy_budget_abs_residual for case in all_budget_cases
+    ) <= energy_budget_abs_residual_limit
+    zero_field_pass = zero_field.cumulative_em_dissipation <= zero_field_em_sink_limit
+    symmetry_pass = sign_symmetry_l2 <= field_sign_symmetry_l2_limit
+    positive_em_pass = all(
+        case.cumulative_em_dissipation > zero_field_em_sink_limit
+        for case in cases[1:]
+    )
+    steady_pass = steady_limit_l2 <= steady_limit_l2_limit
+    acceptance_pass = (
+        spatial_pass
+        and temporal_pass
+        and profile_accuracy_pass
+        and energy_budget_pass
+        and zero_field_pass
+        and symmetry_pass
+        and monotonic
+        and positive_em_pass
+        and steady_pass
+    )
+
+    report = NSBG6Report(
+        cases=cases,
+        convergence=G6ConvergenceSummary(
+            spatial_hartmann=spatial_hartmann,
+            spatial_grids=spatial_grids,
+            spatial_errors=spatial_errors,
+            spatial_orders=spatial_orders,
+            spatial_order_floor=spatial_order_floor,
+            temporal_hartmann=temporal_hartmann,
+            temporal_grid_size=temporal_grid_size,
+            temporal_dts=temporal_dts,
+            temporal_errors=temporal_errors,
+            temporal_orders=temporal_orders,
+            temporal_order_floor=temporal_order_floor,
+        ),
+        acceptance=G6AcceptanceSummary(
+            spatial_convergence_pass=spatial_pass,
+            temporal_convergence_pass=temporal_pass,
+            transient_profile_accuracy_pass=profile_accuracy_pass,
+            energy_budget_pass=energy_budget_pass,
+            zero_field_em_sink_pass=zero_field_pass,
+            field_sign_symmetry_pass=symmetry_pass,
+            monotonic_magnetic_damping_pass=monotonic,
+            positive_em_dissipation_pass=positive_em_pass,
+            steady_limit_consistency_pass=steady_pass,
+            finest_spatial_l2_limit=finest_spatial_l2_limit,
+            finest_temporal_l2_limit=finest_temporal_l2_limit,
+            energy_budget_abs_residual_limit=energy_budget_abs_residual_limit,
+            zero_field_em_sink_limit=zero_field_em_sink_limit,
+            field_sign_symmetry_l2_limit=field_sign_symmetry_l2_limit,
+            steady_limit_l2_limit=steady_limit_l2_limit,
+            field_sign_symmetry_l2=sign_symmetry_l2,
+            steady_limit_l2=steady_limit_l2,
+            acceptance_pass=acceptance_pass,
+        ),
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_nsb_g6_report(report: NSBG6Report) -> bool:
+    expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.report_digest == expected


### PR DESCRIPTION
## Summary

Advances WS-NSB from the steady 1D G5 Hartmann reference to a bounded **time-dependent** quasi-static Hartmann gate with an analytically checkable transient and explicit energy-budget closure.

### Included
- `worldshepherd_sara/nsb_g6_transient_hartmann.py`
  - normalized transient equation `du/dt = d2u/dy2 - Ha^2 u + 1`
  - Crank-Nicolson second-order time integration
  - centered finite differences in space
  - exact Dirichlet sine-series transient profile
  - spatial convergence on 33/65/129 grids
  - temporal convergence on dt = 0.08/0.04/0.02
  - discrete energy identity `Delta E = W_forcing - D_viscous - D_EM`
  - zero-field electromagnetic sink control
  - +Ha/-Ha sign symmetry for the reduced Ha^2 term
  - monotonic magnetic damping sweep
  - long-time consistency check against the steady G5 analytical Hartmann profile
  - deterministic SHA-256 report binding
  - fail-closed claims controls
- `worldshepherd_sara/nsb_g6_cli.py`
- `tests/test_nsb_g6_transient_hartmann.py`
- `docs/WS_NSB_V1_1_G6_TRANSIENT_HARTMANN.md`
- `ws-nsb-g6` console entry point
- dedicated `WS-NSB v1.1 G6 Gate` workflow

## Claims boundary

This remains a transient **1D quasi-static Hartmann reference only**. It does not claim a full MHD solver, induction-equation capability, 2D/3D magnetofluid capability, Hall-MHD/two-fluid/kinetic/plasma capability, adaptive electromagnetic control, laboratory validation, finite-time singularity reproduction, propulsion, shielding, stealth, cloaking, or operational capability.

The report remains `SIMULATED_ONLY` and rejects unsupported promotion flags.

## Acceptance intent

Default gate requires spatial and temporal observed order >= 1.8, finest spatial L2 <= 1e-5, finest temporal L2 <= 5e-5, cumulative energy-budget residual <= 1e-10, zero-field EM dissipation <= 1e-14, positive EM dissipation for all nonzero-Ha cases, +Ha/-Ha L2 difference <= 1e-14, monotonic transient flow reduction with increasing Ha, and long-time consistency with G5 within 1e-5 L2.