### PR TITLE
Add WS-NSB v1.3 G8 independent magnetic replication gate

### DIFF
--- a/.github/workflows/ws-nsb-v1-3-g8.yml
+++ b/.github/workflows/ws-nsb-v1-3-g8.yml
@@ -1,0 +1,62 @@
+name: WS-NSB v1.3 G8 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_independent_magnetic.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g8_independent_magnetic.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_3_G8_INDEPENDENT_MAGNETIC.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-3-g8.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_independent_magnetic.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g8_independent_magnetic.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_3_G8_INDEPENDENT_MAGNETIC.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-3-g8.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  g8-independent-magnetic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and tests
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Run G8 test suite
+        run: python -m pytest tests/test_nsb_g8_independent_magnetic.py -q
+
+      - name: Execute and verify deterministic G8 report
+        run: |
+          rm -f ws_nsb_g8_report.json
+          ws-nsb-g8 --output ws_nsb_g8_report.json
+          ws-nsb-g8 --verify ws_nsb_g8_report.json
+
+      - name: Upload G8 evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ws-nsb-v1-3-g8-report
+          path: deployments/sara_verified_local_v1/ws_nsb_g8_report.json
+          if-no-files-found: error

--- a/deployments/sara_verified_local_v1/docs/WS_NSB_V1_3_G8_INDEPENDENT_MAGNETIC.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NSB_V1_3_G8_INDEPENDENT_MAGNETIC.md
@@ -1,0 +1,113 @@
+# WS-NSB v1.3 — G8 Independent Magnetic Replication Gate
+
+## Purpose
+
+G8 tests the G7 low-magnetic-Reynolds-number imposed-field magnetic operator through a numerically distinct implementation.
+
+G7 uses a Fourier-space damping operator. G8 does **not** call that operator. Instead, it starts from analytical periodic velocity fields, applies normalized quasi-static Ohm/Lorentz relations in physical space, takes the Lorentz-force curl with second-order centered finite differences, and compares the result against the analytical mode-by-mode target.
+
+This is an internal cross-method verification gate, not an independent external laboratory or third-party replication.
+
+## Bounded model
+
+The reference is strictly two-dimensional, periodic, z-invariant, homogeneous, and uses a uniform in-plane imposed field
+
+\[
+\hat{\mathbf B}=(\cos\theta,\sin\theta,0).
+\]
+
+Magnetic-field magnitude, electrical conductivity, density, and other normalization factors are absorbed into the nonnegative coupling parameter \(\Lambda\).
+
+For velocity \(\mathbf u=(u,v,0)\), the normalized low-Rm induced current is
+
+\[
+j_z=uB_y-vB_x.
+\]
+
+The Lorentz force is
+
+\[
+\mathbf f_L
+=
+\Lambda j_z(-B_y,B_x,0).
+\]
+
+The vorticity tendency used by the finite-difference implementation is
+
+\[
+(\nabla\times\mathbf f_L)_z
+=
+\Lambda\left(
+B_x\partial_x j_z+B_y\partial_y j_z
+\right).
+\]
+
+For a Fourier mode with wavevector \(\mathbf k\), incompressibility gives the analytical reference
+
+\[
+\left.\partial_t\hat\omega_{\mathbf k}\right|_B
+=
+-\Lambda
+\frac{(\mathbf k\cdot\hat{\mathbf B})^2}{|\mathbf k|^2}
+\hat\omega_{\mathbf k}.
+\]
+
+The Joule/Lorentz work identity is also checked:
+
+\[
+D_J
+=
+\Lambda\langle j_z^2\rangle
+=
+-\langle\mathbf u\cdot\mathbf f_L\rangle
+\ge 0.
+\]
+
+In this strict 2D in-plane-field geometry the induced current is purely z-directed and all fields are z-invariant, so \(\nabla\cdot\mathbf j=0\) follows geometrically. G8 therefore does **not** claim an electric-potential Poisson solve.
+
+## Verification matrix
+
+The default gate uses a three-mode analytical streamfunction field and grid sizes 32, 64, and 128. It requires factor-two refinement and verifies second-order spatial convergence of the physical-space magnetic vorticity operator.
+
+It separately exercises:
+
+- field parallel to the test wavevector: maximum magnetic damping;
+- field perpendicular to the wavevector: magnetic null;
+- x-directed imposed field with oblique wavevector;
+- arbitrary continuous field angle;
+- reversal \(\mathbf B\rightarrow-\mathbf B\), which must leave the Lorentz damping unchanged;
+- \(\Lambda=0\), which must remove the magnetic operator and Joule dissipation;
+- Joule dissipation equals negative Lorentz work.
+
+## Default acceptance criteria
+
+- observed spatial order >= 1.9;
+- finest-grid L2 error <= 5e-3;
+- finest-grid relative L2 error <= 3e-3;
+- every orientation-case L2 error <= 5e-3;
+- perpendicular-field magnetic sink <= 1e-12;
+- field-reversal L2 difference <= 1e-12;
+- zero-magnetic operator and dissipation <= 1e-12;
+- Joule/work identity error <= 1e-12;
+- deterministic report digest validates.
+
+## Claims boundary
+
+Passing G8 supports only:
+
+`IMPLEMENTED IN SOFTWARE — SIMULATED ONLY`
+
+Specifically, it supports a numerically distinct internal replication of the bounded G7 low-Rm imposed-field magnetic damping operator.
+
+It does not establish:
+
+- magnetic induction or finite-Rm MHD;
+- an electric-potential/current-continuity solver for general geometries;
+- general 2D or 3D magnetofluid boundary conditions;
+- Hall-MHD, two-fluid, kinetic, or plasma capability;
+- adaptive electromagnetic control;
+- laboratory validation;
+- propulsion, shielding, stealth, cloaking, or operational capability;
+- reproduction or validation of any finite-time Navier-Stokes singularity construction.
+
+The next primary scientific gate after G8 is a separately bounded finite-Rm induction test with an analytical magnetic-diffusion/Alfvén reference, not a promotion to plasma or propulsion claims.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -41,6 +41,7 @@ ws-nsb-g4 = "worldshepherd_sara.nsb_g4_cli:main"
 ws-nsb-g5 = "worldshepherd_sara.nsb_g5_cli:main"
 ws-nsb-g6 = "worldshepherd_sara.nsb_g6_cli:main"
 ws-nsb-g7 = "worldshepherd_sara.nsb_g7_cli:main"
