### PR TITLE
Add WS-NSB v1.6 G11 independent nonlinear MHD replication gate

### DIFF
--- a/.github/workflows/ws-nsb-v1-6-g11.yml
+++ b/.github/workflows/ws-nsb-v1-6-g11.yml
@@ -1,0 +1,62 @@
+name: WS-NSB v1.6 G11 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_independent_nonlinear_mhd.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g11_independent_nonlinear_mhd.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_6_G11_INDEPENDENT_NONLINEAR_MHD.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-6-g11.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_independent_nonlinear_mhd.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g11_independent_nonlinear_mhd.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_6_G11_INDEPENDENT_NONLINEAR_MHD.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-6-g11.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  g11-independent-nonlinear-mhd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and tests
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Run G11 test suite
+        run: python -m pytest tests/test_nsb_g11_independent_nonlinear_mhd.py -q
+
+      - name: Execute and verify deterministic G11 report
+        run: |
+          rm -f ws_nsb_g11_report.json
+          ws-nsb-g11 --output ws_nsb_g11_report.json
+          ws-nsb-g11 --verify ws_nsb_g11_report.json
+
+      - name: Upload G11 evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ws-nsb-v1-6-g11-report
+          path: deployments/sara_verified_local_v1/ws_nsb_g11_report.json
+          if-no-files-found: error

--- a/deployments/sara_verified_local_v1/docs/WS_NSB_V1_6_G11_INDEPENDENT_NONLINEAR_MHD.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NSB_V1_6_G11_INDEPENDENT_NONLINEAR_MHD.md
@@ -1,0 +1,48 @@
+# WS-NSB v1.6 — G11 Independent Nonlinear MHD Replication
+
+## Purpose
+
+G11 provides a numerically distinct internal replication of the bounded G10 nonlinear 2D periodic incompressible resistive-MHD reference.
+
+The G10 reference uses Fourier pseudo-spectral derivatives and dealiasing. G11 instead evolves the same vorticity/vector-potential equations with second-order centered finite differences and the Arakawa Jacobian. A Fourier transform is used only to invert the **discrete finite-difference periodic Poisson operator** required to reconstruct streamfunction from vorticity.
+
+## Equations
+
+The independent evolution is
+
+```text
+domega/dt = J(psi, omega) - J(a, j) + nu*laplacian_h(omega)
+da/dt     = J(psi, a) + eta*laplacian_h(a)
+```
+
+with
+
+```text
+-laplacian_h(psi) = omega
+B = (D_y a, -D_x a)
+j = -laplacian_h(a)
+```
+
+where `J` is the Arakawa discretization of the Jacobian.
+
+## Acceptance evidence
+
+The default gate requires:
+
+- decreasing finite-difference/spectral disagreement over 16/32/64 grids;
+- observed cross-method convergence order >= 1.6;
+- finest combined relative field disagreement <= 1%;
+- nontrivial aligned Alfvénic advection and Lorentz terms that cancel to <= 1e-10;
+- induction advection <= 1e-10 in the aligned state;
+- velocity and magnetic divergence <= 1e-10;
+- dissipative finite-difference total energy decrease;
+- final finite-difference/spectral total-energy disagreement <= 1%;
+- deterministic SHA-256 report verification.
+
+## Scientific boundary
+
+G11 is an **internal cross-method numerical replication**. It is not an independent third-party validation. It remains a 2D periodic incompressible resistive-MHD reference and does not establish compressible MHD, 3D MHD, Hall-MHD, two-fluid, kinetic, plasma, or non-periodic physical-boundary capability.
+
+## Claims control
+
+The report is fail-closed at `SIMULATED_ONLY` and explicitly rejects unsupported claims of laboratory validation, adaptive electromagnetic control, propulsion, shielding, stealth, cloaking, operational capability, or finite-time Navier-Stokes singularity reproduction.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -44,6 +44,7 @@ ws-nsb-g7 = "worldshepherd_sara.nsb_g7_cli:main"
 ws-nsb-g8 = "worldshepherd_sara.nsb_g8_cli:main"
 ws-nsb-g9 = "worldshepherd_sara.nsb_g9_cli:main"
 ws-nsb-g10 = "worldshepherd_sara.nsb_g10_cli:main"
