### PR TITLE
Fix G6 post-merge reproducibility and domain contract

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g6_transient_hartmann.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from worldshepherd_sara.nsb_g6_transient_hartmann import (
@@ -75,7 +77,6 @@ def test_invalid_even_grid_is_rejected():
         integrate_transient_hartmann(hartmann=2.0, grid_size=32, dt=0.01, final_time=0.1)
 
 
-
 def test_sweep_requires_a_positive_magnetic_case():
     with pytest.raises(ValueError, match="include a positive field case"):
         run_nsb_g6_benchmark(sweep_hartmann=(0.0,))
@@ -92,3 +93,29 @@ def test_steady_reference_is_finite_for_large_hartmann_values():
     assert extreme_velocity == pytest.approx(1e-310, rel=1e-12, abs=0.0)
     assert steady_hartmann_exact_velocity(-1.0, 1000.0) == pytest.approx(0.0)
     assert steady_hartmann_exact_velocity(1.0, 1000.0) == pytest.approx(0.0)
+
+
+def test_custom_temporal_run_serializes_effective_time_steps_for_reproducibility():
+    custom = run_nsb_g6_benchmark(
+        temporal_dts=(0.3, 0.15, 0.075),
+        temporal_final_time=1.0,
+        temporal_order_floor=0.1,
+        finest_temporal_l2_limit=1.0,
+    )
+    effective = custom.convergence.temporal_effective_dts
+    assert effective == pytest.approx((1.0 / 3.0, 1.0 / 7.0, 1.0 / 13.0))
+    assert custom.convergence.temporal_final_time == pytest.approx(1.0)
+    errors = custom.convergence.temporal_errors
+    reconstructed = (
+        math.log(errors[0] / errors[1]) / math.log(effective[0] / effective[1]),
+        math.log(errors[1] / errors[2]) / math.log(effective[1] / effective[2]),
+    )
+    assert custom.convergence.temporal_orders == pytest.approx(reconstructed)
+
+
+def test_steady_reference_domain_guard_is_field_independent():
+    for ha in (0.0, 1.0, 1000.0):
+        with pytest.raises(ValueError, match=r"y in \[-1, 1\]"):
+            steady_hartmann_exact_velocity(2.0, ha)
+        with pytest.raises(ValueError, match=r"y in \[-1, 1\]"):
+            steady_hartmann_exact_velocity(-2.0, ha)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g6_transient_hartmann.py
@@ -36,6 +36,8 @@ class G6ConvergenceSummary(BaseModel):
     temporal_hartmann: float = Field(gt=0.0)
     temporal_grid_size: int = Field(ge=5)
     temporal_dts: tuple[float, float, float]
+    temporal_effective_dts: tuple[float, float, float]
+    temporal_final_time: float = Field(gt=0.0)
     temporal_errors: tuple[float, float, float]
     temporal_orders: tuple[float, float]
     temporal_order_floor: float = Field(gt=0.0)
@@ -181,21 +183,16 @@ def transient_hartmann_exact_velocity(
         eigenvalue = (0.5 * n * math.pi) ** 2 + ha * ha
         forcing_coefficient = 4.0 / (n * math.pi)
         transient_factor = 1.0 - math.exp(-eigenvalue * time_value)
-        total += (
-            forcing_coefficient
-            * transient_factor
-            * math.sin(n * math.pi * x)
-            / eigenvalue
-        )
+        total += forcing_coefficient * transient_factor * math.sin(n * math.pi * x) / eigenvalue
     return total
 
 
 def steady_hartmann_exact_velocity(y: float, hartmann: float) -> float:
+    if abs(y) > 1.0:
+        raise ValueError("steady Hartmann reference requires y in [-1, 1]")
     ha = abs(hartmann)
     if ha == 0.0:
         return 0.5 * (1.0 - y * y)
-    if abs(y) > 1.0:
-        raise ValueError("steady Hartmann reference requires y in [-1, 1]")
     if ha < 20.0:
         cosh_ratio = math.cosh(ha * y) / math.cosh(ha)
     else:
@@ -283,20 +280,12 @@ def integrate_transient_hartmann(
             dt=effective_dt,
             dy=dy,
         )
-        midpoint = [
-            0.5 * (before + after)
-            for before, after in zip(velocity, next_velocity, strict=True)
-        ]
+        midpoint = [0.5 * (before + after) for before, after in zip(velocity, next_velocity, strict=True)]
         before_energy = _kinetic_energy(velocity, dy)
         after_energy = _kinetic_energy(next_velocity, dy)
         forcing_power = dy * sum(midpoint[1:-1])
-        viscous_power = sum(
-            (midpoint[index + 1] - midpoint[index]) ** 2
-            for index in range(grid_size - 1)
-        ) / dy
-        em_power = abs(hartmann) ** 2 * dy * sum(
-            value * value for value in midpoint[1:-1]
-        )
+        viscous_power = sum((midpoint[index + 1] - midpoint[index]) ** 2 for index in range(grid_size - 1)) / dy
+        em_power = abs(hartmann) ** 2 * dy * sum(value * value for value in midpoint[1:-1])
         step_residual = abs(
             (after_energy - before_energy)
             - effective_dt * (forcing_power - viscous_power - em_power)
@@ -338,10 +327,7 @@ def _case_result(
     )
     dy = 2.0 / (grid_size - 1)
     y = [-1.0 + index * dy for index in range(grid_size)]
-    exact = [
-        transient_hartmann_exact_velocity(value, hartmann, final_time)
-        for value in y
-    ]
+    exact = [transient_hartmann_exact_velocity(value, hartmann, final_time) for value in y]
     center = grid_size // 2
     return (
         TransientHartmannCaseResult(
@@ -453,16 +439,17 @@ def run_nsb_g6_benchmark(
         for dt in temporal_dts
     )
     temporal_errors = tuple(item.l2_velocity_error for item in temporal_cases)
+    temporal_effective_dts = tuple(item.effective_dt for item in temporal_cases)
     temporal_orders = (
         _observed_order(
             temporal_errors[0],
             temporal_errors[1],
-            temporal_cases[0].effective_dt / temporal_cases[1].effective_dt,
+            temporal_effective_dts[0] / temporal_effective_dts[1],
         ),
         _observed_order(
             temporal_errors[1],
             temporal_errors[2],
-            temporal_cases[1].effective_dt / temporal_cases[2].effective_dt,
+            temporal_effective_dts[1] / temporal_effective_dts[2],
         ),
     )
 
@@ -490,10 +477,7 @@ def run_nsb_g6_benchmark(
     )
     dy = 2.0 / (sweep_grid_size - 1)
     y = [-1.0 + index * dy for index in range(sweep_grid_size)]
-    steady_exact = [
-        steady_hartmann_exact_velocity(value, spatial_hartmann)
-        for value in y
-    ]
+    steady_exact = [steady_hartmann_exact_velocity(value, spatial_hartmann) for value in y]
     steady_limit_l2 = _l2_difference(long_time, steady_exact)
 
     centerlines = tuple(case.centerline_velocity for case in cases)
@@ -505,19 +489,11 @@ def run_nsb_g6_benchmark(
     )
 
     zero_field = cases[0]
-    spatial_pass = (
-        min(spatial_orders) >= spatial_order_floor
-        and spatial_errors[-1] <= finest_spatial_l2_limit
-    )
-    temporal_pass = (
-        min(temporal_orders) >= temporal_order_floor
-        and temporal_errors[-1] <= finest_temporal_l2_limit
-    )
+    spatial_pass = min(spatial_orders) >= spatial_order_floor and spatial_errors[-1] <= finest_spatial_l2_limit
+    temporal_pass = min(temporal_orders) >= temporal_order_floor and temporal_errors[-1] <= finest_temporal_l2_limit
     profile_accuracy_pass = max(case.l2_velocity_error for case in cases) <= finest_spatial_l2_limit
     all_budget_cases = (*cases, *spatial_cases, *temporal_cases)
-    energy_budget_pass = max(
-        case.energy_budget_abs_residual for case in all_budget_cases
-    ) <= energy_budget_abs_residual_limit
+    energy_budget_pass = max(case.energy_budget_abs_residual for case in all_budget_cases) <= energy_budget_abs_residual_limit
     zero_field_pass = zero_field.cumulative_em_dissipation <= zero_field_em_sink_limit
     symmetry_pass = sign_symmetry_l2 <= field_sign_symmetry_l2_limit
     positive_em_pass = all(
@@ -548,6 +524,8 @@ def run_nsb_g6_benchmark(
             temporal_hartmann=temporal_hartmann,
             temporal_grid_size=temporal_grid_size,
             temporal_dts=temporal_dts,
+            temporal_effective_dts=temporal_effective_dts,
+            temporal_final_time=temporal_final_time,
             temporal_errors=temporal_errors,
             temporal_orders=temporal_orders,
             temporal_order_floor=temporal_order_floor,


### PR DESCRIPTION
Addresses issue #134 on a branch frozen from main commit `4dbddaa148f9fa5cb98abf2cbf316002e69ca4c3`.

Changes:
- serialize `temporal_effective_dts` and `temporal_final_time` in `G6ConvergenceSummary` so custom-run temporal orders can be reconstructed from report evidence;
- compute temporal orders from the serialized effective-step tuple;
- apply the steady Hartmann `y in [-1,1]` guard before the zero-field return so the input contract is field-independent;
- add regressions using requested dts `(0.3, 0.15, 0.075)` with `final_time=1.0`, reconstructing orders from effective dts `(1/3, 1/7, 1/13)`;
- add out-of-domain regressions for zero and nonzero Hartmann values.

Claims boundary: bounded `SIMULATED_ONLY` reference only. This PR does not establish full MHD, plasma, laboratory, propulsion, shielding, or operational capability.

Gate: draft until relevant CI and fresh exact-head review pass. Do not merge solely on prior PR #133 evidence.