### PR TITLE
Fix post-merge G6 evidence and domain-contract gaps

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
@@ -92,3 +92,22 @@ def test_steady_reference_is_finite_for_large_hartmann_values():
     assert extreme_velocity == pytest.approx(1e-310, rel=1e-12, abs=0.0)
     assert steady_hartmann_exact_velocity(-1.0, 1000.0) == pytest.approx(0.0)
     assert steady_hartmann_exact_velocity(1.0, 1000.0) == pytest.approx(0.0)
+
+def test_convergence_summary_records_effective_time_steps():
+    custom = run_nsb_g6_benchmark(
+        temporal_dts=(0.3, 0.15, 0.075),
+        temporal_final_time=1.0,
+    )
+    assert custom.convergence.temporal_dts == (0.3, 0.15, 0.075)
+    assert custom.convergence.temporal_effective_dts == pytest.approx(
+        (1.0 / 3.0, 1.0 / 7.0, 1.0 / 13.0)
+    )
+    payload = custom.model_dump(mode="json")
+    assert payload["convergence"]["temporal_effective_dts"] == pytest.approx(
+        (1.0 / 3.0, 1.0 / 7.0, 1.0 / 13.0)
+    )
+
+
+def test_steady_reference_rejects_out_of_domain_y_at_zero_field():
+    with pytest.raises(ValueError, match=r"y in \[-1, 1\]"):
+        steady_hartmann_exact_velocity(2.0, 0.0)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py
@@ -36,6 +36,7 @@ class G6ConvergenceSummary(BaseModel):
     temporal_hartmann: float = Field(gt=0.0)
     temporal_grid_size: int = Field(ge=5)
     temporal_dts: tuple[float, float, float]
+    temporal_effective_dts: tuple[float, float, float]
     temporal_errors: tuple[float, float, float]
     temporal_orders: tuple[float, float]
     temporal_order_floor: float = Field(gt=0.0)
@@ -191,11 +192,11 @@ def transient_hartmann_exact_velocity(
 
 
 def steady_hartmann_exact_velocity(y: float, hartmann: float) -> float:
+    if abs(y) > 1.0:
+        raise ValueError("steady Hartmann reference requires y in [-1, 1]")
     ha = abs(hartmann)
     if ha == 0.0:
         return 0.5 * (1.0 - y * y)
-    if abs(y) > 1.0:
-        raise ValueError("steady Hartmann reference requires y in [-1, 1]")
     if ha < 20.0:
         cosh_ratio = math.cosh(ha * y) / math.cosh(ha)
     else:
@@ -548,6 +549,7 @@ def run_nsb_g6_benchmark(
             temporal_hartmann=temporal_hartmann,
             temporal_grid_size=temporal_grid_size,
             temporal_dts=temporal_dts,
+            temporal_effective_dts=tuple(case.effective_dt for case in temporal_cases),
             temporal_errors=temporal_errors,
             temporal_orders=temporal_orders,
             temporal_order_floor=temporal_order_floor,


### PR DESCRIPTION
## Summary

Post-merge correction for two P2 findings that arrived after PR #133 merged:

- serialize the effective temporal step sizes actually used after final-time rounding, so the reported convergence orders are independently reproducible from the evidence record;
- enforce the bounded steady-reference domain `y in [-1, 1]` before the zero-Hartmann early return, making the input contract field-strength independent.

Focused regression coverage uses requested `dt=(0.3, 0.15, 0.075)` at final time 1.0 and verifies effective steps `(1/3, 1/7, 1/13)`, including their serialized presence. A separate regression verifies out-of-domain rejection at zero field.

## Exact-head evidence

Current head: `6d19c0dbc812200131635db2e1e8e1eab9bb93d0`

All eight exact-head workflows pass, including **WS-NSB v1.1 G6 Gate** and **SARA Verified Local v1 Gate**. The fresh exact-head Codex review reported no major issues. Both originating PR #133 P2 threads are dispositioned and resolved.

## Claims boundary

This remains **SIMULATED_ONLY** for the bounded 1D quasi-static Hartmann reference. It does not establish full MHD, plasma, laboratory, propulsion, shielding, stealth, cloaking, or operational capability.

## Gate

**DRAFT / REVIEW CLEAN / BLOCK MERGE** pending explicit CRE1AWS incorporation authorization.