+ws-nsb-g8 = "worldshepherd_sara.nsb_g8_cli:main"
 ws-omega-recursion = "worldshepherd_sara.recursive_discovery_cli:main"
 
 [tool.setuptools]

--- a/deployments/sara_verified_local_v1/tests/test_nsb_g8_independent_magnetic.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g8_independent_magnetic.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.nsb_g8_independent_magnetic import (
+    NSBG8Report,
+    finite_difference_ohm_lorentz_operator,
+    run_nsb_g8_benchmark,
+    verify_nsb_g8_report,
+)
+
+
+@pytest.fixture(scope="module")
+def report():
+    return run_nsb_g8_benchmark()
+
+
+def test_default_g8_gate_passes_and_digest_verifies(report):
+    assert report.acceptance.acceptance_pass is True
+    assert verify_nsb_g8_report(report) is True
+    assert report.report_digest is not None
+    assert report.report_digest.startswith("sha256:")
+
+
+def test_independent_fd_replication_is_second_order(report):
+    assert min(report.acceptance.spatial_orders) >= 1.9
+    assert report.resolution_results[-1].l2_error <= 5e-3
+    assert report.resolution_results[-1].relative_l2_error <= 3e-3
+
+
+def test_orientation_null_and_maximum_cases_are_reproduced(report):
+    parallel = report.orientation_results[0]
+    perpendicular = report.orientation_results[1]
+    assert parallel.orientation_fraction == pytest.approx(1.0, abs=1e-15)
+    assert parallel.joule_dissipation_rate > 0.0
+    assert perpendicular.orientation_fraction == pytest.approx(0.0, abs=1e-15)
+    assert perpendicular.joule_dissipation_rate <= 1e-12
+    assert perpendicular.fd_rms <= 1e-12
+
+
+def test_joule_dissipation_matches_negative_lorentz_work(report):
+    results = (*report.resolution_results, *report.orientation_results)
+    assert max(result.work_identity_abs_error for result in results) <= 1e-12
+
+
+def test_field_reversal_and_zero_magnetic_limits(report):
+    assert report.field_sign_symmetry_l2 <= 1e-12
+    assert report.zero_magnetic_operator_l2 <= 1e-12
+    assert report.zero_magnetic_dissipation <= 1e-12
+
+
+def test_public_fd_operator_rejects_bad_shapes_and_negative_damping():
+    u = [[0.0] * 16 for _ in range(16)]
+    v = [[0.0] * 16 for _ in range(16)]
+    with pytest.raises(ValueError):
+        finite_difference_ohm_lorentz_operator(
+            u=u,
+            v=v[:-1],
+            field_angle_rad=0.0,
+            magnetic_damping=0.7,
+        )
+    with pytest.raises(ValueError):
+        finite_difference_ohm_lorentz_operator(
+            u=u,
+            v=v,
+            field_angle_rad=0.0,
+            magnetic_damping=-0.1,
+        )
+
+
+def test_report_tampering_breaks_digest(report):
+    tampered = report.model_copy(update={"benchmark_version": "tampered"})
+    assert verify_nsb_g8_report(tampered) is False
+
+
+def test_claim_promotion_fails_closed(report):
+    payload = report.model_dump(mode="json")
+    payload["induction_equation_solved"] = True
+    with pytest.raises(ValueError):
+        NSBG8Report.model_validate(payload)
+
+    payload = report.model_dump(mode="json")
+    payload["spectral_magnetic_operator_called"] = True
+    with pytest.raises(ValueError):
+        NSBG8Report.model_validate(payload)
+
+
+def test_non_factor_two_resolution_sequence_is_rejected():
+    with pytest.raises(ValueError):
+        run_nsb_g8_benchmark(resolution_grids=(32, 48, 96))
+
+
+def test_field_angle_is_continuous_not_discrete(report):
+    arbitrary = report.orientation_results[-1]
+    assert arbitrary.field_angle_rad == pytest.approx(0.37)
+    assert 0.0 < arbitrary.orientation_fraction < 1.0
+    assert arbitrary.l2_error <= report.acceptance.orientation_l2_limit

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .nsb_g8_independent_magnetic import NSBG8Report, run_nsb_g8_benchmark, verify_nsb_g8_report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the bounded WS-NSB v1.3 G8 independent finite-difference magnetic replication gate."
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _serialize(report: NSBG8Report) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = NSBG8Report.model_validate(payload)
+        if not verify_nsb_g8_report(report):
+            print("INVALID")
+            return 1
+        if not report.acceptance.acceptance_pass:
+            print("VALID-BUT-GATE-FAILED")
+            return 2
+        print("VALID")
+        return 0
+
+    report = run_nsb_g8_benchmark()
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0 if report.acceptance.acceptance_pass else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_independent_magnetic.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g8_independent_magnetic.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import math
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import CapabilityStatus, canonical_digest
+
+
+TWO_PI = 2.0 * math.pi
+ModeSpec = tuple[str, float, int, int, float]
+
+
+class G8ResolutionResult(BaseModel):
+    grid_size: int = Field(ge=16)
+    target_rms: float = Field(ge=0.0)
+    fd_rms: float = Field(ge=0.0)
+    l2_error: float = Field(ge=0.0)
+    relative_l2_error: float = Field(ge=0.0)
+    max_abs_error: float = Field(ge=0.0)
+    joule_dissipation_rate: float = Field(ge=0.0)
+    lorentz_work_dissipation_rate: float = Field(ge=0.0)
+    work_identity_abs_error: float = Field(ge=0.0)
+
+
+class G8OrientationResult(BaseModel):
+    case_id: str
+    grid_size: int = Field(ge=16)
+    kx: int
+    ky: int
+    field_angle_rad: float
+    orientation_fraction: float = Field(ge=0.0, le=1.0)
+    target_rms: float = Field(ge=0.0)
+    fd_rms: float = Field(ge=0.0)
+    l2_error: float = Field(ge=0.0)
+    joule_dissipation_rate: float = Field(ge=0.0)
+    lorentz_work_dissipation_rate: float = Field(ge=0.0)
+    work_identity_abs_error: float = Field(ge=0.0)
+
+
+class G8AcceptanceSummary(BaseModel):
+    spatial_order_floor: float = Field(gt=0.0)
+    spatial_orders: tuple[float, float]
+    finest_l2_limit: float = Field(gt=0.0)
+    finest_relative_l2_limit: float = Field(gt=0.0)
+    orientation_l2_limit: float = Field(gt=0.0)
+    null_sink_limit: float = Field(gt=0.0)
+    field_sign_l2_limit: float = Field(gt=0.0)
+    work_identity_limit: float = Field(gt=0.0)
+    spatial_convergence_pass: bool
+    orientation_replication_pass: bool
+    field_perpendicular_null_pass: bool
+    field_parallel_max_pass: bool
+    field_sign_symmetry_pass: bool
+    zero_magnetic_limit_pass: bool
+    joule_work_identity_pass: bool
+    acceptance_pass: bool
+
+
+class NSBG8Report(BaseModel):
+    qualification_id: str = "WS-NSB-2026-G8-001"
+    benchmark_version: str = "1.3"
+    formulation: str = "independent finite-difference Ohm-Lorentz replication of the G7 low-Rm imposed-field magnetic operator"
+    physical_scope: str = "strictly 2D periodic, z-invariant, homogeneous low-Rm imposed-field reference"
+    normalized_ohm_law: str = "j_z = u*B_y - v*B_x"
+    normalized_lorentz_force: str = "f = Lambda*j_z*(-B_y, B_x)"
+    vorticity_operator: str = "curl(f)_z = Lambda*(B_x*d_x(j_z) + B_y*d_y(j_z))"
+    joule_identity: str = "D_J = Lambda*<j_z^2> = -<u dot f>"
+    spatial_scheme: str = "second-order centered finite differences on a periodic grid"
+    reference_target: str = "analytical Fourier-mode decay operator -Lambda*(k_parallel^2/|k|^2)*omega"
+    resolution_results: tuple[G8ResolutionResult, ...]
+    orientation_results: tuple[G8OrientationResult, ...]
+    field_sign_symmetry_l2: float = Field(ge=0.0)
+    zero_magnetic_operator_l2: float = Field(ge=0.0)
+    zero_magnetic_dissipation: float = Field(ge=0.0)
+    acceptance: G8AcceptanceSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    independent_fd_ohm_lorentz_replication_implemented: bool = True
+    analytical_reference_target_used: bool = True
+    spectral_magnetic_operator_called: bool = False
+    current_potential_poisson_solved: bool = False
+    induction_equation_solved: bool = False
+    finite_rm_mhd_claimed: bool = False
+    general_2d_or_3d_mhd_claimed: bool = False
+    hall_two_fluid_or_kinetic_solved: bool = False
+    plasma_solved: bool = False
+    adaptive_em_control_validated: bool = False
+    laboratory_validation_performed: bool = False
+    navier_stokes_singularity_reproduced: bool = False
+    propulsion_or_shielding_validated: bool = False
+    operational_validation_performed: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "G8 is an internal numerically distinct replication of the bounded G7 low-Rm imposed-field magnetic operator.",
+        "The finite-difference path does not call the G7 spectral magnetic operator; the comparison target is derived analytically mode by mode.",
+        "In this strict 2D in-plane-field reference, induced current is purely z-directed and charge conservation is automatic under z invariance; no electric-potential Poisson solve is claimed.",
+        "Passing G8 does not establish finite-Rm induction physics, general MHD, Hall-MHD, two-fluid, kinetic, plasma, adaptive electromagnetic control, laboratory, propulsion, shielding, stealth, cloaking, or operational capability.",
+        "Passing G8 does not reproduce, validate, or refute any finite-time Navier-Stokes singularity construction.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "NSBG8Report":
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("WS-NSB v1.3 must remain SIMULATED_ONLY")
+        if not self.independent_fd_ohm_lorentz_replication_implemented or not self.analytical_reference_target_used:
+            raise ValueError("G8 must represent the complete independent finite-difference replication gate")
+        if self.spectral_magnetic_operator_called:
+            raise ValueError("G8 independence is invalid if the G7 spectral magnetic operator is called")
+        prohibited = (
+            self.current_potential_poisson_solved,
+            self.induction_equation_solved,
+            self.finite_rm_mhd_claimed,
+            self.general_2d_or_3d_mhd_claimed,
+            self.hall_two_fluid_or_kinetic_solved,
+            self.plasma_solved,
+            self.adaptive_em_control_validated,
+            self.laboratory_validation_performed,
+            self.navier_stokes_singularity_reproduced,
+            self.propulsion_or_shielding_validated,
+            self.operational_validation_performed,
+        )
+        if any(prohibited):
+            raise ValueError("WS-NSB v1.3 cannot promote unsupported MHD, plasma, physical, singularity, or operational claims")
+        return self
+
+
+def _validate_grid(grid_size: int) -> None:
+    if grid_size < 16 or grid_size % 2:
+        raise ValueError("G8 requires an even periodic grid_size >= 16")
+
+
+def _field_mean(field: list[list[float]]) -> float:
+    n = len(field)
+    return sum(value for row in field for value in row) / (n * n)
+
+
+def _field_rms(field: list[list[float]]) -> float:
+    return math.sqrt(_field_mean([[value * value for value in row] for row in field]))
+
+
+def _l2_difference(left: list[list[float]], right: list[list[float]]) -> float:
+    n = len(left)
+    if n != len(right) or any(len(row) != n for row in left) or any(len(row) != n for row in right):
+        raise ValueError("G8 fields must be square and have matching shapes")
+    return math.sqrt(
+        sum((left[i][j] - right[i][j]) ** 2 for i in range(n) for j in range(n)) / (n * n)
+    )
+
+
+def _max_abs_difference(left: list[list[float]], right: list[list[float]]) -> float:
+    n = len(left)
+    return max(abs(left[i][j] - right[i][j]) for i in range(n) for j in range(n))
+
+
+def _centered_dx(field: list[list[float]], spacing: float) -> list[list[float]]:
+    n = len(field)
+    return [
+        [
+            (field[(i + 1) % n][j] - field[(i - 1) % n][j]) / (2.0 * spacing)
+            for j in range(n)
+        ]
+        for i in range(n)
+    ]
+
+
+def _centered_dy(field: list[list[float]], spacing: float) -> list[list[float]]:
+    n = len(field)
+    return [
+        [
+            (field[i][(j + 1) % n] - field[i][(j - 1) % n]) / (2.0 * spacing)
+            for j in range(n)
+        ]
+        for i in range(n)
+    ]
+
+
+def _validate_modes(grid_size: int, modes: tuple[ModeSpec, ...]) -> None:
+    _validate_grid(grid_size)
+    if not modes:
+        raise ValueError("G8 requires at least one analytical mode")
+    for kind, amplitude, kx, ky, _phase in modes:
+        if kind not in {"sin", "cos"}:
+            raise ValueError("mode kind must be sin or cos")
+        if amplitude == 0.0:
+            raise ValueError("mode amplitude must be nonzero")
+        if kx == 0 and ky == 0:
+            raise ValueError("zero wavenumber mode is not allowed")
+        if 4 * max(abs(kx), abs(ky)) >= grid_size:
+            raise ValueError("analytical modes must remain comfortably resolved on the G8 grid")
+
+
+def _analytic_velocity_and_vorticity(
+    grid_size: int,
+    modes: tuple[ModeSpec, ...],
+) -> tuple[list[list[float]], list[list[float]], list[list[float]]]:
+    _validate_modes(grid_size, modes)
+    spacing = TWO_PI / grid_size
+    u = [[0.0] * grid_size for _ in range(grid_size)]
+    v = [[0.0] * grid_size for _ in range(grid_size)]
+    omega = [[0.0] * grid_size for _ in range(grid_size)]
+
+    for i in range(grid_size):
+        x = i * spacing
+        for j in range(grid_size):
+            y = j * spacing
+            for kind, amplitude, kx, ky, phase in modes:
+                argument = kx * x + ky * y + phase
+                if kind == "sin":
+                    streamfunction = amplitude * math.sin(argument)
+                    directional_derivative = amplitude * math.cos(argument)
+                else:
+                    streamfunction = amplitude * math.cos(argument)
+                    directional_derivative = -amplitude * math.sin(argument)
+                u[i][j] += ky * directional_derivative
+                v[i][j] -= kx * directional_derivative
+                omega[i][j] += (kx * kx + ky * ky) * streamfunction
+    return u, v, omega
+
+
+def _orientation_fraction(kx: int, ky: int, field_angle_rad: float) -> float:
+    k2 = kx * kx + ky * ky
+    if k2 <= 0:
+        raise ValueError("orientation reference requires nonzero wavevector")
+    bx = math.cos(field_angle_rad)
+    by = math.sin(field_angle_rad)
+    k_parallel = bx * kx + by * ky
+    fraction = (k_parallel * k_parallel) / k2
+    return min(1.0, max(0.0, fraction))
+
+
+def _analytical_magnetic_target(
+    grid_size: int,
+    modes: tuple[ModeSpec, ...],
+    *,
+    field_angle_rad: float,
+    magnetic_damping: float,
+) -> list[list[float]]:
+    _validate_modes(grid_size, modes)
+    if magnetic_damping < 0.0:
+        raise ValueError("magnetic_damping must be nonnegative")
+    spacing = TWO_PI / grid_size
+    bx = math.cos(field_angle_rad)
+    by = math.sin(field_angle_rad)
+    target = [[0.0] * grid_size for _ in range(grid_size)]
+
+    for i in range(grid_size):
+        x = i * spacing
+        for j in range(grid_size):
+            y = j * spacing
+            for kind, amplitude, kx, ky, phase in modes:
+                argument = kx * x + ky * y + phase
+                streamfunction = amplitude * (
+                    math.sin(argument) if kind == "sin" else math.cos(argument)
+                )
+                k2 = kx * kx + ky * ky
+                omega_mode = k2 * streamfunction
+                k_parallel = bx * kx + by * ky
+                target[i][j] -= magnetic_damping * (k_parallel * k_parallel / k2) * omega_mode
+    return target
+
+
+def finite_difference_ohm_lorentz_operator(
+    *,
+    u: list[list[float]],
+    v: list[list[float]],
+    field_angle_rad: float,
+    magnetic_damping: float,
+) -> tuple[list[list[float]], float, float]:
+    if magnetic_damping < 0.0:
+        raise ValueError("magnetic_damping must be nonnegative")
+    n = len(u)
+    _validate_grid(n)
+    if len(v) != n or any(len(row) != n for row in u) or any(len(row) != n for row in v):
+        raise ValueError("u and v must be matching square fields")
+
+    spacing = TWO_PI / n
+    bx = math.cos(field_angle_rad)
+    by = math.sin(field_angle_rad)
+    current_z = [
+        [by * u[i][j] - bx * v[i][j] for j in range(n)]
+        for i in range(n)
+    ]
+    force_x = [
+        [-magnetic_damping * by * current_z[i][j] for j in range(n)]
+        for i in range(n)
+    ]
+    force_y = [
+        [magnetic_damping * bx * current_z[i][j] for j in range(n)]
+        for i in range(n)
+    ]
+
+    d_force_y_dx = _centered_dx(force_y, spacing)
+    d_force_x_dy = _centered_dy(force_x, spacing)
+    vorticity_tendency = [
+        [d_force_y_dx[i][j] - d_force_x_dy[i][j] for j in range(n)]
+        for i in range(n)
+    ]
+
+    joule_dissipation = magnetic_damping * _field_mean(
+        [[current_z[i][j] ** 2 for j in range(n)] for i in range(n)]
+    )
+    lorentz_work_dissipation = -_field_mean(
+        [
+            [u[i][j] * force_x[i][j] + v[i][j] * force_y[i][j] for j in range(n)]
+            for i in range(n)
+        ]
+    )
+    return vorticity_tendency, joule_dissipation, lorentz_work_dissipation
+
+
+def _resolution_case(
+    *,
+    grid_size: int,
+    modes: tuple[ModeSpec, ...],
+    field_angle_rad: float,
+    magnetic_damping: float,
+) -> G8ResolutionResult:
+    u, v, _omega = _analytic_velocity_and_vorticity(grid_size, modes)
+    target = _analytical_magnetic_target(
+        grid_size,
+        modes,
+        field_angle_rad=field_angle_rad,
+        magnetic_damping=magnetic_damping,
+    )
+    fd, joule, work = finite_difference_ohm_lorentz_operator(
+        u=u,
+        v=v,
+        field_angle_rad=field_angle_rad,
+        magnetic_damping=magnetic_damping,
+    )
+    target_rms = _field_rms(target)
+    error = _l2_difference(fd, target)
+    return G8ResolutionResult(
+        grid_size=grid_size,
+        target_rms=target_rms,
+        fd_rms=_field_rms(fd),
+        l2_error=error,
+        relative_l2_error=error / max(target_rms, 1e-15),
+        max_abs_error=_max_abs_difference(fd, target),
+        joule_dissipation_rate=joule,
+        lorentz_work_dissipation_rate=work,
+        work_identity_abs_error=abs(joule - work),
+    )
+
+
+def _orientation_case(
+    *,
+    case_id: str,
+    grid_size: int,
+    kx: int,
+    ky: int,
+    field_angle_rad: float,
+    magnetic_damping: float,
+) -> G8OrientationResult:
+    modes: tuple[ModeSpec, ...] = (("sin", 1.0, kx, ky, 0.2),)
+    u, v, _omega = _analytic_velocity_and_vorticity(grid_size, modes)
+    target = _analytical_magnetic_target(
+        grid_size,
+        modes,
+        field_angle_rad=field_angle_rad,
+        magnetic_damping=magnetic_damping,
+    )
+    fd, joule, work = finite_difference_ohm_lorentz_operator(
+        u=u,
+        v=v,
+        field_angle_rad=field_angle_rad,
+        magnetic_damping=magnetic_damping,
+    )
+    return G8OrientationResult(
+        case_id=case_id,
+        grid_size=grid_size,
+        kx=kx,
+        ky=ky,
+        field_angle_rad=field_angle_rad,
+        orientation_fraction=_orientation_fraction(kx, ky, field_angle_rad),
+        target_rms=_field_rms(target),
+        fd_rms=_field_rms(fd),
+        l2_error=_l2_difference(fd, target),
+        joule_dissipation_rate=joule,
+        lorentz_work_dissipation_rate=work,
+        work_identity_abs_error=abs(joule - work),
+    )
+
+
+def _observed_order(coarse_error: float, fine_error: float) -> float:
+    if coarse_error <= 0.0 or fine_error <= 0.0:
+        raise ValueError("G8 convergence errors must be positive")
+    return math.log(coarse_error / fine_error) / math.log(2.0)
+
+
+def run_nsb_g8_benchmark(
+    *,
+    resolution_grids: tuple[int, int, int] = (32, 64, 128),
+    field_angle_rad: float = 0.37,
+    magnetic_damping: float = 0.7,
+    spatial_order_floor: float = 1.9,
+    finest_l2_limit: float = 5e-3,
+    finest_relative_l2_limit: float = 3e-3,
+    orientation_l2_limit: float = 5e-3,
+    null_sink_limit: float = 1e-12,
+    field_sign_l2_limit: float = 1e-12,
+    work_identity_limit: float = 1e-12,
+) -> NSBG8Report:
+    if magnetic_damping <= 0.0:
+        raise ValueError("default G8 benchmark requires positive magnetic_damping")
+    if not (
+        resolution_grids[1] == 2 * resolution_grids[0]
+        and resolution_grids[2] == 2 * resolution_grids[1]
+    ):
+        raise ValueError("G8 resolution_grids must use exact factor-two refinement")
+    for grid_size in resolution_grids:
+        _validate_grid(grid_size)
+
+    mixed_modes: tuple[ModeSpec, ...] = (
+        ("sin", 1.0, 2, 1, 0.2),
+        ("cos", 0.35, 1, 3, -0.4),
+        ("sin", 0.25, 3, -2, 0.1),
+    )
+    resolution_results = tuple(
+        _resolution_case(
+            grid_size=grid_size,
+            modes=mixed_modes,
+            field_angle_rad=field_angle_rad,
+            magnetic_damping=magnetic_damping,
+        )
+        for grid_size in resolution_grids
+    )
+    spatial_orders = (
+        _observed_order(resolution_results[0].l2_error, resolution_results[1].l2_error),
+        _observed_order(resolution_results[1].l2_error, resolution_results[2].l2_error),
+    )
+
+    kx, ky = 2, 1
+    field_parallel = math.atan2(ky, kx)
+    field_perpendicular = field_parallel + 0.5 * math.pi
+    orientation_results = (
+        _orientation_case(
+            case_id="field_parallel_to_k_max_damping",
+            grid_size=resolution_grids[-1],
+            kx=kx,
+            ky=ky,
+            field_angle_rad=field_parallel,
+            magnetic_damping=magnetic_damping,
+        ),
+        _orientation_case(
+            case_id="field_perpendicular_to_k_null",
+            grid_size=resolution_grids[-1],
+            kx=kx,
+            ky=ky,
+            field_angle_rad=field_perpendicular,
+            magnetic_damping=magnetic_damping,
+        ),
+        _orientation_case(
+            case_id="field_x_axis_oblique_k",
+            grid_size=resolution_grids[-1],
+            kx=kx,
+            ky=ky,
+            field_angle_rad=0.0,
+            magnetic_damping=magnetic_damping,
+        ),
+        _orientation_case(
+            case_id="field_arbitrary_oblique",
+            grid_size=resolution_grids[-1],
+            kx=kx,
+            ky=ky,
+            field_angle_rad=field_angle_rad,
+            magnetic_damping=magnetic_damping,
+        ),
+    )
+
+    symmetry_grid = resolution_grids[1]
+    u_sym, v_sym, _ = _analytic_velocity_and_vorticity(symmetry_grid, mixed_modes)
+    positive_field, _, _ = finite_difference_ohm_lorentz_operator(
+        u=u_sym,
+        v=v_sym,
+        field_angle_rad=field_angle_rad,
+        magnetic_damping=magnetic_damping,
+    )
+    reversed_field, _, _ = finite_difference_ohm_lorentz_operator(
+        u=u_sym,
+        v=v_sym,
+        field_angle_rad=field_angle_rad + math.pi,
+        magnetic_damping=magnetic_damping,
+    )
+    field_sign_symmetry_l2 = _l2_difference(positive_field, reversed_field)
+
+    zero_magnetic, zero_joule, zero_work = finite_difference_ohm_lorentz_operator(
+        u=u_sym,
+        v=v_sym,
+        field_angle_rad=field_angle_rad,
+        magnetic_damping=0.0,
+    )
+    zero_field = [[0.0] * symmetry_grid for _ in range(symmetry_grid)]
+    zero_magnetic_operator_l2 = _l2_difference(zero_magnetic, zero_field)
+    zero_magnetic_dissipation = max(zero_joule, zero_work)
+
+    max_orientation_error = max(case.l2_error for case in orientation_results)
+    max_work_error = max(
+        [
+            *(case.work_identity_abs_error for case in resolution_results),
+            *(case.work_identity_abs_error for case in orientation_results),
+            abs(zero_joule - zero_work),
+        ]
+    )
+
+    spatial_pass = (
+        min(spatial_orders) >= spatial_order_floor
+        and resolution_results[-1].l2_error <= finest_l2_limit
+        and resolution_results[-1].relative_l2_error <= finest_relative_l2_limit
+    )
+    orientation_pass = max_orientation_error <= orientation_l2_limit
+    parallel_case = orientation_results[0]
+    perpendicular_case = orientation_results[1]
+    perpendicular_pass = (
+        perpendicular_case.orientation_fraction <= 1e-15
+        and perpendicular_case.joule_dissipation_rate <= null_sink_limit
+        and perpendicular_case.fd_rms <= null_sink_limit
+    )
+    parallel_pass = (
+        abs(parallel_case.orientation_fraction - 1.0) <= 1e-15
+        and parallel_case.joule_dissipation_rate > 0.0
+        and parallel_case.fd_rms > 0.0
+    )
+    sign_pass = field_sign_symmetry_l2 <= field_sign_l2_limit
+    zero_pass = (
+        zero_magnetic_operator_l2 <= null_sink_limit
+        and zero_magnetic_dissipation <= null_sink_limit
+    )
+    work_pass = max_work_error <= work_identity_limit
+    acceptance_pass = all(
+        (
+            spatial_pass,
+            orientation_pass,
+            perpendicular_pass,
+            parallel_pass,
+            sign_pass,
+            zero_pass,
+            work_pass,
+        )
+    )
+
+    report = NSBG8Report(
+        resolution_results=resolution_results,
+        orientation_results=orientation_results,
+        field_sign_symmetry_l2=field_sign_symmetry_l2,
+        zero_magnetic_operator_l2=zero_magnetic_operator_l2,
+        zero_magnetic_dissipation=zero_magnetic_dissipation,
+        acceptance=G8AcceptanceSummary(
+            spatial_order_floor=spatial_order_floor,
+            spatial_orders=spatial_orders,
+            finest_l2_limit=finest_l2_limit,
+            finest_relative_l2_limit=finest_relative_l2_limit,
+            orientation_l2_limit=orientation_l2_limit,
+            null_sink_limit=null_sink_limit,
+            field_sign_l2_limit=field_sign_l2_limit,
+            work_identity_limit=work_identity_limit,
+            spatial_convergence_pass=spatial_pass,
+            orientation_replication_pass=orientation_pass,
+            field_perpendicular_null_pass=perpendicular_pass,
+            field_parallel_max_pass=parallel_pass,
+            field_sign_symmetry_pass=sign_pass,
+            zero_magnetic_limit_pass=zero_pass,
+            joule_work_identity_pass=work_pass,
+            acceptance_pass=acceptance_pass,
+        ),
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_nsb_g8_report(report: NSBG8Report) -> bool:
+    expected = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.report_digest == expected


### PR DESCRIPTION
## Summary

Adds **G8**, a numerically distinct internal replication of the bounded G7 low-Rm imposed-field magnetic operator.

### Included
- `worldshepherd_sara/nsb_g8_independent_magnetic.py`
  - physical-space normalized Ohm/Lorentz path `j_z = u B_y - v B_x`
  - Lorentz force `f = Lambda*j_z*(-B_y, B_x)`
  - second-order centered finite-difference curl
  - analytical Fourier-mode target without calling the G7 spectral magnetic operator
  - 32/64/128 spatial-convergence sweep
  - field-parallel maximum-damping case
  - field-perpendicular magnetic-null case
  - arbitrary continuous field orientation
  - `B -> -B` sign symmetry
  - `Lambda -> 0` magnetic-null limit
  - Joule dissipation / negative Lorentz-work identity
  - deterministic SHA-256 report binding and fail-closed claims controls
- `worldshepherd_sara/nsb_g8_cli.py`
- `tests/test_nsb_g8_independent_magnetic.py`
- `docs/WS_NSB_V1_3_G8_INDEPENDENT_MAGNETIC.md`
- `ws-nsb-g8` console entry point
- dedicated `WS-NSB v1.3 G8 Gate` workflow

## Scientific boundary

This is a strictly 2D periodic, z-invariant, homogeneous, low-magnetic-Reynolds-number imposed-field reference. In this geometry the induced current is purely z-directed, so charge conservation follows geometrically; no electric-potential Poisson solve is claimed.

G8 is an **internal cross-method replication**, not independent third-party or laboratory validation.

## Claims boundary

The report remains `SIMULATED_ONLY`. It does not claim finite-Rm induction physics, a full MHD solver, general 2D/3D magnetofluid boundary conditions, Hall-MHD/two-fluid/kinetic/plasma capability, adaptive electromagnetic control, laboratory validation, finite-time Navier-Stokes singularity reproduction, propulsion, shielding, stealth, cloaking, or operational capability.

## Acceptance intent

Default gate requires observed spatial order >= 1.9, finest L2 <= 5e-3, finest relative L2 <= 3e-3, every orientation-case L2 <= 5e-3, perpendicular-field magnetic sink <= 1e-12, field-reversal L2 <= 1e-12, zero-magnetic operator/dissipation <= 1e-12, Joule/work identity error <= 1e-12, and deterministic report verification.