+ws-nsb-g11 = "worldshepherd_sara.nsb_g11_cli:main"
 ws-omega-recursion = "worldshepherd_sara.recursive_discovery_cli:main"
 
 [tool.setuptools]

--- a/deployments/sara_verified_local_v1/tests/test_nsb_g11_independent_nonlinear_mhd.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g11_independent_nonlinear_mhd.py
@@ -8,8 +8,11 @@ from worldshepherd_sara.nsb_g11_independent_nonlinear_mhd import (
 )
 
 
+REPORT = run_nsb_g11_benchmark()
+
+
 def test_g11_default_report_passes_and_verifies():
-    report = run_nsb_g11_benchmark()
+    report = REPORT
     assert report.acceptance.acceptance_pass
     assert report.acceptance.cross_method_pass
     assert report.acceptance.cancellation_pass
@@ -19,7 +22,7 @@ def test_g11_default_report_passes_and_verifies():
 
 
 def test_g11_cross_method_converges_with_refinement():
-    report = run_nsb_g11_benchmark()
+    report = REPORT
     points = report.cross_method_case.points
     assert points[1].combined_relative_difference < points[0].combined_relative_difference
     assert points[2].combined_relative_difference < points[1].combined_relative_difference
@@ -28,7 +31,7 @@ def test_g11_cross_method_converges_with_refinement():
 
 
 def test_g11_aligned_alfvenic_case_cancels_nonlinearity():
-    case = run_nsb_g11_benchmark().aligned_case
+    case = REPORT.aligned_case
     assert case.nonlinear_advection_rms > 1e-3
     assert case.lorentz_curl_rms > 1e-3
     assert case.nonlinear_cancellation_rms <= 1e-10
@@ -36,7 +39,7 @@ def test_g11_aligned_alfvenic_case_cancels_nonlinearity():
 
 
 def test_g11_geometry_and_energy_are_bounded():
-    report = run_nsb_g11_benchmark()
+    report = REPORT
     case = report.cross_method_case
     assert case.fd_velocity_divergence_rms <= report.acceptance.divergence_limit
     assert case.fd_magnetic_divergence_rms <= report.acceptance.divergence_limit
@@ -59,7 +62,7 @@ def test_g11_integrator_rejects_invalid_dt():
 
 
 def test_g11_digest_detects_tampering():
