### PR TITLE
Add WS-NSB v1.7 G12 adaptive Lorentz-curl simulated control gate

### DIFF
--- a/.github/workflows/ws-nsb-v1-7-g12.yml
+++ b/.github/workflows/ws-nsb-v1-7-g12.yml
@@ -1,0 +1,62 @@
+name: WS-NSB v1.7 G12 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_adaptive_lorentz_control.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g12_adaptive_lorentz_control.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_7_G12_ADAPTIVE_LORENTZ_CONTROL.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-7-g12.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_adaptive_lorentz_control.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_nsb_g12_adaptive_lorentz_control.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_NSB_V1_7_G12_ADAPTIVE_LORENTZ_CONTROL.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-nsb-v1-7-g12.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  g12-adaptive-lorentz-control:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and tests
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Run G12 test suite
+        run: python -m pytest tests/test_nsb_g12_adaptive_lorentz_control.py -q
+
+      - name: Execute and verify deterministic G12 report
+        run: |
+          rm -f ws_nsb_g12_report.json
+          ws-nsb-g12 --output ws_nsb_g12_report.json
+          ws-nsb-g12 --verify ws_nsb_g12_report.json
+
+      - name: Upload G12 evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ws-nsb-v1-7-g12-report
+          path: deployments/sara_verified_local_v1/ws_nsb_g12_report.json
+          if-no-files-found: error

--- a/deployments/sara_verified_local_v1/docs/WS_NSB_V1_7_G12_ADAPTIVE_LORENTZ_CONTROL.md
+++ b/deployments/sara_verified_local_v1/docs/WS_NSB_V1_7_G12_ADAPTIVE_LORENTZ_CONTROL.md
@@ -1,0 +1,51 @@
+# WS-NSB v1.7 — G12 Adaptive Lorentz-Curl Control Abstraction
+
+## Purpose
+
+G12 is the first closed-loop control gate in the WS-NSB chain. It places a deterministic bounded feedback controller around the validated G10 nonlinear 2D periodic incompressible resistive-MHD plant.
+
+The control input is **not a claimed hardware field**. It is an abstract, prescribed basis for the vorticity source `curl(f_EM)/rho`. That abstraction allows the control algorithm, safety bounds, zero-control parity, wrong-sign red-team behavior, and deterministic evidence path to be tested before any real coil/electrode/metasurface mapping is asserted.
+
+## Controller
+
+Three fixed low-order actuator basis functions are used. At each timestep the controller projects the measured vorticity state onto those modes and applies bounded negative feedback:
+
+```text
+c_k = <omega,g_k>/<g_k,g_k>
+u_k = clip(-K*c_k, -u_max, u_max)
+s_omega = sum_k u_k*g_k
+```
+
+The commands are held over one midpoint-RK2 step and then recomputed from the new state.
+
+## Plant equation
+
+The underlying G10 vorticity equation is augmented only by the abstract control source:
+
+```text
+domega/dt = -u.grad(omega) + B.grad(j) + nu*laplacian(omega) + s_omega
+da/dt     = -u.grad(a) + eta*laplacian(a)
+```
+
+## Acceptance evidence
+
+The default gate requires:
+
+- zero-control evolution matching the unmodified G10 plant to <= 1e-12 combined L2;
+- every command remaining inside the declared command bound;
+- >= 5% reduction in targeted vorticity modal energy versus the identical uncontrolled case;
+- >= 2% reduction in final enstrophy versus the identical uncontrolled case;
+- a wrong-sign controller producing a worse targeted-mode outcome than the correct feedback law;
+- velocity and magnetic divergence <= 1e-10;
+- nonzero finite control effort and a state-dependent command change over the trajectory;
+- deterministic report verification.
+
+## Scientific boundary
+
+G12 demonstrates a **simulated control algorithm** against an abstract Lorentz-force-curl actuator kernel. It does not establish that any particular real electromagnetic hardware can generate the commanded kernel.
+
+Mapping real coil currents, electrode voltages, RF/metasurface states, geometry, conductivity, skin depth, plasma response, or actuator power into this control basis is a later validation problem.
+
+## Claims control
+
+G12 remains `SIMULATED_ONLY`. It explicitly rejects claims of physical actuator mapping, laboratory adaptive EM control, compressible/3D MHD, Hall/two-fluid/kinetic/plasma validation, propulsion, shielding, stealth, cloaking, operational capability, or finite-time Navier-Stokes singularity reproduction.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -45,6 +45,7 @@ ws-nsb-g8 = "worldshepherd_sara.nsb_g8_cli:main"
 ws-nsb-g9 = "worldshepherd_sara.nsb_g9_cli:main"
 ws-nsb-g10 = "worldshepherd_sara.nsb_g10_cli:main"
 ws-nsb-g11 = "worldshepherd_sara.nsb_g11_cli:main"