-    report = run_nsb_g11_benchmark()
+    report = REPORT
     tampered = report.model_copy(
         update={
             "cross_method_case": report.cross_method_case.model_copy(
@@ -71,16 +74,14 @@ def test_g11_digest_detects_tampering():
 
 
 def test_g11_fail_closed_external_validation_claim():
-    report = run_nsb_g11_benchmark()
-    payload = report.model_dump(mode="json")
+    payload = REPORT.model_dump(mode="json")
     payload["independent_third_party_validation_claimed"] = True
     with pytest.raises(ValueError):
         NSBG11Report.model_validate(payload)
 
 
 def test_g11_fail_closed_plasma_claim():
-    report = run_nsb_g11_benchmark()
-    payload = report.model_dump(mode="json")
+    payload = REPORT.model_dump(mode="json")
     payload["plasma_solved"] = True
     with pytest.raises(ValueError):
         NSBG11Report.model_validate(payload)

--- a/deployments/sara_verified_local_v1/tests/test_nsb_g11_independent_nonlinear_mhd.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g11_independent_nonlinear_mhd.py
@@ -1,0 +1,86 @@
+import pytest
+
+from worldshepherd_sara.nsb_g11_independent_nonlinear_mhd import (
+    NSBG11Report,
+    integrate_fd_mhd,
+    run_nsb_g11_benchmark,
+    verify_nsb_g11_report,
+)
+
+
+def test_g11_default_report_passes_and_verifies():
+    report = run_nsb_g11_benchmark()
+    assert report.acceptance.acceptance_pass
+    assert report.acceptance.cross_method_pass
+    assert report.acceptance.cancellation_pass
+    assert report.acceptance.geometry_pass
+    assert report.acceptance.energy_pass
+    assert verify_nsb_g11_report(report)
+
+
+def test_g11_cross_method_converges_with_refinement():
+    report = run_nsb_g11_benchmark()
+    points = report.cross_method_case.points
+    assert points[1].combined_relative_difference < points[0].combined_relative_difference
+    assert points[2].combined_relative_difference < points[1].combined_relative_difference
+    assert min(report.cross_method_case.observed_orders) >= report.acceptance.spatial_order_floor
+    assert points[-1].combined_relative_difference <= report.acceptance.cross_method_relative_limit
+
+
+def test_g11_aligned_alfvenic_case_cancels_nonlinearity():
+    case = run_nsb_g11_benchmark().aligned_case
+    assert case.nonlinear_advection_rms > 1e-3
+    assert case.lorentz_curl_rms > 1e-3
+    assert case.nonlinear_cancellation_rms <= 1e-10
+    assert case.induction_advection_rms <= 1e-10
+
+
+def test_g11_geometry_and_energy_are_bounded():
+    report = run_nsb_g11_benchmark()
+    case = report.cross_method_case
+    assert case.fd_velocity_divergence_rms <= report.acceptance.divergence_limit
+    assert case.fd_magnetic_divergence_rms <= report.acceptance.divergence_limit
+    assert case.fd_total_energy_final < case.fd_total_energy_initial
+    assert case.final_total_energy_relative_difference <= report.acceptance.energy_relative_limit
+
+
+def test_g11_integrator_rejects_invalid_dt():
+    omega = [[0.0] * 8 for _ in range(8)]
+    a = [[0.0] * 8 for _ in range(8)]
+    with pytest.raises(ValueError):
+        integrate_fd_mhd(
+            initial_vorticity=omega,
+            initial_magnetic_potential=a,
+            viscosity=0.01,
+            resistivity=0.01,
+            dt=0.0,
+            final_time=0.01,
+        )
+
+
+def test_g11_digest_detects_tampering():
+    report = run_nsb_g11_benchmark()
+    tampered = report.model_copy(
+        update={
+            "cross_method_case": report.cross_method_case.model_copy(
+                update={"finest_combined_relative_difference": report.cross_method_case.finest_combined_relative_difference + 0.01}
+            )
+        }
+    )
+    assert not verify_nsb_g11_report(tampered)
+
+
+def test_g11_fail_closed_external_validation_claim():
+    report = run_nsb_g11_benchmark()
+    payload = report.model_dump(mode="json")
+    payload["independent_third_party_validation_claimed"] = True
+    with pytest.raises(ValueError):
+        NSBG11Report.model_validate(payload)
+
+
+def test_g11_fail_closed_plasma_claim():
+    report = run_nsb_g11_benchmark()
+    payload = report.model_dump(mode="json")
+    payload["plasma_solved"] = True
+    with pytest.raises(ValueError):
+        NSBG11Report.model_validate(payload)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .nsb_g11_independent_nonlinear_mhd import NSBG11Report, run_nsb_g11_benchmark, verify_nsb_g11_report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run WS-NSB v1.6 G11 independent nonlinear 2D MHD replication gate."
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _serialize(report: NSBG11Report) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = NSBG11Report.model_validate(payload)
+        if not verify_nsb_g11_report(report):
+            print("INVALID")
+            return 1
+        if not report.acceptance.acceptance_pass:
+            print("VALID-BUT-GATE-FAILED")
+            return 2
+        print("VALID")
+        return 0
+
+    report = run_nsb_g11_benchmark()
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0 if report.acceptance.acceptance_pass else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_independent_nonlinear_mhd.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g11_independent_nonlinear_mhd.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import math
+
+from pydantic import BaseModel, Field, model_validator
+
+from .nsb_g3_solver import TWO_PI, _fft2, _field_mean, _field_rms, _ifft2_real, _l2_difference, _require_radix2, _wavenumbers
+from .nsb_g10_nonlinear_mhd import integrate_periodic_mhd as integrate_spectral_mhd
+from .qualification import CapabilityStatus, canonical_digest
+
+
+class G11AlignedCase(BaseModel):
+    grid_size: int = Field(ge=8)
+    nonlinear_advection_rms: float = Field(ge=0.0)
+    lorentz_curl_rms: float = Field(ge=0.0)
+    nonlinear_cancellation_rms: float = Field(ge=0.0)
+    induction_advection_rms: float = Field(ge=0.0)
+    velocity_divergence_rms: float = Field(ge=0.0)
+    magnetic_divergence_rms: float = Field(ge=0.0)
+
+
+class G11CrossMethodPoint(BaseModel):
+    grid_size: int = Field(ge=8)
+    dt: float = Field(gt=0.0)
+    final_time: float = Field(gt=0.0)
+    vorticity_l2_difference: float = Field(ge=0.0)
+    magnetic_potential_l2_difference: float = Field(ge=0.0)
+    combined_relative_difference: float = Field(ge=0.0)
+
+
+class G11CrossMethodCase(BaseModel):
+    points: tuple[G11CrossMethodPoint, ...]
+    observed_orders: tuple[float, ...]
+    finest_combined_relative_difference: float = Field(ge=0.0)
+    fd_total_energy_initial: float = Field(ge=0.0)
+    fd_total_energy_final: float = Field(ge=0.0)
+    spectral_total_energy_final: float = Field(ge=0.0)
+    final_total_energy_relative_difference: float = Field(ge=0.0)
+    fd_velocity_divergence_rms: float = Field(ge=0.0)
+    fd_magnetic_divergence_rms: float = Field(ge=0.0)
+
+
+class G11AcceptanceSummary(BaseModel):
+    spatial_order_floor: float = Field(gt=0.0)
+    cross_method_relative_limit: float = Field(gt=0.0)
+    cancellation_limit: float = Field(gt=0.0)
+    divergence_limit: float = Field(gt=0.0)
+    energy_relative_limit: float = Field(gt=0.0)
+    dissipative_energy_drop_floor: float = Field(gt=0.0)
+    cross_method_pass: bool
+    cancellation_pass: bool
+    geometry_pass: bool
+    energy_pass: bool
+    acceptance_pass: bool
+
+
+class NSBG11Report(BaseModel):
+    qualification_id: str = "WS-NSB-2026-G11-001"
+    benchmark_version: str = "1.6"
+    formulation: str = "independent 2D periodic incompressible nonlinear resistive-MHD replication"
+    independent_spatial_scheme: str = "second-order centered finite differences with Arakawa Jacobian"
+    elliptic_solver: str = "periodic discrete-Laplacian inversion using the finite-difference Fourier symbol"
+    temporal_scheme: str = "explicit midpoint RK2"
+    reference_solver: str = "G10 Fourier pseudo-spectral nonlinear MHD"
+    aligned_case: G11AlignedCase
+    cross_method_case: G11CrossMethodCase
+    acceptance: G11AcceptanceSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    independent_nonlinear_mhd_replication_implemented: bool = True
+    arakawa_jacobian_used: bool = True
+    finite_difference_dynamics_used: bool = True
+    nonlinear_2d_mhd_cross_method_agreement_demonstrated: bool = True
+    independent_third_party_validation_claimed: bool = False
+    compressible_mhd_claimed: bool = False
+    three_dimensional_mhd_claimed: bool = False
+    hall_two_fluid_or_kinetic_solved: bool = False
+    plasma_solved: bool = False
+    adaptive_em_control_validated: bool = False
+    laboratory_validation_performed: bool = False
+    navier_stokes_singularity_reproduced: bool = False
+    propulsion_or_shielding_validated: bool = False
+    operational_validation_performed: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "G11 is an internal cross-method replication of the bounded G10 2D periodic incompressible nonlinear resistive-MHD reference.",
+        "The G11 evolution uses finite-difference dynamics and an Arakawa Jacobian; the Fourier transform is used only to invert the discrete periodic Poisson operator.",
+        "G11 is not independent third-party validation and does not establish compressible, 3D, Hall, two-fluid, kinetic, or plasma capability.",
+        "Passing G11 does not establish adaptive electromagnetic control, laboratory validation, propulsion, shielding, stealth, cloaking, or operational capability.",
+        "Passing G11 does not reproduce, validate, or refute a finite-time Navier-Stokes singularity construction.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "NSBG11Report":
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("WS-NSB v1.6 must remain SIMULATED_ONLY")
+        if not all((
+            self.independent_nonlinear_mhd_replication_implemented,
+            self.arakawa_jacobian_used,
+            self.finite_difference_dynamics_used,
+            self.nonlinear_2d_mhd_cross_method_agreement_demonstrated,
+        )):
+            raise ValueError("G11 report must represent the executed internal cross-method replication")
+        prohibited = (
+            self.independent_third_party_validation_claimed,
+            self.compressible_mhd_claimed,
+            self.three_dimensional_mhd_claimed,
+            self.hall_two_fluid_or_kinetic_solved,
+            self.plasma_solved,
+            self.adaptive_em_control_validated,
+            self.laboratory_validation_performed,
+            self.navier_stokes_singularity_reproduced,
+            self.propulsion_or_shielding_validated,
+            self.operational_validation_performed,
+        )
+        if any(prohibited):
+            raise ValueError("WS-NSB v1.6 cannot promote unsupported external, physical, or higher-fidelity claims")
+        return self
+
+
+def _dx(field):
+    n = len(field)
+    h = TWO_PI / n
+    return [[(field[(i + 1) % n][j] - field[(i - 1) % n][j]) / (2.0 * h) for j in range(n)] for i in range(n)]
+
+
+def _dy(field):
+    n = len(field)
+    h = TWO_PI / n
+    return [[(field[i][(j + 1) % n] - field[i][(j - 1) % n]) / (2.0 * h) for j in range(n)] for i in range(n)]
+
+
+def _lap(field):
+    n = len(field)
+    h2 = (TWO_PI / n) ** 2
+    return [[
+        (field[(i + 1) % n][j] + field[(i - 1) % n][j] + field[i][(j + 1) % n] + field[i][(j - 1) % n] - 4.0 * field[i][j]) / h2
+        for j in range(n)
+    ] for i in range(n)]
+
+
+def _solve_minus_laplacian(rhs):
+    n = len(rhs)
+    _require_radix2(n)
+    if any(len(row) != n for row in rhs):
+        raise ValueError("G11 fields must be square")
+    rhs_hat = _fft2(rhs)
+    modes = _wavenumbers(n)
+    h = TWO_PI / n
+    solution_hat = [[0.0j] * n for _ in range(n)]
+    for i, kx in enumerate(modes):
+        for j, ky in enumerate(modes):
+            symbol = 4.0 * (math.sin(0.5 * kx * h) ** 2 + math.sin(0.5 * ky * h) ** 2) / (h * h)
+            solution_hat[i][j] = 0.0j if symbol <= 1e-15 else rhs_hat[i][j] / symbol
+    return _ifft2_real(solution_hat)
+
+
+def _arakawa_jacobian(f, g):
+    n = len(f)
+    h2 = (TWO_PI / n) ** 2
+    out = [[0.0] * n for _ in range(n)]
+    scale = 1.0 / (12.0 * h2)
+    for i in range(n):
+        ip, im = (i + 1) % n, (i - 1) % n
+        for j in range(n):
+            jp, jm = (j + 1) % n, (j - 1) % n
+            j1 = (
+                (f[ip][j] - f[im][j]) * (g[i][jp] - g[i][jm])
+                - (f[i][jp] - f[i][jm]) * (g[ip][j] - g[im][j])
+            )
+            j2 = (
+                f[ip][j] * (g[ip][jp] - g[ip][jm])
+                - f[im][j] * (g[im][jp] - g[im][jm])
+                - f[i][jp] * (g[ip][jp] - g[im][jp])
+                + f[i][jm] * (g[ip][jm] - g[im][jm])
+            )
+            j3 = (
+                g[i][jp] * (f[ip][jp] - f[im][jp])
+                - g[i][jm] * (f[ip][jm] - f[im][jm])
+                - g[ip][j] * (f[ip][jp] - f[ip][jm])
+                + g[im][j] * (f[im][jp] - f[im][jm])
+            )
+            out[i][j] = scale * (j1 + j2 + j3)
+    return out
+
+
+def _velocity_fd(omega):
+    psi = _solve_minus_laplacian(omega)
+    psi_x, psi_y = _dx(psi), _dy(psi)
+    u = psi_y
+    v = [[-value for value in row] for row in psi_x]
+    return u, v, psi
+
+
+def _magnetic_fd(a):
+    ax, ay = _dx(a), _dy(a)
+    bx = ay
+    by = [[-value for value in row] for row in ax]
+    current = [[-value for value in row] for row in _lap(a)]
+    return bx, by, current
+
+
+def _divergence_rms(x, y):
+    dx_x, dy_y = _dx(x), _dy(y)
+    n = len(x)
+    return math.sqrt(sum((dx_x[i][j] + dy_y[i][j]) ** 2 for i in range(n) for j in range(n)) / (n * n))
+
+
+def _add_scaled_pair(omega, a, domega, da, scale):
+    n = len(omega)
+    return (
+        [[omega[i][j] + scale * domega[i][j] for j in range(n)] for i in range(n)],
+        [[a[i][j] + scale * da[i][j] for j in range(n)] for i in range(n)],
+    )
+
+
+def _rhs_fd(omega, a, *, viscosity: float, resistivity: float):
+    if viscosity < 0.0 or resistivity < 0.0:
+        raise ValueError("viscosity and resistivity must be nonnegative")
+    n = len(omega)
+    _require_radix2(n)
+    if len(a) != n or any(len(row) != n for row in omega) or any(len(row) != n for row in a):
+        raise ValueError("omega and a must be equal square fields")
+    _, _, psi = _velocity_fd(omega)
+    _, _, current = _magnetic_fd(a)
+    adv_w = _arakawa_jacobian(psi, omega)
+    lorentz_raw = _arakawa_jacobian(a, current)
+    lorentz = [[-value for value in row] for row in lorentz_raw]
+    adv_a = _arakawa_jacobian(psi, a)
+    lap_w, lap_a = _lap(omega), _lap(a)
+    domega = [[adv_w[i][j] + lorentz[i][j] + viscosity * lap_w[i][j] for j in range(n)] for i in range(n)]
+    da = [[adv_a[i][j] + resistivity * lap_a[i][j] for j in range(n)] for i in range(n)]
+    return domega, da, {"advection_w": adv_w, "lorentz": lorentz, "advection_a": adv_a}
+
+
+def _midpoint_step_fd(omega, a, *, dt: float, viscosity: float, resistivity: float):
+    k1w, k1a, _ = _rhs_fd(omega, a, viscosity=viscosity, resistivity=resistivity)
+    mw, ma = _add_scaled_pair(omega, a, k1w, k1a, 0.5 * dt)
+    k2w, k2a, _ = _rhs_fd(mw, ma, viscosity=viscosity, resistivity=resistivity)
+    return _add_scaled_pair(omega, a, k2w, k2a, dt)
+
+
+def integrate_fd_mhd(*, initial_vorticity, initial_magnetic_potential, viscosity: float, resistivity: float, dt: float, final_time: float):
+    n = len(initial_vorticity)
+    _require_radix2(n)
+    if len(initial_magnetic_potential) != n:
+        raise ValueError("initial fields must have matching dimensions")
+    if dt <= 0.0 or final_time <= 0.0:
+        raise ValueError("dt and final_time must be positive")
+    if abs(_field_mean(initial_vorticity)) > 1e-12:
+        raise ValueError("periodic discrete Poisson inversion requires near-zero mean vorticity")
+    steps = max(1, round(final_time / dt))
+    effective_dt = final_time / steps
+    omega = [row[:] for row in initial_vorticity]
+    a = [row[:] for row in initial_magnetic_potential]
+    for _ in range(steps):
+        omega, a = _midpoint_step_fd(omega, a, dt=effective_dt, viscosity=viscosity, resistivity=resistivity)
+        if not all(math.isfinite(value) for row in omega for value in row) or not all(math.isfinite(value) for row in a for value in row):
+            raise ValueError("G11 finite-difference integration became non-finite")
+    return omega, a, effective_dt, steps
+
+
+def _energetics_fd(omega, a):
+    n = len(omega)
+    u, v, _ = _velocity_fd(omega)
+    bx, by, _ = _magnetic_fd(a)
+    kinetic = 0.5 * sum(u[i][j] ** 2 + v[i][j] ** 2 for i in range(n) for j in range(n)) / (n * n)
+    magnetic = 0.5 * sum(bx[i][j] ** 2 + by[i][j] ** 2 for i in range(n) for j in range(n)) / (n * n)
+    return kinetic + magnetic
+
+
+def _spectral_total_energy(omega, a):
+    from .nsb_g10_nonlinear_mhd import _energetics
+    return _energetics(omega, a, 0.0, 0.0)["total"]
+
+
+def _mixed_initial(n: int):
+    _require_radix2(n)
+    h = TWO_PI / n
+    omega = [[
+        math.sin(i * h) * math.cos(2 * j * h)
+        + 0.45 * math.cos(2 * i * h + j * h)
+        + 0.25 * math.sin(3 * i * h - 2 * j * h)
+        for j in range(n)
+    ] for i in range(n)]
+    a = [[
+        0.7 * math.cos(i * h - j * h)
+        + 0.3 * math.sin(2 * i * h + 2 * j * h)
+        + 0.18 * math.cos(3 * i * h + j * h)
+        for j in range(n)
+    ] for i in range(n)]
+    return omega, a
+
+
+def _aligned_case(n: int = 32):
+    h = TWO_PI / n
+    psi = [[math.sin(i * h) * math.sin(j * h) + 0.2 * math.sin(2 * i * h + j * h) for j in range(n)] for i in range(n)]
+    omega = [[-value for value in row] for row in _lap(psi)]
+    a = [row[:] for row in psi]
+    _, _, terms = _rhs_fd(omega, a, viscosity=0.0, resistivity=0.0)
+    cancellation = [[terms["advection_w"][i][j] + terms["lorentz"][i][j] for j in range(n)] for i in range(n)]
+    u, v, _ = _velocity_fd(omega)
+    bx, by, _ = _magnetic_fd(a)
+    return G11AlignedCase(
+        grid_size=n,
+        nonlinear_advection_rms=_field_rms(terms["advection_w"]),
+        lorentz_curl_rms=_field_rms(terms["lorentz"]),
+        nonlinear_cancellation_rms=_field_rms(cancellation),
+        induction_advection_rms=_field_rms(terms["advection_a"]),
+        velocity_divergence_rms=_divergence_rms(u, v),
+        magnetic_divergence_rms=_divergence_rms(bx, by),
+    )
+
+
+def _cross_point(n: int, *, viscosity: float = 0.01, resistivity: float = 0.015, dt: float = 0.00025, final_time: float = 0.004):
+    omega0, a0 = _mixed_initial(n)
+    fd_w, fd_a, effective_dt, _ = integrate_fd_mhd(
+        initial_vorticity=omega0,
+        initial_magnetic_potential=a0,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        dt=dt,
+        final_time=final_time,
+    )
+    sp_w, sp_a, _, _ = integrate_spectral_mhd(
+        initial_vorticity=omega0,
+        initial_magnetic_potential=a0,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        dt=dt,
+        final_time=final_time,
+    )
+    ew = _l2_difference(fd_w, sp_w)
+    ea = _l2_difference(fd_a, sp_a)
+    denom = math.sqrt(_field_rms(sp_w) ** 2 + _field_rms(sp_a) ** 2)
+    combined = math.sqrt(ew * ew + ea * ea) / max(denom, 1e-15)
+    return G11CrossMethodPoint(
+        grid_size=n,
+        dt=effective_dt,
+        final_time=final_time,
+        vorticity_l2_difference=ew,
+        magnetic_potential_l2_difference=ea,
+        combined_relative_difference=combined,
+    )
+
+
+def _cross_method_case():
+    points = tuple(_cross_point(n) for n in (16, 32, 64))
+    orders = tuple(math.log(points[i].combined_relative_difference / points[i + 1].combined_relative_difference, 2.0) for i in range(len(points) - 1))
+    n = 64
+    omega0, a0 = _mixed_initial(n)
+    e0 = _energetics_fd(omega0, a0)
+    fd_w, fd_a, _, _ = integrate_fd_mhd(initial_vorticity=omega0, initial_magnetic_potential=a0, viscosity=0.01, resistivity=0.015, dt=0.00025, final_time=0.01)
+    sp_w, sp_a, _, _ = integrate_spectral_mhd(initial_vorticity=omega0, initial_magnetic_potential=a0, viscosity=0.01, resistivity=0.015, dt=0.00025, final_time=0.01)
+    efd = _energetics_fd(fd_w, fd_a)
+    esp = _spectral_total_energy(sp_w, sp_a)
+    u, v, _ = _velocity_fd(fd_w)
+    bx, by, _ = _magnetic_fd(fd_a)
+    return G11CrossMethodCase(
+        points=points,
+        observed_orders=orders,
+        finest_combined_relative_difference=points[-1].combined_relative_difference,
+        fd_total_energy_initial=e0,
+        fd_total_energy_final=efd,
+        spectral_total_energy_final=esp,
+        final_total_energy_relative_difference=abs(efd - esp) / max(abs(esp), 1e-15),
+        fd_velocity_divergence_rms=_divergence_rms(u, v),
+        fd_magnetic_divergence_rms=_divergence_rms(bx, by),
+    )
+
+
+def run_nsb_g11_benchmark(
+    *,
+    spatial_order_floor: float = 1.6,
+    cross_method_relative_limit: float = 0.01,
+    cancellation_limit: float = 1e-10,
+    divergence_limit: float = 1e-10,
+    energy_relative_limit: float = 0.01,
+    dissipative_energy_drop_floor: float = 1e-5,
+) -> NSBG11Report:
+    aligned = _aligned_case()
+    cross = _cross_method_case()
+    cross_pass = min(cross.observed_orders) >= spatial_order_floor and cross.finest_combined_relative_difference <= cross_method_relative_limit
+    cancellation_pass = (
+        aligned.nonlinear_advection_rms > 1e-3
+        and aligned.lorentz_curl_rms > 1e-3
+        and aligned.nonlinear_cancellation_rms <= cancellation_limit
+        and aligned.induction_advection_rms <= cancellation_limit
+    )
+    geometry_pass = max(
+        aligned.velocity_divergence_rms,
+        aligned.magnetic_divergence_rms,
+        cross.fd_velocity_divergence_rms,
+        cross.fd_magnetic_divergence_rms,
+    ) <= divergence_limit
+    energy_pass = (
+        cross.fd_total_energy_final <= cross.fd_total_energy_initial - dissipative_energy_drop_floor
+        and cross.final_total_energy_relative_difference <= energy_relative_limit
+    )
+    acceptance_pass = all((cross_pass, cancellation_pass, geometry_pass, energy_pass))
+    report = NSBG11Report(
+        aligned_case=aligned,
+        cross_method_case=cross,
+        acceptance=G11AcceptanceSummary(
+            spatial_order_floor=spatial_order_floor,
+            cross_method_relative_limit=cross_method_relative_limit,
+            cancellation_limit=cancellation_limit,
+            divergence_limit=divergence_limit,
+            energy_relative_limit=energy_relative_limit,
+            dissipative_energy_drop_floor=dissipative_energy_drop_floor,
+            cross_method_pass=cross_pass,
+            cancellation_pass=cancellation_pass,
+            geometry_pass=geometry_pass,
+            energy_pass=energy_pass,
+            acceptance_pass=acceptance_pass,
+        ),
+        nonlinear_2d_mhd_cross_method_agreement_demonstrated=acceptance_pass,
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_nsb_g11_report(report: NSBG11Report) -> bool:
+    return report.report_digest == canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))


### PR DESCRIPTION
## Summary

Adds **G11**, a numerically distinct internal replication of the bounded G10 nonlinear 2D periodic incompressible resistive-MHD reference.

### Included
- `worldshepherd_sara/nsb_g11_independent_nonlinear_mhd.py`
  - second-order centered finite-difference dynamics
  - Arakawa Jacobian for nonlinear advection/coupling
  - discrete periodic Poisson inversion using the finite-difference Fourier symbol
  - independently reconstructed velocity, magnetic field and current
  - aligned Alfvénic nonlinear cancellation case
  - 16/32/64 cross-method convergence against G10 spectral evolution
  - dissipative energy and divergence checks
  - deterministic SHA-256 report binding and fail-closed claims controls
- `worldshepherd_sara/nsb_g11_cli.py`
- `tests/test_nsb_g11_independent_nonlinear_mhd.py`
- `docs/WS_NSB_V1_6_G11_INDEPENDENT_NONLINEAR_MHD.md`
- `ws-nsb-g11` console entry point
- dedicated `WS-NSB v1.6 G11 Gate` workflow

## Scientific boundary

G11 is an **internal cross-method numerical replication**, not independent third-party validation. The evolution path is finite-difference/Arakawa; Fourier transforms are used only for the discrete periodic Poisson inversion.

## Claims boundary

The report remains `SIMULATED_ONLY`. It does not claim compressible or 3D MHD, Hall/two-fluid/kinetic/plasma capability, adaptive electromagnetic control, laboratory validation, finite-time Navier-Stokes singularity reproduction, propulsion, shielding, stealth, cloaking, or operational capability.

## Acceptance intent

Default gate requires decreasing cross-method disagreement over 16/32/64 grids, observed order >= 1.6, finest combined relative disagreement <= 1%, nonlinear aligned-case cancellation and induction-advection residuals <= 1e-10, divergence <= 1e-10, dissipative FD energy decrease, final FD/spectral energy disagreement <= 1%, and deterministic report verification.