+ws-nsb-g12 = "worldshepherd_sara.nsb_g12_cli:main"
 ws-omega-recursion = "worldshepherd_sara.recursive_discovery_cli:main"
 
 [tool.setuptools]

--- a/deployments/sara_verified_local_v1/tests/test_nsb_g12_adaptive_lorentz_control.py
+++ b/deployments/sara_verified_local_v1/tests/test_nsb_g12_adaptive_lorentz_control.py
@@ -1,0 +1,90 @@
+import pytest
+
+from worldshepherd_sara.nsb_g12_adaptive_lorentz_control import (
+    NSBG12Report,
+    integrate_feedback_control,
+    run_nsb_g12_benchmark,
+    verify_nsb_g12_report,
+)
+
+
+REPORT = run_nsb_g12_benchmark()
+
+
+def test_g12_default_report_passes_and_verifies():
+    assert REPORT.acceptance.acceptance_pass
+    assert REPORT.acceptance.baseline_parity_pass
+    assert REPORT.acceptance.bounded_command_pass
+    assert REPORT.acceptance.target_reduction_pass
+    assert REPORT.acceptance.enstrophy_reduction_pass
+    assert REPORT.acceptance.wrong_sign_ordering_pass
+    assert REPORT.acceptance.geometry_pass
+    assert REPORT.acceptance.adaptive_response_pass
+    assert verify_nsb_g12_report(REPORT)
+
+
+def test_g12_controller_reduces_target_and_enstrophy():
+    case = REPORT.control_case
+    assert case.target_modal_energy_controlled_final < case.target_modal_energy_baseline_final
+    assert case.controlled_enstrophy_final < case.baseline_enstrophy_final
+    assert case.target_modal_energy_reduction_fraction >= REPORT.acceptance.target_reduction_floor
+    assert case.enstrophy_reduction_fraction >= REPORT.acceptance.enstrophy_reduction_floor
+
+
+def test_g12_wrong_sign_is_worse_than_correct_feedback():
+    case = REPORT.control_case
+    assert case.target_modal_energy_wrong_sign_final > case.target_modal_energy_controlled_final
+    assert case.wrong_sign_vs_controlled_fraction > 0.0
+
+
+def test_g12_commands_remain_bounded_and_adaptive():
+    case = REPORT.control_case
+    assert case.max_abs_command <= case.command_limit + REPORT.acceptance.command_bound_tolerance
+    assert case.control_effort > 0.0
+    assert case.initial_command_rms > 0.0
+    assert abs(case.final_command_rms - case.initial_command_rms) > 1e-6
+
+
+def test_g12_zero_control_matches_g10_plant():
+    assert REPORT.control_case.baseline_parity_l2 <= REPORT.acceptance.baseline_parity_limit
+
+
+def test_g12_integrator_rejects_invalid_gain():
+    omega = [[0.0] * 8 for _ in range(8)]
+    a = [[0.0] * 8 for _ in range(8)]
+    with pytest.raises(ValueError):
+        integrate_feedback_control(
+            initial_vorticity=omega,
+            initial_magnetic_potential=a,
+            viscosity=0.01,
+            resistivity=0.01,
+            dt=0.001,
+            final_time=0.01,
+            gain=-1.0,
+            command_limit=1.0,
+        )
+
+
+def test_g12_digest_detects_tampering():
+    tampered = REPORT.model_copy(
+        update={
+            "control_case": REPORT.control_case.model_copy(
+                update={"control_effort": REPORT.control_case.control_effort + 1.0}
+            )
+        }
+    )
+    assert not verify_nsb_g12_report(tampered)
+
+
+def test_g12_fail_closed_physical_actuator_claim():
+    payload = REPORT.model_dump(mode="json")
+    payload["physical_actuator_mapping_validated"] = True
+    with pytest.raises(ValueError):
+        NSBG12Report.model_validate(payload)
+
+
+def test_g12_fail_closed_propulsion_claim():
+    payload = REPORT.model_dump(mode="json")
+    payload["propulsion_or_shielding_validated"] = True
+    with pytest.raises(ValueError):
+        NSBG12Report.model_validate(payload)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_adaptive_lorentz_control.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_adaptive_lorentz_control.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import math
+
+from pydantic import BaseModel, Field, model_validator
+
+from .nsb_g3_solver import TWO_PI, _field_rms, _l2_difference, _spectral_divergence_rms, _velocity_and_streamfunction
+from .nsb_g10_nonlinear_mhd import _magnetic_state, _mixed_initial, _rhs, integrate_periodic_mhd
+from .qualification import CapabilityStatus, canonical_digest
+
+
+class G12ControlCase(BaseModel):
+    grid_size: int = Field(ge=8)
+    viscosity: float = Field(gt=0.0)
+    resistivity: float = Field(gt=0.0)
+    final_time: float = Field(gt=0.0)
+    dt: float = Field(gt=0.0)
+    feedback_gain: float = Field(gt=0.0)
+    command_limit: float = Field(gt=0.0)
+    baseline_parity_l2: float = Field(ge=0.0)
+    target_modal_energy_initial: float = Field(ge=0.0)
+    target_modal_energy_baseline_final: float = Field(ge=0.0)
+    target_modal_energy_controlled_final: float = Field(ge=0.0)
+    target_modal_energy_wrong_sign_final: float = Field(ge=0.0)
+    target_modal_energy_reduction_fraction: float
+    baseline_enstrophy_final: float = Field(ge=0.0)
+    controlled_enstrophy_final: float = Field(ge=0.0)
+    enstrophy_reduction_fraction: float
+    wrong_sign_vs_controlled_fraction: float
+    control_effort: float = Field(ge=0.0)
+    max_abs_command: float = Field(ge=0.0)
+    initial_command_rms: float = Field(ge=0.0)
+    final_command_rms: float = Field(ge=0.0)
+    controlled_velocity_divergence_rms: float = Field(ge=0.0)
+    controlled_magnetic_divergence_rms: float = Field(ge=0.0)
+
+
+class G12AcceptanceSummary(BaseModel):
+    baseline_parity_limit: float = Field(gt=0.0)
+    target_reduction_floor: float = Field(gt=0.0)
+    enstrophy_reduction_floor: float = Field(gt=0.0)
+    divergence_limit: float = Field(gt=0.0)
+    command_bound_tolerance: float = Field(ge=0.0)
+    baseline_parity_pass: bool
+    bounded_command_pass: bool
+    target_reduction_pass: bool
+    enstrophy_reduction_pass: bool
+    wrong_sign_ordering_pass: bool
+    geometry_pass: bool
+    adaptive_response_pass: bool
+    acceptance_pass: bool
+
+
+class NSBG12Report(BaseModel):
+    qualification_id: str = "WS-NSB-2026-G12-001"
+    benchmark_version: str = "1.7"
+    formulation: str = "bounded adaptive Lorentz-force-curl control abstraction on the validated G10 nonlinear 2D MHD plant"
+    plant: str = "G10 2D periodic incompressible nonlinear resistive-MHD reference"
+    controller: str = "deterministic bounded modal feedback with zero-order-held commands"
+    actuator_abstraction: str = "prescribed basis for curl(f_EM)/rho injected into the vorticity equation"
+    control_case: G12ControlCase
+    acceptance: G12AcceptanceSummary
+    capability_status: CapabilityStatus = CapabilityStatus.SIMULATED_ONLY
+    adaptive_lorentz_curl_control_simulated: bool = True
+    bounded_feedback_loop_executed: bool = True
+    zero_control_ablation_executed: bool = True
+    wrong_sign_red_team_executed: bool = True
+    physical_actuator_mapping_validated: bool = False
+    adaptive_em_control_validated: bool = False
+    laboratory_validation_performed: bool = False
+    hardware_boundary_control_validated: bool = False
+    compressible_or_3d_mhd_validated: bool = False
+    hall_two_fluid_kinetic_or_plasma_validated: bool = False
+    navier_stokes_singularity_reproduced: bool = False
+    propulsion_or_shielding_validated: bool = False
+    operational_validation_performed: bool = False
+    claims_boundary: tuple[str, ...] = (
+        "G12 demonstrates bounded feedback against an abstract Lorentz-force-curl actuator basis inside the validated G10 simulation plant.",
+        "The actuator basis is a control abstraction; no mapping from real coils, electrodes, metasurface cells, currents, voltages, or RF hardware to that basis is established by G12.",
+        "G12 is simulated control evidence only and does not establish physical adaptive electromagnetic control or laboratory performance.",
+        "G12 does not establish compressible/3D MHD, Hall-MHD, two-fluid, kinetic, plasma, propulsion, shielding, stealth, cloaking, or operational capability.",
+        "Passing G12 does not reproduce, validate, or refute a finite-time Navier-Stokes singularity construction.",
+    )
+    report_digest: str | None = None
+
+    @model_validator(mode="after")
+    def fail_closed_claims(self) -> "NSBG12Report":
+        if self.capability_status != CapabilityStatus.SIMULATED_ONLY:
+            raise ValueError("WS-NSB v1.7 must remain SIMULATED_ONLY")
+        if not all((
+            self.adaptive_lorentz_curl_control_simulated,
+            self.bounded_feedback_loop_executed,
+            self.zero_control_ablation_executed,
+            self.wrong_sign_red_team_executed,
+        )):
+            raise ValueError("G12 report must represent the executed bounded simulated control gate")
+        prohibited = (
+            self.physical_actuator_mapping_validated,
+            self.adaptive_em_control_validated,
+            self.laboratory_validation_performed,
+            self.hardware_boundary_control_validated,
+            self.compressible_or_3d_mhd_validated,
+            self.hall_two_fluid_kinetic_or_plasma_validated,
+            self.navier_stokes_singularity_reproduced,
+            self.propulsion_or_shielding_validated,
+            self.operational_validation_performed,
+        )
+        if any(prohibited):
+            raise ValueError("WS-NSB v1.7 cannot promote unsupported physical, hardware, or higher-fidelity claims")
+        return self
+
+
+def _basis_fields(n: int):
+    h = TWO_PI / n
+    return (
+        [[math.sin(i * h) * math.cos(2.0 * j * h) for j in range(n)] for i in range(n)],
+        [[math.cos(2.0 * i * h + j * h) for j in range(n)] for i in range(n)],
+        [[math.sin(3.0 * i * h - 2.0 * j * h) for j in range(n)] for i in range(n)],
+    )
+
+
+def _projection(field, basis):
+    n = len(field)
+    numerator = sum(field[i][j] * basis[i][j] for i in range(n) for j in range(n)) / (n * n)
+    denominator = sum(basis[i][j] ** 2 for i in range(n) for j in range(n)) / (n * n)
+    return numerator / max(denominator, 1e-15)
+
+
+def _commands(omega, *, gain: float, command_limit: float, feedback_sign: float):
+    bases = _basis_fields(len(omega))
+    commands = []
+    for basis in bases:
+        amplitude = _projection(omega, basis)
+        raw = feedback_sign * gain * amplitude
+        commands.append(max(-command_limit, min(command_limit, raw)))
+    return tuple(commands), bases
+
+
+def _source_from_commands(commands, bases):
+    n = len(bases[0])
+    return [[sum(commands[k] * bases[k][i][j] for k in range(len(commands))) for j in range(n)] for i in range(n)]
+
+
+def _controlled_rhs(omega, a, *, viscosity: float, resistivity: float, source):
+    domega, da, components = _rhs(omega, a, viscosity=viscosity, resistivity=resistivity)
+    n = len(omega)
+    controlled = [[domega[i][j] + source[i][j] for j in range(n)] for i in range(n)]
+    return controlled, da, components
+
+
+def _add_scaled_pair(omega, a, domega, da, scale):
+    n = len(omega)
+    return (
+        [[omega[i][j] + scale * domega[i][j] for j in range(n)] for i in range(n)],
+        [[a[i][j] + scale * da[i][j] for j in range(n)] for i in range(n)],
+    )
+
+
+def _controlled_midpoint_step(omega, a, *, dt: float, viscosity: float, resistivity: float, source):
+    k1w, k1a, _ = _controlled_rhs(omega, a, viscosity=viscosity, resistivity=resistivity, source=source)
+    mw, ma = _add_scaled_pair(omega, a, k1w, k1a, 0.5 * dt)
+    k2w, k2a, _ = _controlled_rhs(mw, ma, viscosity=viscosity, resistivity=resistivity, source=source)
+    return _add_scaled_pair(omega, a, k2w, k2a, dt)
+
+
+def integrate_feedback_control(
+    *,
+    initial_vorticity,
+    initial_magnetic_potential,
+    viscosity: float,
+    resistivity: float,
+    dt: float,
+    final_time: float,
+    gain: float,
+    command_limit: float,
+    feedback_sign: float = -1.0,
+):
+    if dt <= 0.0 or final_time <= 0.0:
+        raise ValueError("dt and final_time must be positive")
+    if gain < 0.0 or command_limit <= 0.0:
+        raise ValueError("gain must be nonnegative and command_limit positive")
+    n = len(initial_vorticity)
+    if n < 8 or n & (n - 1):
+        raise ValueError("G12 requires radix-2 grid size >= 8")
+    steps = max(1, round(final_time / dt))
+    effective_dt = final_time / steps
+    omega = [row[:] for row in initial_vorticity]
+    a = [row[:] for row in initial_magnetic_potential]
+    effort = 0.0
+    max_abs = 0.0
+    first_commands = None
+    last_commands = None
+    for _ in range(steps):
+        commands, bases = _commands(omega, gain=gain, command_limit=command_limit, feedback_sign=feedback_sign)
+        if first_commands is None:
+            first_commands = commands
+        last_commands = commands
+        max_abs = max(max_abs, *(abs(value) for value in commands))
+        effort += effective_dt * sum(value * value for value in commands)
+        source = _source_from_commands(commands, bases)
+        omega, a = _controlled_midpoint_step(
+            omega,
+            a,
+            dt=effective_dt,
+            viscosity=viscosity,
+            resistivity=resistivity,
+            source=source,
+        )
+        if not all(math.isfinite(value) for row in omega for value in row):
+            raise ValueError("G12 controlled plant became non-finite")
+    assert first_commands is not None and last_commands is not None
+    rms0 = math.sqrt(sum(value * value for value in first_commands) / len(first_commands))
+    rmsf = math.sqrt(sum(value * value for value in last_commands) / len(last_commands))
+    return omega, a, effective_dt, steps, effort, max_abs, rms0, rmsf
+
+
+def _target_modal_energy(omega):
+    bases = _basis_fields(len(omega))
+    n = len(omega)
+    total = 0.0
+    for basis in bases:
+        amplitude = _projection(omega, basis)
+        norm = sum(value * value for row in basis for value in row) / (n * n)
+        total += 0.5 * amplitude * amplitude * norm
+    return total
+
+
+def _enstrophy(omega):
+    n = len(omega)
+    return 0.5 * sum(value * value for row in omega for value in row) / (n * n)
+
+
+def _control_case(
+    *,
+    n: int = 16,
+    viscosity: float = 0.01,
+    resistivity: float = 0.015,
+    dt: float = 0.0005,
+    final_time: float = 0.05,
+    feedback_gain: float = 4.0,
+    command_limit: float = 2.0,
+):
+    omega0, a0 = _mixed_initial(n)
+    target0 = _target_modal_energy(omega0)
+    baseline_w, baseline_a, _, _, _, _, _, _ = integrate_feedback_control(
+        initial_vorticity=omega0,
+        initial_magnetic_potential=a0,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        dt=dt,
+        final_time=final_time,
+        gain=0.0,
+        command_limit=command_limit,
+        feedback_sign=-1.0,
+    )
+    reference_w, reference_a, _, _ = integrate_periodic_mhd(
+        initial_vorticity=omega0,
+        initial_magnetic_potential=a0,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        dt=dt,
+        final_time=final_time,
+    )
+    parity = math.sqrt(_l2_difference(baseline_w, reference_w) ** 2 + _l2_difference(baseline_a, reference_a) ** 2)
+    controlled_w, controlled_a, effective_dt, _, effort, max_abs, rms0, rmsf = integrate_feedback_control(
+        initial_vorticity=omega0,
+        initial_magnetic_potential=a0,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        dt=dt,
+        final_time=final_time,
+        gain=feedback_gain,
+        command_limit=command_limit,
+        feedback_sign=-1.0,
+    )
+    wrong_w, _, _, _, _, _, _, _ = integrate_feedback_control(
+        initial_vorticity=omega0,
+        initial_magnetic_potential=a0,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        dt=dt,
+        final_time=final_time,
+        gain=feedback_gain,
+        command_limit=command_limit,
+        feedback_sign=1.0,
+    )
+    target_b = _target_modal_energy(baseline_w)
+    target_c = _target_modal_energy(controlled_w)
+    target_w = _target_modal_energy(wrong_w)
+    enstrophy_b = _enstrophy(baseline_w)
+    enstrophy_c = _enstrophy(controlled_w)
+    u, v, _ = _velocity_and_streamfunction(controlled_w)
+    bx, by, _ = _magnetic_state(controlled_a)
+    return G12ControlCase(
+        grid_size=n,
+        viscosity=viscosity,
+        resistivity=resistivity,
+        final_time=final_time,
+        dt=effective_dt,
+        feedback_gain=feedback_gain,
+        command_limit=command_limit,
+        baseline_parity_l2=parity,
+        target_modal_energy_initial=target0,
+        target_modal_energy_baseline_final=target_b,
+        target_modal_energy_controlled_final=target_c,
+        target_modal_energy_wrong_sign_final=target_w,
+        target_modal_energy_reduction_fraction=(target_b - target_c) / max(target_b, 1e-15),
+        baseline_enstrophy_final=enstrophy_b,
+        controlled_enstrophy_final=enstrophy_c,
+        enstrophy_reduction_fraction=(enstrophy_b - enstrophy_c) / max(enstrophy_b, 1e-15),
+        wrong_sign_vs_controlled_fraction=(target_w - target_c) / max(target_c, 1e-15),
+        control_effort=effort,
+        max_abs_command=max_abs,
+        initial_command_rms=rms0,
+        final_command_rms=rmsf,
+        controlled_velocity_divergence_rms=_spectral_divergence_rms(u, v),
+        controlled_magnetic_divergence_rms=_spectral_divergence_rms(bx, by),
+    )
+
+
+def run_nsb_g12_benchmark(
+    *,
+    baseline_parity_limit: float = 1e-12,
+    target_reduction_floor: float = 0.05,
+    enstrophy_reduction_floor: float = 0.02,
+    divergence_limit: float = 1e-10,
+    command_bound_tolerance: float = 1e-12,
+) -> NSBG12Report:
+    case = _control_case()
+    parity_pass = case.baseline_parity_l2 <= baseline_parity_limit
+    bound_pass = case.max_abs_command <= case.command_limit + command_bound_tolerance
+    target_pass = case.target_modal_energy_reduction_fraction >= target_reduction_floor
+    enstrophy_pass = case.enstrophy_reduction_fraction >= enstrophy_reduction_floor
+    wrong_sign_pass = case.target_modal_energy_wrong_sign_final > case.target_modal_energy_controlled_final
+    geometry_pass = max(case.controlled_velocity_divergence_rms, case.controlled_magnetic_divergence_rms) <= divergence_limit
+    adaptive_pass = case.initial_command_rms > 0.0 and abs(case.final_command_rms - case.initial_command_rms) > 1e-6 and case.control_effort > 0.0
+    acceptance_pass = all((parity_pass, bound_pass, target_pass, enstrophy_pass, wrong_sign_pass, geometry_pass, adaptive_pass))
+    report = NSBG12Report(
+        control_case=case,
+        acceptance=G12AcceptanceSummary(
+            baseline_parity_limit=baseline_parity_limit,
+            target_reduction_floor=target_reduction_floor,
+            enstrophy_reduction_floor=enstrophy_reduction_floor,
+            divergence_limit=divergence_limit,
+            command_bound_tolerance=command_bound_tolerance,
+            baseline_parity_pass=parity_pass,
+            bounded_command_pass=bound_pass,
+            target_reduction_pass=target_pass,
+            enstrophy_reduction_pass=enstrophy_pass,
+            wrong_sign_ordering_pass=wrong_sign_pass,
+            geometry_pass=geometry_pass,
+            adaptive_response_pass=adaptive_pass,
+            acceptance_pass=acceptance_pass,
+        ),
+    )
+    digest = canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))
+    return report.model_copy(update={"report_digest": digest})
+
+
+def verify_nsb_g12_report(report: NSBG12Report) -> bool:
+    return report.report_digest == canonical_digest(report.model_dump(mode="json", exclude={"report_digest"}))

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/nsb_g12_cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .nsb_g12_adaptive_lorentz_control import NSBG12Report, run_nsb_g12_benchmark, verify_nsb_g12_report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run WS-NSB v1.7 G12 adaptive Lorentz-curl simulated control gate."
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--verify", type=Path)
+    return parser
+
+
+def _serialize(report: NSBG12Report) -> str:
+    return json.dumps(
+        report.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify is not None:
+        payload = json.loads(args.verify.read_text(encoding="utf-8"))
+        report = NSBG12Report.model_validate(payload)
+        if not verify_nsb_g12_report(report):
+            print("INVALID")
+            return 1
+        if not report.acceptance.acceptance_pass:
+            print("VALID-BUT-GATE-FAILED")
+            return 2
+        print("VALID")
+        return 0
+
+    report = run_nsb_g12_benchmark()
+    serialized = _serialize(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+        print(report.report_digest)
+    else:
+        print(serialized, end="")
+    return 0 if report.acceptance.acceptance_pass else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds **G12**, the first closed-loop control gate in the WS-NSB chain. It places deterministic bounded modal feedback around the validated G10 nonlinear 2D periodic incompressible resistive-MHD plant.

### Included
- `worldshepherd_sara/nsb_g12_adaptive_lorentz_control.py`
  - abstract prescribed basis for `curl(f_EM)/rho` actuation in the vorticity equation
  - state projection and bounded negative-feedback commands
  - zero-order-held commands with RK2 plant integration
  - zero-control ablation against the unmodified G10 plant
  - wrong-sign red-team controller
  - target modal-energy and enstrophy comparison
  - command effort, command bound, divergence and adaptive-response diagnostics
  - deterministic SHA-256 report binding and fail-closed claims controls
- `worldshepherd_sara/nsb_g12_cli.py`
- `tests/test_nsb_g12_adaptive_lorentz_control.py`
- `docs/WS_NSB_V1_7_G12_ADAPTIVE_LORENTZ_CONTROL.md`
- `ws-nsb-g12` console entry point
- dedicated `WS-NSB v1.7 G12 Gate` workflow

## Scientific boundary

G12 demonstrates simulated bounded feedback against an **abstract Lorentz-force-curl actuator kernel**. It does not establish that real coils, electrodes, metasurface cells, RF hardware, currents, or voltages can generate that kernel.

## Claims boundary

The report remains `SIMULATED_ONLY`. It does not claim physical actuator mapping, laboratory adaptive EM control, compressible/3D MHD, Hall/two-fluid/kinetic/plasma validation, finite-time Navier-Stokes singularity reproduction, propulsion, shielding, stealth, cloaking, or operational capability.

## Acceptance intent

Default gate requires zero-control parity with G10 <= 1e-12, bounded commands, >=5% reduction in targeted modal energy, >=2% reduction in final enstrophy, wrong-sign behavior worse than correct feedback, divergence <=1e-10, nonzero finite control effort, state-dependent command change, and deterministic report verification.