### PR TITLE
Document PRIME all-domain modular architecture through v0.8

### DIFF
--- a/config/prime_all_domain_v0_4.json
+++ b/config/prime_all_domain_v0_4.json
@@ -1,0 +1,83 @@
+{
+  "schema": "worldshepherd.prime.all_domain.v0.4",
+  "claims_state": "engineering_targets_only",
+  "deployment": {
+    "prime_per_psdm": 4,
+    "prime_per_olv": 4,
+    "standard_squad": 8,
+    "standard_squad_launch_groups": 2,
+    "growth_formation": 12,
+    "growth_launch_groups": 3
+  },
+  "prime_reference_frame": {
+    "origin": "pelvic_structural_center",
+    "axes": {"x": "forward", "y": "left", "z": "up"},
+    "body_targets_m": {
+      "standing_height": 1.86,
+      "shoulder_width": 0.52,
+      "pelvic_width": 0.38,
+      "torso_depth": 0.30
+    },
+    "folded_targets_m": {
+      "bare_core": [1.45, 0.74, 0.64],
+      "space_configured": [1.60, 0.82, 0.75]
+    }
+  },
+  "pumi": {
+    "hardpoints_m": {
+      "upper_left": [-0.10, 0.23, 0.32],
+      "upper_right": [-0.10, -0.23, 0.32],
+      "lower_left": [-0.08, 0.20, -0.23],
+      "lower_right": [-0.08, -0.20, -0.23]
+    },
+    "service_power": {
+      "hv_bus_class_vdc": 120,
+      "lv_bus_class_vdc": 28,
+      "controlled_bidirectional_target_kw": 10,
+      "primary_propulsion_routed_through_pumi": false
+    },
+    "thermal": {
+      "active_transfer_target_kw_per_prime": 2,
+      "passive_path_required": true,
+      "active_loop_optional": true
+    },
+    "classes": {
+      "S": {"max_pack_mass_kg": 50, "max_cg_offset_m": 0.25, "working_load_kn": 8, "working_moment_knm": 1.5},
+      "H": {"max_pack_mass_kg": 100, "max_cg_offset_m": 0.30, "working_load_kn": 12, "working_moment_knm": 2.0},
+      "X": {"max_pack_mass_kg": 150, "max_cg_offset_m": 0.35, "working_load_kn": 15, "working_moment_knm": 2.5, "development_proof_load_kn": 22.5, "development_proof_moment_knm": 3.75, "initial_combined_node_article_screen_kn": 10}
+    },
+    "data_channels": ["D-A_primary_high_rate", "D-B_redundant_high_rate", "D-S_independent_safety_health"],
+    "energy_domains": ["P0_core", "P1_mission_pack", "P2_survival_reserve", "P3_return_mobility_reserve"]
+  },
+  "psdm4": {
+    "independent_bays": 4,
+    "cassette_clear_envelope_m": [1.70, 0.90, 0.82],
+    "module_envelope_target_m": [1.95, 2.00, 1.90],
+    "loaded_mass_target_tonnes": [1.0, 1.3],
+    "launch_restraints_separate_from_pumi": true
+  },
+  "pack_inertia_screens": {
+    "axis_order": "XYZ",
+    "S": {"mass_kg": 50, "envelope_m": [0.25, 0.60, 0.45], "cg_inertia_kg_m2": [2.34, 1.10, 1.76]},
+    "H": {"mass_kg": 100, "envelope_m": [0.35, 0.75, 0.80], "cg_inertia_kg_m2": [10.02, 6.35, 5.71]},
+    "X": {"mass_kg": 150, "envelope_m": [0.45, 0.85, 1.05], "cg_inertia_kg_m2": [22.81, 16.31, 11.56]}
+  },
+  "domain_pack_targets": {
+    "SUBTERRA_SUBSPACE": {"pumi_class": "S", "max_external_pack_mass_kg": 35},
+    "SPACE": {"preferred_pumi_class": "S", "local_mobility_target_kg": 50, "heavier_variant_class": "H"},
+    "AERO": {"pumi_class": "H", "max_pack_mass_kg": 90, "architecture": "short_VTOL_plus_wing_borne_cruise", "open_rotor_geometry_frozen": false},
+    "HADAL": {"pumi_class": "X", "max_dry_handling_pack_mass_kg": 150, "hydrostatic_closure_required": true}
+  },
+  "experimental_tracks": ["Baseline", "E-Single", "E-Mix", "E-MULTI", "E-X"],
+  "blocked": [
+    "pumi_laminate_insert_fea",
+    "physical_folded_pose_verification",
+    "full_multiaxial_pumi_test",
+    "hadal_pressure_hydrostatic_validation",
+    "aero_propulsion_aerodynamic_validation",
+    "space_vacuum_thermal_radiation_validation",
+    "psdm_launch_vibration_shock_validation",
+    "ws_alti_structural_credit",
+    "unconventional_propulsion_performance_credit"
+  ]
+}

--- a/config/prime_all_domain_v0_5.json
+++ b/config/prime_all_domain_v0_5.json
@@ -1,0 +1,66 @@
+{
+  "schema": "worldshepherd.prime.all_domain.v0.5",
+  "claims_state": "engineering_screens_only",
+  "inherits": "worldshepherd.prime.all_domain.v0.4",
+  "aero": {
+    "gross_mass_screen_kg": 182,
+    "wing_area_screen_m2": 4.8,
+    "clmax_screen": 1.6,
+    "cruise_speed_screen_m_s": 35,
+    "lift_to_drag_screen": 12,
+    "propulsive_efficiency_screen": 0.8,
+    "stall_speed_screen_m_s": 19.5,
+    "cruise_input_power_screen_kw": 6.5,
+    "baseline_energy_kwh": 10.8,
+    "vtol_total_minutes_screen": 4,
+    "vtol_power_screen_kw": 36,
+    "energy_reserve_fraction": 0.2,
+    "idealized_baseline_range_screen_nmi": 65,
+    "experimental_shadow_range_screen_nmi": 95,
+    "range_status": "SIMULATED_ONLY_FIRST_ORDER",
+    "open_rotor_geometry_frozen": false
+  },
+  "space_thermal": {
+    "emissivity_screen": 0.9,
+    "radiator_temperature_screen_k": 300,
+    "ideal_radiative_flux_w_m2": 413,
+    "ideal_radiator_area_m2": {
+      "700_w": 1.69,
+      "1200_w": 2.90,
+      "2000_w": 4.84
+    },
+    "status": "BLOCKED_ENVIRONMENT_SPECIFIC_THERMAL_ANALYSIS"
+  },
+  "hadal_buoyancy_sensitivity": {
+    "seawater_density_kg_m3": 1025,
+    "screens": [
+      {"material_density_kg_m3": 500, "net_buoyancy_kg_per_l": 0.525, "liters_for_100kg": 190},
+      {"material_density_kg_m3": 600, "net_buoyancy_kg_per_l": 0.425, "liters_for_100kg": 235},
+      {"material_density_kg_m3": 700, "net_buoyancy_kg_per_l": 0.325, "liters_for_100kg": 308}
+    ],
+    "status": "DENSITY_ONLY_SCREEN_NOT_MATERIAL_SPECIFICATION"
+  },
+  "subspace": {
+    "mine_hazardous_location_gate_separate": true,
+    "space_vacuum_outgassing_radiation_gate_separate": true,
+    "shared_core_strategy": "controlled_sealed_joint_modules_plus_replaceable_environment_layer"
+  },
+  "psdm_olv": {
+    "psdm_external_screen_m": [1.95, 2.00, 1.90],
+    "circular_fairing_face_m": [2.00, 1.90],
+    "minimum_circumscribed_diameter_before_clearance_m": 2.76,
+    "compact_air_launch_packaging_status": "BLOCKED",
+    "redesign_branches": ["corner_nested", "canted", "circularized"]
+  },
+  "promotion_state": {
+    "AERO": "BLOCKED_CFD_PROPULSION_TRANSITION_ACOUSTICS_THERMAL_FLIGHT_CONTROL_RESERVE",
+    "SPACE": "BLOCKED_FULL_THERMAL_ENVIRONMENT",
+    "HADAL": "BLOCKED_PRESSURE_HYDROSTATIC_MATERIAL",
+    "SUBSPACE": "ARCHITECTURE_DEFINED_DUAL_QUALIFICATION_REQUIRED",
+    "PSDM_OLV": "BLOCKED_CIRCULAR_FAIRING_PACKAGING"
+  },
+  "performance_credit": {
+    "experimental_new_credit": false,
+    "unconventional_propulsion_credit": false
+  }
+}

--- a/config/prime_all_domain_v0_6.json
+++ b/config/prime_all_domain_v0_6.json
@@ -1,0 +1,104 @@
+{
+  "schema": "worldshepherd.prime.all_domain",
+  "version": "0.6",
+  "date": "2026-09-10",
+  "claims_control": {
+    "physical_performance_status": "ENGINEERING_TARGET_OR_SCREEN_ONLY",
+    "image_generated_values_are_evidence": false,
+    "experimental_performance_credit_before_validation": false,
+    "unconventional_propulsion_credit": 0,
+    "ws_alti_structural_credit": "BLOCKED_PENDING_COUPON_JOINT_SUBASSEMBLY_EVIDENCE"
+  },
+  "formation": {
+    "prime_per_psdm": 4,
+    "prime_per_olv": 4,
+    "standard_squad": 8,
+    "standard_olv_per_squad": 2,
+    "growth_formation": 12
+  },
+  "prime_reference": {
+    "core_mass_target_kg": 92.0,
+    "space_launch_fold_m": {
+      "axial": 1.60,
+      "cross_a": 0.82,
+      "cross_b": 0.75
+    },
+    "reference_frame_origin": "pelvis_centerline",
+    "pumi_upper_to_pelvic_vertical_spacing_m": 0.55,
+    "pumi_lateral_spacing_m": 0.46
+  },
+  "pumi": {
+    "classes": {
+      "S": {"pack_mass_target_kg_max": 50, "cg_offset_m_max": 0.25, "working_load_kN": 8, "working_moment_kNm": 1.5},
+      "H": {"pack_mass_target_kg_max": 100, "cg_offset_m_max": 0.30, "working_load_kN": 12, "working_moment_kNm": 2.0},
+      "X": {"pack_mass_target_kg_max": 150, "cg_offset_m_max": 0.35, "working_load_kN": 15, "working_moment_kNm": 2.5}
+    },
+    "development_proof_factor": 1.5,
+    "x_class_proof_load_kN": 22.5,
+    "x_class_proof_moment_kNm": 3.75,
+    "moment_couple_at_0_55m_kN": 6.82,
+    "simple_peak_node_load_screen_kN": 9.03,
+    "initial_node_article_proof_target_kN": 10.0,
+    "candidate_pin_screen": {
+      "diameter_mm": 14,
+      "load_kN": 10,
+      "ideal_double_shear_MPa": 32.5,
+      "local_bearing_stack_thickness_mm": 10,
+      "nominal_bearing_MPa": 71.4,
+      "status": "SCREEN_ONLY"
+    },
+    "power": {
+      "service_high_voltage_class_VDC": 120,
+      "safety_control_voltage_class_VDC": "24/28",
+      "controlled_bidirectional_service_target_kW": 10,
+      "propulsion_power_local_to_pack": true,
+      "domains": ["P0_CORE", "P1_MISSION", "P2_SURVIVAL_RESERVE", "P3_RETURN_MOBILITY_RESERVE"]
+    },
+    "data": ["D-A_PRIMARY", "D-B_REDUNDANT", "D-S_INDEPENDENT_SAFETY_HEALTH"],
+    "thermal": {"active_transfer_target_kW_continuous": 2.0, "pack_safe_without_active_coupling": true}
+  },
+  "psdm4": {
+    "bays": 4,
+    "bay_independence_required": true,
+    "launch_restraint_separate_from_pumi": true,
+    "raw_folded_body_cross_section_total_m2": 2.46,
+    "circularization": {
+      "topology": "FOUR_CONFORMAL_PETAL_CASSETTES_AROUND_CENTRAL_SERVICE_SPINE",
+      "fallback_clear_internal_diameter_m": 2.65,
+      "objective_clear_internal_diameter_m": 2.55,
+      "stretch_clear_internal_diameter_m": 2.45,
+      "circle_area_m2": {"2.45": 4.71, "2.55": 5.11, "2.65": 5.52},
+      "raw_folded_body_occupancy_percent": {"2.45": 52.2, "2.55": 48.2, "2.65": 44.6},
+      "mass_savings_credit": "NOT_CURRENTLY_CLAIMED",
+      "status": "ENGINEERING_TARGET_REQUIRES_PARAMETERIZED_CAD"
+    },
+    "loaded_mass_target_tonnes": [1.0, 1.3]
+  },
+  "domain_pack_mapping": {
+    "SUBTERRA_SUBSPACE": {"target_class": "PUMI-S", "external_equipment_mass_target_kg_max": 35},
+    "SPACE": {"target_class": "PUMI-S_OR_H", "local_mobility_mass_target_kg_max": 50},
+    "AERO": {"target_class": "PUMI-H", "mass_target_kg_max": 90, "status": "BLOCKED_COMPLETE_PROPULSION_ENERGY_AERO_CLOSURE"},
+    "HADAL": {"target_class": "PUMI-X", "dry_handling_mass_target_kg_max": 150, "status": "BLOCKED_HYDROSTATIC_PRESSURE_CAD"}
+  },
+  "olv4": {
+    "prime_payload_count": 4,
+    "psdm_payload_class_tonnes_min_planning": 1.5,
+    "v0_5_rectangular_layout_status": "FAILED_PACKAGING_SCREEN",
+    "v0_6_gate": "PSDM4_CIRCULARIZED_CAD_MUST_CLOSE_BEFORE_OLV_GEOMETRY_FREEZE",
+    "propulsion_or_staging_design_in_this_record": false
+  },
+  "experimental_tracks": ["BASELINE", "E_SINGLE", "E_MIX", "E_MULTI", "E_X"],
+  "military_government_scope": {
+    "allowed_architecture_scope": ["mobility", "transport", "logistics", "engineering", "rescue_recovery", "sensing", "communications", "environmental_operations", "platform_survivability", "space_support"],
+    "weapon_employment": "OUT_OF_SCOPE",
+    "targeting": "OUT_OF_SCOPE"
+  },
+  "next_gates": [
+    "PARAMETERIZED_PSDM4_FOUR_PETAL_CAD",
+    "PUMI_NODE_LAMINATE_INSERT_FEA",
+    "PSDM4_ACTUAL_MASS_INERTIA_UPDATE",
+    "AERO_NON_ENERGY_MASS_CLOSURE",
+    "SPACE_RADIATOR_DEPLOYMENT_CLOSURE",
+    "HADAL_PRESSURE_BUOYANCY_STRUCTURAL_CLOSURE"
+  ]
+}

--- a/config/prime_all_domain_v0_7.json
+++ b/config/prime_all_domain_v0_7.json
@@ -1,0 +1,159 @@
+{
+  "schema": "worldshepherd.prime.all_domain",
+  "version": "0.7",
+  "date": "2026-09-10",
+  "claims_control": {
+    "physical_performance_status": "ENGINEERING_TARGET_OR_SCREEN_ONLY",
+    "experimental_performance_credit_before_validation": false,
+    "image_generated_values_are_evidence": false,
+    "unconventional_propulsion_credit": 0,
+    "weapon_employment": "OUT_OF_SCOPE",
+    "targeting": "OUT_OF_SCOPE"
+  },
+  "formation": {
+    "prime_per_psdm": 4,
+    "prime_per_olv": 4,
+    "standard_squad": 8,
+    "standard_olv_per_squad": 2,
+    "growth_formation": 12
+  },
+  "psdm4_geometry_trades": {
+    "space_fold_cross_section_each_m": [0.82, 0.75],
+    "central_service_cross_gap_m": 0.10,
+    "compact_raw_grid_m": [1.74, 1.60],
+    "compact_raw_grid_diagonal_m": 2.364,
+    "compact_circular": {
+      "fallback_clear_id_m": 2.65,
+      "fallback_radial_corner_margin_m": 0.143,
+      "objective_clear_id_m": 2.55,
+      "objective_radial_corner_margin_m": 0.093,
+      "stretch_clear_id_m": 2.45,
+      "stretch_radial_corner_margin_m": 0.043,
+      "status": "BLOCKED_PENDING_PARAMETERIZED_CAD"
+    },
+    "slender_air_launch": {
+      "designation": "PSDM-4L",
+      "units_per_longitudinal_station": 2,
+      "stations": 2,
+      "raw_station_cross_section_m": [1.74, 0.75],
+      "raw_station_diagonal_m": 1.895,
+      "clear_diameter_target_m": 2.10,
+      "axial_length_target_m": [3.6, 3.7],
+      "status": "LEADING_AIR_LAUNCH_TRADE_BLOCKED_PENDING_CAD_LOADS"
+    },
+    "single_file_remote_trade": {
+      "designation": "PSDM-4S",
+      "clear_diameter_screen_m": [1.3, 1.4],
+      "axial_length_screen_m": 7.0,
+      "status": "REMOTE_TRADE_LENGTH_BENDING_PENALTY"
+    }
+  },
+  "pumi": {
+    "x_class_proof_load_kN": 22.5,
+    "x_class_proof_moment_kNm": 3.75,
+    "simple_peak_node_load_screen_kN": 9.03,
+    "initial_node_article_proof_target_kN": 10.0,
+    "launch_restraint_separate_from_pumi": true
+  },
+  "aero": {
+    "gross_mass_screen_kg": 182,
+    "pack_mass_gate_kg": 90,
+    "non_energy_hardware_mass_gate_kg": 45,
+    "effective_lift_area_trade_m2": {
+      "6.28": {"design_power_kW": 37.5, "four_minute_vtol_energy_kWh": 2.50},
+      "8.0": {"design_power_kW": 33.2, "four_minute_vtol_energy_kWh": 2.21},
+      "10.0": {"design_power_kW": 29.7, "four_minute_vtol_energy_kWh": 1.98}
+    },
+    "effective_lift_area_objective_m2_min": 8.0,
+    "propulsion_inverter_allocation_kg": 15,
+    "required_peak_specific_power_for_33_2kW_kW_per_kg": 2.21,
+    "architecture_preference": ["ENCLOSED", "DUCTED", "PARTIALLY_SHROUDED", "EMBEDDED", "FOLDING", "OTHER_PROTECTED"],
+    "open_rotor": "FALLBACK_TRADE_NOT_DEFAULT",
+    "status": "BLOCKED_DETAILED_BOM_PROPULSION_AERO_THERMAL_FLIGHT_TEST"
+  },
+  "space_thermal": {
+    "deployable_radiator_area_target_m2": 2.4,
+    "emissivity_screen": 0.9,
+    "effective_rejection_factor_screen": 0.70,
+    "rejection_screen_W": {
+      "330K": 1017,
+      "350K": 1287
+    },
+    "nominal_local_heat_target_W": 700,
+    "pumi_thermal_transfer_capability_kW": 2.0,
+    "continuous_2kW_rejection_claimed": false,
+    "two_kW_for_15min_at_350K_buffer_requirement": {
+      "energy_kJ": 642,
+      "energy_kWh": 0.178
+    },
+    "status": "BLOCKED_MISSION_SPECIFIC_ORBIT_SURFACE_THERMAL_BALANCE_AND_DEPLOYMENT_RELIABILITY"
+  },
+  "hadal": {
+    "baseline_pressure_strategies": [
+      "PRESSURE_BALANCED_OR_OIL_FILLED_WHERE_COMPONENTS_ALLOW",
+      "MINIMIZED_DRY_PRESSURE_VESSELS_FOR_SENSITIVE_EQUIPMENT",
+      "DISTRIBUTED_QUALIFIED_SYNTACTIC_OR_CERAMIC_BUOYANCY",
+      "INDEPENDENT_RELEASABLE_BALLAST_AND_POSITIVE_BUOYANCY_EMERGENCY_ASCENT"
+    ],
+    "experimental_article": "HADAL-BUOY-E1_CERAMIC_SPHERE_DISTRIBUTED_FLOTATION",
+    "status": "BLOCKED_REPRESENTATIVE_PRESSURE_HYDROSTATIC_MATERIAL_SEAL_CONNECTOR_THRUSTER_TESTING"
+  },
+  "subspace": {
+    "same_serialized_prime_core": true,
+    "mine_and_space_qualification_independent": true,
+    "transition_gate": [
+      "DECONTAMINATION_CLEANING",
+      "MECHANICAL_AND_NDT_INSPECTION_AS_REQUIRED",
+      "CONNECTOR_AND_INSULATION_CHECK",
+      "SEAL_LUBRICANT_CONDITION",
+      "BATTERY_HEALTH",
+      "STRUCTURAL_HEALTH_REVIEW",
+      "PACK_PROVENANCE",
+      "VACUUM_OUTGASSING_ENVIRONMENT_ACCEPTANCE"
+    ],
+    "status": "ARCHITECTURE_DEFINED_VALIDATION_REQUIRED"
+  },
+  "external_evidence_operationalization": [
+    {
+      "source": "NASA TechPort HPDM-30",
+      "updated": "2026-08-20",
+      "evidence": "30 kW integrated motor-drive project targeting 10 kW/kg continuous",
+      "use": "AERO_E_SINGLE_PWR_BENCHMARK",
+      "credit": "NO_DIRECT_PRIME_PERFORMANCE_CREDIT"
+    },
+    {
+      "source": "NASA Electric Aircraft Propulsion Power Converters",
+      "evidence": "250 kW converter reported at 10.6 kW/kg and 99.3% efficiency",
+      "use": "AERO_INVERTER_BENCHMARK",
+      "credit": "NO_DIRECT_PRIME_PERFORMANCE_CREDIT"
+    },
+    {
+      "source": "NASA 2026 Small Spacecraft Thermal Systems State of the Art",
+      "evidence": "deployable radiator technology increases radiating area when body area is insufficient",
+      "use": "SPACE_DEPLOYABLE_RADIATOR_BASELINE_REQUIREMENT",
+      "credit": "ARCHITECTURE_PRECEDENT_ONLY"
+    },
+    {
+      "source": "WHOI deep-ocean engineering sources",
+      "evidence": "spherical/cylindrical pressure housings, syntactic flotation, oil pressure equalization, ceramic flotation",
+      "use": "HADAL_BASELINE_AND_E_SINGLE_BUOYANCY_ARCHITECTURE",
+      "credit": "EXTERNAL_PRACTICE_NOT_WORLDSHEPHERD_HARDWARE_EVIDENCE"
+    }
+  ],
+  "experimental_tracks": ["BASELINE", "E_SINGLE", "E_MIX", "E_MULTI", "E_X"],
+  "new_experimental_articles": [
+    "AERO-E-SINGLE-PWR",
+    "AERO-E-SINGLE-LIFT",
+    "SPACE-E-SINGLE-THERM",
+    "HADAL-E-SINGLE-BUOY",
+    "PSDM-E-SINGLE-MAT",
+    "PUMI-E-SINGLE-NODE"
+  ],
+  "next_gates": [
+    "PARAMETERIZED_CAD_COMPARE_PSDM4C_VS_PSDM4L",
+    "PUMI_NODE_LAMINATE_INSERT_FEA",
+    "AERO_DETAILED_NON_ENERGY_BOM",
+    "SPACE_RADIATOR_STOW_DEPLOY_MASS_AND_THERMAL_LOOP",
+    "HADAL_DRY_VOLUME_PRESSURE_BUOYANCY_ACCOUNTING"
+  ]
+}

--- a/config/prime_all_domain_v0_8.json
+++ b/config/prime_all_domain_v0_8.json
@@ -1,0 +1,162 @@
+{
+  "schema": "worldshepherd.prime.all_domain",
+  "version": "0.8",
+  "date": "2026-09-10",
+  "claims_control": {
+    "physical_performance_status": "ENGINEERING_TARGET_OR_SCREEN_ONLY",
+    "experimental_performance_credit_before_validation": false,
+    "unconventional_propulsion_credit": 0,
+    "weapon_employment": "OUT_OF_SCOPE",
+    "targeting": "OUT_OF_SCOPE"
+  },
+  "psdm4l": {
+    "prime_count": 4,
+    "stations": 2,
+    "prime_per_station": 2,
+    "clear_diameter_target_m_max": 2.10,
+    "axial_length_target_m": [3.6, 3.7],
+    "nominal_loaded_mass_target_kg": 1100,
+    "hard_loaded_mass_ceiling_kg": 1300,
+    "nominal_mass_breakdown_kg": {
+      "four_space_configured_prime": 520,
+      "four_cassettes_and_restraints": 100,
+      "primary_and_outer_structure": 150,
+      "power_and_thermal_service": 70,
+      "deployment_release_systems": 60,
+      "avionics_timing_comms_health": 25,
+      "protected_psdm_contingency_energy": 25,
+      "common_wiring_fluid_connectors": 30,
+      "structural_integration_growth": 120
+    },
+    "paired_release_first_order_cg_shift_m": 0.26,
+    "post_paired_release_cg_shift_target_m_max": 0.30,
+    "individual_release": "REQUIRES_ACTUAL_MASS_PROPERTY_AND_ATTITUDE_CONTROL_CLOSURE",
+    "status": "LEADING_AIR_LAUNCH_TRADE_BLOCKED_PENDING_CAD_AND_STRUCTURAL_ANALYSIS"
+  },
+  "aero": {
+    "pack_mass_gate_kg": 90,
+    "installed_energy_and_reserve_allocation_kg": 45,
+    "non_energy_hard_mass_gate_kg": 45,
+    "non_energy_bom_target_kg": {
+      "lift_cruise_effectors_ducts_local_protection": 12.0,
+      "motors_inverters": 6.0,
+      "wing_primary_structure": 10.0,
+      "fold_tilt_deployment_mechanisms": 5.0,
+      "thermal": 3.0,
+      "avionics_flight_control_sensors": 2.0,
+      "power_distribution_harness_contactors": 2.0,
+      "landing_docking": 2.0,
+      "acoustic_fault_containment_shells": 1.5,
+      "growth": 1.5
+    },
+    "design_power_screen_kW_at_8m2": 33.2,
+    "motor_inverter_allocation_specific_power_screen_kW_per_kg": 5.53,
+    "highest_risk_mass_line": "LIFT_CRUISE_EFFECTORS_DUCTS_LOCAL_PROTECTION",
+    "preferred_effector_architectures": ["ENCLOSED", "DUCTED", "PARTIALLY_SHROUDED", "EMBEDDED", "FOLDING", "OTHER_PROTECTED"],
+    "open_rotor": "FALLBACK_ONLY_IF_MASS_EFFICIENCY_AND_SAFETY_GATES_REQUIRE",
+    "status": "BLOCKED_CANDIDATE_GEOMETRY_PART_MASS_THERMAL_AND_FAILURE_MODE_CLOSURE"
+  },
+  "space_thermal": {
+    "space_s50": {
+      "pumi_class": "S",
+      "pack_mass_target_kg": 50,
+      "thermal_allocation_kg": 8,
+      "v0_7_total_effective_radiator_area_target_m2": 2.4,
+      "fully_deployable_2_4m2_against_external_lt8kg_per_m2_benchmark": {
+        "radiator_mass_upper_screen_kg": 19.2,
+        "result": "FAIL_BLOCKED_AGAINST_8KG_THERMAL_ALLOCATION"
+      },
+      "redesign": {
+        "designation": "SPACE-S50-TBI",
+        "body_integrated_effective_area_target_m2": 1.2,
+        "deployable_supplemental_area_target_m2": 1.2,
+        "reserved_loop_interface_valves_actuation_kg": 2.0,
+        "deployable_radiator_mass_budget_kg": 6.0,
+        "deployable_areal_mass_target_kg_per_m2_max": 5.0,
+        "status": "ENGINEERING_TARGET_REQUIRES_VIEW_FACTOR_MASS_AND_ENVIRONMENT_VALIDATION"
+      }
+    },
+    "space_h70_therm": {
+      "pumi_class": "H",
+      "purpose": "HIGHER_SUSTAINED_HEAT_LOAD_PARALLEL_CONFIGURATION",
+      "status": "TARGET_REQUIRES_COMPLETE_MASS_CG_INERTIA_ENERGY_AND_MOBILITY_CLOSURE"
+    },
+    "continuous_2kW_vacuum_rejection_claimed": false
+  },
+  "hadal": {
+    "core_mass_target_kg": 92,
+    "pack_mass_ceiling_kg": 150,
+    "system_mass_screen_kg": 242,
+    "seawater_density_kg_per_m3": 1025,
+    "operating_apparent_negative_mass_target_kg": 10,
+    "effective_displacement_for_minus10kg_trim_L": 226.3,
+    "ballast_release_branch_kg": 15,
+    "post_release_apparent_positive_buoyancy_target_kg": 5,
+    "rebalanced_pack_mass_target_kg": {
+      "pressure_buoyancy_architecture": 55,
+      "energy": 25,
+      "thrusters_drives": 20,
+      "structure_interface": 15,
+      "sonar_environment_sensing": 10,
+      "ballast_release": 15,
+      "controls_comms_thermal": 5,
+      "growth": 5
+    },
+    "emergency_ascent_requires_continuous_thrusters": false,
+    "status": "HYDROSTATIC_TARGET_BLOCKED_CAD_PRESSURE_STABILITY_AND_REPRESENTATIVE_TESTING"
+  },
+  "subspace": {
+    "post_hazard_state": "QUARANTINED_FOR_REQUALIFICATION",
+    "state_clearance_requires": [
+      "DECONTAMINATION_CLEANING",
+      "MECHANICAL_AND_NDT_INSPECTION_AS_REQUIRED",
+      "CONNECTOR_AND_INSULATION_CHECKS",
+      "SEAL_AND_TRIBOLOGY_CONDITION",
+      "BATTERY_HEALTH",
+      "STRUCTURAL_HEALTH_REVIEW",
+      "PACK_PROVENANCE",
+      "TARGET_ENVIRONMENT_ACCEPTANCE"
+    ],
+    "new_space_pack_alone_can_clear_quarantine": false,
+    "sara_role": "CONFIGURATION_CUSTODY",
+    "prime_sentinel_role": "INDEPENDENT_ENVIRONMENT_AUTHORIZATION",
+    "echo_role": "BEFORE_AFTER_EVIDENCE_PROVENANCE"
+  },
+  "external_evidence": [
+    {
+      "source": "NASA TechPort project 113167",
+      "updated": "2026-01-22",
+      "statement": "deployable freeze-tolerant radiator design reports meeting solicitation mass requirement below 8 kg/m2",
+      "use": "SPACE_S50_MASS_GATE_AND_REDESIGN_INPUT",
+      "credit": "EXTERNAL_BENCHMARK_ONLY"
+    },
+    {
+      "source": "NASA Small Spacecraft Thermal Control SOA",
+      "updated": "2026-05-07",
+      "statement": "deployable radiators increase available radiative area where body area is constrained",
+      "use": "SPACE_BODY_INTEGRATED_PLUS_DEPLOYABLE_ARCHITECTURE",
+      "credit": "ARCHITECTURE_PRECEDENT_ONLY"
+    },
+    {
+      "source": "NASA TechPort HPDM-30",
+      "updated": "2026-08-20",
+      "statement": "30 kW integrated motor drive project target 10 kW/kg continuous",
+      "use": "AERO_MOTOR_INVERTER_BENCHMARK",
+      "credit": "NO_DIRECT_PRIME_PERFORMANCE_CREDIT"
+    }
+  ],
+  "new_experimental_articles": [
+    "SPACE-E-SINGLE-RAD",
+    "SPACE-E-SINGLE-MULTITHERM",
+    "AERO-E-SINGLE-EFFECTOR",
+    "PSDM-E-SINGLE-SPINE",
+    "HADAL-E-SINGLE-TRIM"
+  ],
+  "next_gates": [
+    "AERO_CANDIDATE_GEOMETRY_AND_PART_SOURCING_FOR_45KG_NON_ENERGY_BOM",
+    "SPACE_S50_BODY_RADIATOR_VIEW_FACTOR_AND_RADIATOR_MASS_MODEL",
+    "PSDM4L_ACTUAL_INERTIA_TENSOR_AND_LOAD_CASE_SCHEMA",
+    "HADAL_BODY_PACK_DISPLACED_VOLUME_LEDGER",
+    "SARA_QUARANTINE_STATE_MACHINE_INTEGRATION"
+  ]
+}

--- a/deployments/sara_verified_local_v1/PRIME_ARCHITECTURE_CI_TRIGGER_2026-09-10.md
+++ b/deployments/sara_verified_local_v1/PRIME_ARCHITECTURE_CI_TRIGGER_2026-09-10.md
@@ -1,0 +1,7 @@
+# PRIME architecture CI trigger
+
+Purpose: ensure the protected-branch `test-and-build` verification job executes for Worldshepherd PRIME architecture/configuration changes in PR #142.
+
+This file intentionally lives under `deployments/sara_verified_local_v1/**`, the path currently configured to trigger the SARA Verified Local v1 Gate. It does not alter runtime behavior, branch protection, physical capability claims, or deployment configuration.
+
+Claims boundary: passing this software/CI gate establishes only repository-level build/test/evidence behavior. It does not establish physical PRIME, PUMI, PSDM, AERO, HADAL, SUBSPACE, carrier, launch, or SPACE performance.

--- a/docs/WS_PRIME_ALL_DOMAIN_ARCHITECTURE_2026-09-10.md
+++ b/docs/WS_PRIME_ALL_DOMAIN_ARCHITECTURE_2026-09-10.md
@@ -1,0 +1,130 @@
+# Worldshepherd PRIME All-Domain Modular Architecture
+
+Status: architecture definition / engineering targets / claims-controlled.
+
+This document records the current implementation-facing architecture for the Worldshepherd PRIME all-domain program. It does not claim validated robot, aircraft, deep-sea, launch, or space hardware performance.
+
+## Canonical nomenclature
+
+- **WHX**: humanoids.
+- **CHX**: companions/helpers.
+- **PRIME**: top-tier all-domain architecture.
+- **PUMI**: PRIME Universal Mission Interface.
+- **PSDM-4**: four-PRIME deployment module.
+- **OLV-4**: orbital launch vehicle carrying one PSDM-4.
+- **PASC**: autonomous PRIME squad carrier.
+
+## PRIME-4 deployment rule
+
+The standard deployment module contains **four PRIME units**. One PSDM-4 / OLV-4 carries four PRIME units. A standard eight-PRIME squad uses two independent groups of four. Twelve-unit growth uses three groups of four.
+
+The four-unit grouping is intended to persist across ground, subterranean, maritime/deep-sea, atmospheric, orbital, lunar/asteroid, industrial, rescue, scientific, and authorized government configurations.
+
+## All-domain core and mission packs
+
+PRIME uses a persistent standardized robot core plus detachable domain packs rather than carrying every environment system simultaneously.
+
+- **SUBTERRA**: mines, caves, tunnels, dust/water, hazardous-environment sensing, climbing and communications.
+- **SUBSPACE**: dual mining/space configuration; the same serialized PRIME core can transition from underground service to a SPACE configuration after inspection, decontamination, and qualification checks.
+- **HADAL**: pressure architecture, pressure-balanced mechanisms where appropriate, protected electronics, syntactic buoyancy, thrusters, ballast, sonar, dedicated dive power, and emergency positive buoyancy.
+- **AERO**: detachable atmospheric-flight structure with its own propulsion, inverters, flight energy, flight controls, and emergency recovery energy.
+- **SPACE**: vacuum-compatible mobility, thermal rejection/heaters, radiation-aware avionics, particulate/dust awareness, communications, maneuvering propulsion, and protected emergency-return energy.
+
+Space capability does not imply self-launch to orbit. Orbital insertion remains a carrier/launch-vehicle function.
+
+## PUMI v0.3
+
+PUMI uses a four-point torso/pelvis load frame with two upper capture nodes and two pelvic load nodes. Candidate hardpoint spacing is approximately 0.46 m laterally and 0.55 m vertically, subject to packaging and FEA. Pack loads bypass cosmetic shells and enter the primary spine/pelvic structure.
+
+Preliminary mechanical classes:
+
+| Class | Pack mass target | CG offset target | Working load target | Working moment target |
+|---|---:|---:|---:|---:|
+| PUMI-S | <= 50 kg | <= 0.25 m | 8 kN | 1.5 kN-m |
+| PUMI-H | <= 100 kg | <= 0.30 m | 12 kN | 2.0 kN-m |
+| PUMI-X | <= 150 kg | <= 0.35 m | 15 kN | 2.5 kN-m |
+
+A 2.5 kN-m moment across 0.55 m produces about a 4.55 kN tension/compression couple before proof factors. Development proof loading begins at >=1.5x the applicable working envelope. Exact node, insert, laminate, fatigue, fracture, bearing, and impact behavior remains **BLOCKED pending FEA and physical test**.
+
+## Power isolation
+
+- **P0**: PRIME core energy.
+- **P1**: mission-pack energy.
+- **P2**: protected survival reserve.
+- **P3**: protected emergency mobility/return reserve.
+
+Mission packs power their own high-current propulsion loops. PUMI provides controlled service/cross-feed rather than becoming the primary flight, dive, or space-propulsion bus.
+
+Design targets are a 120 VDC-class high-voltage service bus, 24/28 VDC-class safety/control bus, and up to 10 kW controlled bidirectional service transfer. These values require engineering validation.
+
+## Data, safety, and custody
+
+PUMI separates:
+
+- **D-A**: primary high-rate mission network.
+- **D-B**: independent redundant high-rate network.
+- **D-S**: independent deterministic safety/health channel.
+
+Loss or compromise of D-A must not disable pack isolation, safe-torque-off, emergency release, thermal protection, insulation-fault response, or protected-reserve commands.
+
+Every mission pack presents a machine-readable digital passport containing identity, revision, mass properties, PUMI class, environment rating, power/reserve state, thermal limits, inspection state, structural-health state, compatibility, experimental maturity, and authorization state.
+
+SARA handles orchestration/configuration custody; PRIME SENTINEL is the independent authorization boundary; ECHO SENTINEL LINK records provenance; OVERWATCH tracks health/operational state.
+
+## Thermal interface
+
+PUMI supports passive conductive heat transfer plus optional dry-break active coolant supply/return. Current active transfer target is 2 kW continuous per PRIME, with higher transients subject to thermal-mass analysis. Cooling loss must cause derating/controlled shutdown rather than an unsafe dependency.
+
+## PSDM-4 v0.3
+
+PSDM-4 contains four mechanically and electrically independent PRIME cassettes. Each cassette has its own launch restraint, shock/vibration isolation, service connection, health monitoring, electrical isolation, thermal conditioning, emergency service power, and deployment mechanism.
+
+Current packaging targets:
+
+- folded/reclined bay: approximately 2.1 m x 0.85 m x 0.65 m per PRIME;
+- complete PSDM-4 envelope: approximately 2.4 m x 2.1 m x 1.7-1.9 m before launch-stage integration;
+- loaded PSDM-4: approximately 1.0-1.3 tonnes.
+
+These are CAD/FEA targets, not validated dimensions or masses.
+
+Launch restraints are separate from PUMI and transfer launch loads into dedicated primary structural restraint points.
+
+## Autonomous carrier / air-launch branch
+
+PASC is an autonomous heavy airborne mission carrier sized around complete four-PRIME launch groups. Minimum squad configuration carries two independently releasable OLV-4 / PSDM-4 assemblies for eight PRIME units; growth configuration supports three groups of four.
+
+The air-launch branch uses the high-level carrier-aircraft plus released orbital-stage pattern. Autonomous flight/payload functions remain bounded by independent safety and authorization gates. Failed launch criteria result in no release and safe return when the vehicle design and mission state permit.
+
+## Experimental technology tracks
+
+Every major family maintains:
+
+1. **Baseline** control.
+2. **E-Single** one-variable experimental articles.
+3. **E-Mix** selected experimental combinations.
+4. **E-MULTI** experimentally promoted combinations.
+5. **E-X** all-experimental shadow architecture.
+
+E-X uses experimental challengers across major technology-bearing subsystems wherever one exists, but receives no hidden credit from baseline hardware. Experimental candidates include T1200/T1100-CNT structural hybrids, CF/CNT transition zones, CF-PAEK nodes, WS-AlTi graded nodes after coupon validation, compliant/tendon/artificial-muscle distal actuation, parallel-elastic/variable-ratio joints, advanced battery chemistries, secondary structural storage, CNT conductors, structural heat spreading, self-healing composites, embedded health sensing, programmable RF surfaces, and autonomous repair/manufacturing research.
+
+E-X must remain externally interoperable with the common PUMI contract.
+
+## Claims-control boundaries
+
+- No image-generated number is evidence.
+- No experimental technology contributes credited performance before measured validation.
+- WS-AlTi remains an IP-stage / validation-stage challenger pending modeling and physical evidence.
+- Unconventional propulsion contributes zero lift, thrust, energy, or range credit until calibrated measurement and replication.
+- SARA software evidence does not establish physical robot, aircraft, launch, deep-sea, or space performance.
+
+## Government / military derivatives
+
+Authorized government or military derivatives may reuse the same PRIME-4, PUMI, PSDM-4, carrier, and domain-pack architecture for qualified-domain transport, mobility, logistics, engineering, rescue/recovery, sensing, communications, environmental operations, platform survivability, and space-support missions. "Anywhere insertion" means physically engineered, tested, authorized, and legally permitted domains; it is not an assumption of unrestricted reach. Weapon employment and targeting are outside this architecture document.
+
+## Immediate engineering closure
+
+1. Run PUMI v0.3 structural/topology and laminate/insert FEA against S/H/X envelopes.
+2. Freeze folded WHX-PRIME geometry and mass-property reference frames.
+3. Close HADAL, AERO, SUBSPACE, and SPACE pack mass/CG/inertia against PUMI classes.
+4. Close PSDM-4 launch-load paths, bay release independence, service power, and thermal budgets.
+5. Continue one-variable experimental articles before E-MULTI promotion; retain E-X as a non-credit shadow configuration until evidence closes.

--- a/docs/WS_PRIME_CROSS_DOMAIN_CLOSURE_2026-09-10.md
+++ b/docs/WS_PRIME_CROSS_DOMAIN_CLOSURE_2026-09-10.md
@@ -1,0 +1,60 @@
+# Worldshepherd PRIME Cross-Domain Closure
+
+Status: engineering target / mathematical screening / requires validation.
+
+This addendum advances PUMI v0.3 into cross-domain mass, load, energy, buoyancy, and carrier packaging screens. It does not promote any physical capability beyond the claims state supported by evidence.
+
+## Environmental load rule
+
+PUMI qualification depends on environmental loads as well as attached pack mass. The interface load model must combine inertial force from mass/CG, aerodynamic or hydrodynamic force at the pack center of pressure, pack-generated reaction torque, and transient contact/impact loads. Meeting the pack-mass limit alone is insufficient.
+
+For PUMI-X, the 2.5 kN-m working moment becomes 3.75 kN-m at the current 1.5x development proof factor. Across the candidate 0.55 m vertical hardpoint spacing this produces an approximately 6.82 kN tension/compression couple. Combined with the 15 kN working / 22.5 kN proof load envelope, initial hardpoint articles should screen at approximately 10 kN combined-equivalent proof load before detailed vector load cases and FEA refine the requirement.
+
+## Preliminary pack-class mapping
+
+| Pack | Preliminary class | Mass target | Key unresolved load |
+|---|---|---:|---|
+| SUBTERRA / SUBSPACE | PUMI-S | <= 35 kg target | impacts, climbing, hazardous-environment constraints |
+| SPACE local mobility | PUMI-S / H | <= 50 kg S target; heavier H allowed | maneuvering reactions, thermal equipment |
+| AERO | PUMI-H | <= 90 kg target | rotor/wing loads, vibration, landing transients |
+| HADAL | PUMI-X | <= 150 kg dry-handling target | buoyancy, drag, hydrostatic stability, pressure architecture |
+
+A pack that fails its assigned class is redesigned first. PUMI classes are not enlarged solely to rescue an overweight or over-load pack.
+
+## AERO first-order closure
+
+Using the current 92 kg PRIME-core target plus a 90 kg AERO pack produces a 182 kg gross design screen.
+
+Eight 1.0 m diameter lift rotors provide approximately 6.28 m^2 total disk area. At sea-level density, ideal induced hover power screens at approximately 19.2 kW. Applying the current preliminary figure-of-merit/drivetrain screen yields roughly 30 kW propulsion input before reserve; adding a provisional 20 percent peak reserve pushes the design-power screen toward approximately 36 kW.
+
+These are mathematical targets only. Aerodynamic interference, motor/inverter efficiency, thermal behavior, acoustic limits, control authority, gust response, rotor safety, structure, and flight test remain unresolved.
+
+A 45 kg qualified-pack energy allocation at 240 Wh/kg usable would provide approximately 10.8 kWh. Four total minutes at a 36 kW peak screen consumes approximately 2.4 kWh; ten minutes consumes approximately 6.0 kWh before cruise, reserves, and conversion losses. The baseline architecture therefore remains **short VTOL plus wing-borne cruise**, not sustained multirotor hover.
+
+An E-X shadow energy pack at 320 Wh/kg usable would provide approximately 14.4 kWh at the same 45 kg mass, but the additional 3.6 kWh receives no baseline credit until an installed pack demonstrates it.
+
+## HADAL first-order closure
+
+HADAL should not attempt to obtain all buoyancy from a single backpack. A 200 kg robot-plus-pack system requires approximately 195 L of total effective displaced seawater volume merely to balance weight at 1025 kg/m^3, before stability or reserve buoyancy is considered.
+
+The working architecture therefore favors distributed pressure-tolerant volume/buoyancy across the body and pack, slightly negative seabed operating buoyancy, independently releasable ballast, and protected positive-buoyancy ascent capability. Exact syntactic-foam volume, pressure-vessel mass, flooded volume, drag, metacentric/stability behavior, and center-of-buoyancy location remain BLOCKED pending a complete hydrostatic CAD model.
+
+## PSDM-4 / OLV-4 payload closure
+
+The current 1.0-1.3 tonne loaded PSDM-4 target implies that each OLV-4 should be treated as at least a **1.5 tonne orbital-payload-class planning requirement** after adapter and growth margin. This is a separate launch-vehicle/partner development problem and is substantially beyond small air-launched satellite systems.
+
+PASC must carry two independent OLV-4 / PSDM-4 assemblies for the standard eight-PRIME squad.
+
+For the two-vehicle carrier, tandem or otherwise centerline-dominant launch stations are preferred for early trade studies because a single release produces less lateral roll asymmetry than widely separated left/right payloads. Fore/aft CG migration, aeroelasticity, flutter, structural loads, separation aerodynamics, and return-with-payload behavior remain mandatory analyses before carrier geometry is frozen.
+
+## Closure status
+
+- **PUMI-S/H/X three-class architecture:** retained.
+- **SUBTERRA/SUBSPACE:** PUMI-S target; engineering development.
+- **SPACE:** PUMI-S/H depending mobility and thermal equipment; engineering development.
+- **AERO:** PUMI-H; BLOCKED on full propulsion/energy/aerodynamic closure.
+- **HADAL:** PUMI-X; BLOCKED on hydrostatic/pressure closure.
+- **PSDM-4:** four independent bays retained.
+- **OLV-4:** one four-PRIME orbital insertion module retained.
+- **PASC:** two independent four-PRIME launch groups minimum; autonomous-carrier development remains a separate major program.
+- **E-X:** parallel non-credit shadow design; no experimental performance transfers into baseline until validated.

--- a/docs/WS_PRIME_V0_4_ENGINEERING_CLOSURE_2026-09-10.md
+++ b/docs/WS_PRIME_V0_4_ENGINEERING_CLOSURE_2026-09-10.md
@@ -1,0 +1,118 @@
+# Worldshepherd PRIME v0.4 Engineering Closure
+
+Status: architecture-defined / engineering targets / claims-controlled.
+
+This closure advances the PRIME all-domain architecture from PUMI/PSDM v0.3.1 into a reference geometry and mass-property screen. It does not claim validated humanoid, flight, deep-sea, launch, or space hardware performance.
+
+## PRIME body reference frame
+
+Coordinate origin is the pelvic structural center. +X is forward, +Y is left, +Z is up.
+
+Preliminary PUMI aft hardpoints:
+
+- upper left/right: (-0.10 m, +/-0.23 m, +0.32 m)
+- lower left/right: (-0.08 m, +/-0.20 m, -0.23 m)
+
+This preserves approximately 0.55 m vertical and 0.40-0.46 m lateral separation. Pack loads must enter the torso/pelvic primary structure, not cosmetic shells.
+
+## PUMI-X proof-load screen
+
+- working load target: 15 kN
+- development proof target: 22.5 kN
+- working moment target: 2.5 kN-m
+- development proof moment: 3.75 kN-m
+- proof-moment row couple across 0.55 m: about 6.82 kN
+- symmetric per-node moment share: about 3.41 kN
+- nominal per-node proof-force share: 5.625 kN
+- simple worst-direction additive node screen: about 9.03 kN
+- retained initial hardpoint article screen: approximately 10 kN combined-equivalent per node
+
+Detailed multiaxial FEA and physical testing must still cover torsion, asymmetric loads, insert/bearing failure, peel, fatigue, impact, and damaged-state operation.
+
+## WHX-PRIME packaging reference
+
+Current design targets for packaging studies:
+
+- standing height: 1.86 m
+- shoulder width: 0.52 m
+- pelvic width: 0.38 m
+- torso depth: approximately 0.30 m
+- bare-core folded envelope: 1.45 m x 0.74 m x 0.64 m
+- SPACE-configured folded envelope: 1.60 m x 0.82 m x 0.75 m
+- PSDM cassette clear envelope: approximately 1.70 m x 0.90 m x 0.82 m
+
+These values remain CAD targets until full joint-range/clearance verification proves the folded pose.
+
+## PSDM-4 v0.4 packaging
+
+A two-across/two-level arrangement of four 1.70 m x 0.90 m x 0.82 m cassettes yields an initial external module target of approximately 1.95 m x 2.00 m x 1.90 m including preliminary structural/service allowances.
+
+The prior nominal 2.4 m x 2.1 m x 1.8 m screen is about 9.07 m3. The v0.4 notional envelope is about 7.41 m3, roughly 18% lower volume. No structural mass reduction is credited from this geometric reduction until FEA closes; the loaded PSDM-4 target remains approximately 1.0-1.3 tonnes.
+
+## Pack mass-property screens
+
+Early rectangular-prism inertia screens use X as depth, Y as width, and Z as height.
+
+| Class | Mass | Screen envelope X x Y x Z | Ixx | Iyy | Izz |
+|---|---:|---:|---:|---:|---:|
+| PUMI-S | 50 kg | 0.25 x 0.60 x 0.45 m | 2.34 | 1.10 | 1.76 kg-m2 |
+| PUMI-H | 100 kg | 0.35 x 0.75 x 0.80 m | 10.02 | 6.35 | 5.71 kg-m2 |
+| PUMI-X | 150 kg | 0.45 x 0.85 x 1.05 m | 22.81 | 16.31 | 11.56 kg-m2 |
+
+These are conservative geometric screening values, not measured pack inertias. A pack that meets mass and CG limits but exceeds dynamic-inertia limits must be redesigned or reclassified.
+
+Normal aft-mounted packs target lateral CG offset |Y| <= 0.03 m. Offsets beyond 0.05 m require explicit control/structural/fatigue analysis.
+
+## Domain mass-budget screens
+
+### SUBTERRA / SUBSPACE
+
+External pack target remains <=35 kg. Mass is allocated across environmental protection, gas/environment sensing, climbing/resource tools, communications, pack energy, thermal control, and emergency support. PUMI-S remains the preferred class.
+
+### SPACE
+
+Local-mobility pack target remains <=50 kg for PUMI-S. First allocation screen:
+
+- structure/interface: 6 kg
+- mission energy: 12 kg
+- maneuvering propulsion/propellant: 10 kg
+- thermal hardware: 8 kg
+- avionics/comms: 4 kg
+- dust/radiation/environment protection: 4 kg
+- protected survival/return reserve: 6 kg
+
+Heavier SPACE configurations move to PUMI-H rather than expanding PUMI-S.
+
+### AERO
+
+PUMI-H target remains <=90 kg. First allocation screen:
+
+- installed energy including protected reserve allocation: 45 kg
+- wing/load structure: approximately 18 kg
+- propulsion/inverters: approximately 15 kg
+- thermal, avionics, landing/docking, wiring, growth: approximately 12 kg
+
+The earlier eight-by-one-meter rotor calculation remains equivalent disk-area bookkeeping only; it is not a frozen exposed-rotor architecture. Enclosed, ducted, embedded, tilt, and other efficient VTOL candidates remain active trades. Short VTOL plus wing-borne cruise remains the baseline architectural preference.
+
+### HADAL
+
+PUMI-X dry-handling target remains <=150 kg. First allocation screen:
+
+- pressure/buoyancy architecture: approximately 55 kg
+- energy: 25 kg
+- thrusters/drives: 20 kg
+- structure/interface: 15 kg
+- sonar/environment sensing: 10 kg
+- ballast/release: 10 kg
+- controls/comms/thermal interfaces: 5 kg
+- growth: 10 kg
+
+Full-ocean-depth capability remains BLOCKED pending pressure-vessel, buoyancy-material, sealing, connector, thruster, hydrostatic, stability, and representative-depth validation.
+
+## Claims-control result
+
+Architecture-defined in this pass: PRIME body reference frame, preliminary PUMI node coordinates, hardpoint article screen, reduced folded/cassette packaging targets, pack inertia screens, and first domain mass allocations.
+
+Still BLOCKED: laminate/insert FEA, physical folded-pose verification, complete multiaxial PUMI tests, HADAL pressure/hydrostatic closure, AERO propulsion/aerodynamic closure, SPACE vacuum/thermal/radiation closure, and PSDM launch-vibration/shock qualification.
+
+No experimental technology or unconventional propulsion receives new performance credit from this closure.

--- a/docs/WS_PRIME_V0_5_CROSS_DOMAIN_PHYSICS_CLOSURE_2026-09-10.md
+++ b/docs/WS_PRIME_V0_5_CROSS_DOMAIN_PHYSICS_CLOSURE_2026-09-10.md
@@ -1,0 +1,74 @@
+# Worldshepherd PRIME v0.5 Cross-Domain Physics Closure
+
+Status: engineering screen / claims-controlled / not validated hardware performance.
+
+## AERO wing-borne cruise screen
+
+Assumptions: 182 kg gross PRIME+AERO mass, 4.8 m2 wing, rho=1.225 kg/m3, provisional CLmax=1.6, 35 m/s cruise, L/D=12, propulsive efficiency=0.80.
+
+Results:
+
+- first-order stall-speed screen: ~19.5 m/s
+- cruise propulsion-input screen: ~6.5 kW
+- baseline pack screen: 10.8 kWh
+- four total VTOL minutes at 36 kW: ~2.4 kWh
+- 20% pack reserve: 2.16 kWh
+- remaining idealized cruise energy: ~6.24 kWh
+- idealized cruise duration: ~0.96 h
+- idealized range screen: ~121 km / 65 nmi
+
+Climb, transition, wind, avionics, thermal loads, reserve policy, and drag growth will reduce actual range. This is not a promised range.
+
+E-X shadow energy at 14.4 kWh screens near 95 nmi under the same assumptions, but receives zero baseline credit until installed-pack and integrated-flight evidence exists.
+
+The prior eight-by-one-meter rotor arithmetic remains equivalent disk-area bookkeeping only. It does not freeze an exposed-rotor architecture. Enclosed, ducted, embedded, tilt, and other efficient VTOL concepts remain active trades, with short VTOL plus wing-borne cruise preferred.
+
+## SPACE radiator closure
+
+At emissivity 0.9 and 300 K, simple blackbody radiative flux is ~413 W/m2 before solar/albedo, view-factor, degradation, conduction, and packaging penalties.
+
+Ideal radiator-area screens:
+
+- 700 W: ~1.69 m2
+- 1.2 kW: ~2.90 m2
+- 2.0 kW: ~4.84 m2
+
+Therefore the 2 kW PUMI thermal-transfer target does not imply that a SPACE pack can reject 2 kW continuously. SPACE requires deployable/distributed radiator area, acceptable higher radiator temperature, thermal storage/derating, or a combination. Exact orbital/surface thermal balance remains BLOCKED.
+
+## HADAL buoyancy sensitivity
+
+Generic density-only screens in 1025 kg/m3 seawater:
+
+- 500 kg/m3 buoyancy material -> ~0.525 kg net buoyancy per liter
+- 600 kg/m3 -> ~0.425 kg/L
+- 700 kg/m3 -> ~0.325 kg/L
+
+Offsetting 100 kg of negative mass would require roughly 190, 235, or 308 L respectively before pressure compression and packaging. These are not candidate-material specifications. The result reinforces distributed pressure-housing displacement, distributed buoyancy, flooded structures, controlled slightly-negative seabed buoyancy, releasable ballast, and protected emergency ascent rather than a single giant buoyancy backpack.
+
+## SUBSPACE dual qualification
+
+The common mining/space PRIME core must keep mine hazardous-location qualification and space vacuum/outgassing/radiation qualification as separate gates. The architecture therefore places vacuum-compatible tribology and critical sensing inside controlled/sealed joint modules while keeping mine-specific outer boots, contamination barriers, gas sensing, and hazardous-environment electrical provisions replaceable at the mission layer.
+
+A mine-sealed joint is not automatically space-qualified; a space-qualified joint is not automatically safe in a hazardous mine atmosphere.
+
+## OLV-4 fairing blocker
+
+The v0.4 PSDM external screen is ~1.95 x 2.00 x 1.90 m. Carrying a 2.00 x 1.90 m face inside a circular fairing requires a circumscribed diameter of:
+
+sqrt(2.00^2 + 1.90^2) ~= 2.76 m
+
+before clearance, insulation, separation hardware, or fairing structure.
+
+Therefore the current rectangular PSDM requires roughly a 2.8 m-or-larger internal circular envelope or a cross-section redesign. This is a formal compact-air-launch packaging BLOCKER.
+
+Next branch: compare corner-nested, canted, and circularized four-cassette arrangements. The fairing requirement will not simply be enlarged until the redesign options are compared for mass, structure, access, thermal management, and deployment reliability.
+
+## Promotion state
+
+- AERO: first-order range/endurance screen complete; BLOCKED on CFD, propulsion, transition, acoustics, thermal, flight-control, and reserve validation.
+- SPACE: first-order radiator-area screen complete; BLOCKED on full environment-specific thermal closure.
+- HADAL: buoyancy sensitivity screen complete; BLOCKED on pressure/hydrostatic/material qualification.
+- SUBSPACE: dual-qualification architecture defined; both mine and space certifications remain separate gates.
+- PSDM/OLV: volume reduction achieved as a design screen, but circular-fairing compatibility is now a formal blocker requiring redesign.
+
+No experimental or unconventional technology receives additional performance credit from this closure.

--- a/docs/WS_PRIME_V0_6_PSDM_CIRCULARIZATION_2026-09-10.md
+++ b/docs/WS_PRIME_V0_6_PSDM_CIRCULARIZATION_2026-09-10.md
@@ -1,0 +1,72 @@
+# Worldshepherd PRIME v0.6 — PSDM-4 Circularization and PUMI Hardpoint Closure
+
+Status: engineering screen / architecture target / claims-controlled.
+
+This closure attacks the v0.5 OLV-4 circular-fairing packaging blocker without enlarging the PRIME body or silently relaxing PUMI/PSDM constraints.
+
+## 1. PSDM-4 circularization trade
+
+Current SPACE-equipped PRIME launch-fold envelope target: 1.60 m axial x 0.82 m x 0.75 m cross-section. Four raw folded-body cross-sections therefore occupy approximately 2.46 m^2 before cassette walls, service gaps, primary structure, thermal routing, deployment mechanisms, and clearance.
+
+A circular section provides the following first-order area screen:
+
+- 2.45 m clear internal diameter: about 4.71 m^2; folded-body occupancy about 52.2%.
+- 2.55 m clear internal diameter: about 5.11 m^2; folded-body occupancy about 48.2%.
+- 2.65 m clear internal diameter: about 5.52 m^2; folded-body occupancy about 44.6%.
+
+Area alone does not prove geometric fit. It shows that the v0.5 problem is primarily rectangular-cassette inefficiency rather than raw PRIME cross-sectional area.
+
+The v0.6 geometry branch therefore uses three gates:
+
+1. PSDM-4C-FALLBACK: <= 2.65 m clear internal diameter using conservative cassette packaging.
+2. PSDM-4C-OBJECTIVE: <= 2.55 m clear internal diameter using conformal/canted four-petal cassettes and a central service spine.
+3. PSDM-4C-STRETCH: <= 2.45 m clear internal diameter if full CAD, deployment clearances, structural paths, and service routing close.
+
+No cassette or PSDM mass reduction is credited from circularization until CAD and FEA demonstrate it.
+
+## 2. Four-petal architecture
+
+The preferred v0.6 topology places four independent conformal cassettes around a central service/structure spine. Each cassette remains independently restrained, powered, monitored, conditioned, and deployable. The shape may taper or clip unused corner volume around the folded robot rather than preserving the old full rectangular cassette section.
+
+The central spine carries common PSDM structure, service power distribution, thermal manifolds where used, timing/data backbone, and launch-vehicle interface loads. It must not create a common release single point of failure: each bay retains an independent final deployment release path.
+
+## 3. PUMI-X hardpoint screen
+
+Existing PUMI-X development proof targets remain 22.5 kN resultant working-direction proof load and 3.75 kN-m proof moment based on the 1.5x development screen.
+
+At the current 0.55 m upper-to-pelvic hardpoint separation, the 3.75 kN-m proof moment produces an approximately 6.82 kN upper/lower force couple. A simple worst-direction distribution with 22.5 kN axial proof load shared across four nodes gives approximately 5.63 kN/node axial contribution. If moment-couple load is shared by the two nodes in the loaded upper or lower pair, it adds approximately 3.41 kN/node, producing about 9.03 kN at the most highly loaded node before local secondary effects.
+
+The existing 10 kN/node initial article proof target therefore remains a useful first screen, but it is not yet a final requirement. Detailed FEA must add local eccentricity, latch preload, bearing, peel, torsion, impact, manufacturing tolerance, thermal strain, and fatigue.
+
+A candidate mechanical article may use a replaceable metallic bearing/pin cartridge isolated from the composite primary structure through a CF-PAEK or equivalent transition collar. A 14 mm pin carrying 10 kN in ideal double shear would see only about 32.5 MPa nominal shear; a 10 mm-thick local bearing stack at the same load would screen at about 71 MPa nominal bearing stress. These calculations show that local composite transfer, insert pullout, peel, fatigue, and damage tolerance are more likely to govern than ideal pin shear. Material allowables are not assigned until coupon/subcomponent evidence exists.
+
+Baseline hardpoint cartridge: qualified aerospace titanium candidate.
+Experimental challengers: lighter hybrid composite/metal cartridge and WS-AlTi graded-node article only after its own coupon/joint gates pass.
+
+## 4. Required v0.6 structural load cases
+
+PUMI/PSDM FEA and subsequent test articles must include, at minimum: +X/-X, +Y/-Y, +Z/-Z; roll/pitch/yaw moments; combined load+moment; latch preload; pack CG tolerance; dynamic step/stumble loading; AERO thrust/reaction loads; HADAL drag/buoyancy loads; launch restraint interaction; wet/salt exposure; vacuum/thermal-cycle exposure for SPACE; damaged-laminate and one-latch-degraded cases.
+
+Launch restraint remains separate from PUMI. PSDM cassettes carry launch acceleration/vibration into dedicated PRIME restraint nodes rather than forcing PUMI alone to be a rocket restraint.
+
+## 5. OLV-4 packaging decision
+
+The v0.5 rectangular PSDM cross-section requiring roughly 2.76 m circular diameter remains a failed layout, not a passed requirement. OLV-4 integration is now gated on PSDM-4C CAD proving one of the <=2.65/2.55/2.45 m internal-diameter configurations with all four occupied bays, service routing, thermal hardware, deployment clearance, tolerances, and launch restraint structure represented.
+
+OLV-4 propulsion/staging design is outside this architecture record. OLV-4 remains a partner/launch-vehicle development program carrying one PSDM-4 with four PRIME units.
+
+## 6. Status after v0.6
+
+- PRIME-4 grouping: ARCHITECTURE LOCKED.
+- Four PRIME per PSDM-4 / OLV-4: ARCHITECTURE LOCKED.
+- PSDM-4C four-petal circularization: ENGINEERING TARGET.
+- 2.65 m clear-ID fallback: TARGET — requires CAD.
+- 2.55 m clear-ID objective: TARGET — requires CAD.
+- 2.45 m clear-ID stretch: TARGET — requires CAD.
+- 10 kN/node PUMI article proof screen: RETAINED DEVELOPMENT SCREEN.
+- titanium/CF-PAEK hardpoint cartridge: BASELINE DESIGN CANDIDATE.
+- WS-AlTi hardpoint credit: BLOCKED pending material/joint evidence.
+- OLV-4 packaging: BLOCKED until circularized CAD closes.
+- PSDM mass savings from circularization: NOT CURRENTLY CLAIMED.
+
+Next closure: parameterized CAD of the four-petal section, node-level laminate/insert FEA, and a PSDM mass/inertia update using actual geometry rather than bounding boxes.

--- a/docs/WS_PRIME_V0_7_DOMAIN_AND_AIRLAUNCH_CLOSURE_2026-09-10.md
+++ b/docs/WS_PRIME_V0_7_DOMAIN_AND_AIRLAUNCH_CLOSURE_2026-09-10.md
@@ -1,0 +1,114 @@
+# Worldshepherd PRIME v0.7 — Domain-Pack and Air-Launch Closure
+
+Status: engineering screen / architecture target / claims-controlled.
+
+This pass continues the v0.6 packaging branch and advances AERO, SPACE, HADAL, SUBSPACE, PSDM-4, and OLV-4 together. No physical capability is promoted by calculation alone.
+
+## 1. PSDM-4 geometry: compact versus slender
+
+The current SPACE-configured folded PRIME cross-section target is 0.82 m x 0.75 m. If four such envelopes are arranged as a 2x2 body grid around a 0.10 m central utility/service cross, the raw grid is approximately 1.74 m x 1.60 m and its circumscribed diagonal is approximately 2.364 m.
+
+That produces a useful radial-corner-clearance screen:
+
+- 2.45 m clear circular diameter: about 43 mm radial margin beyond the raw grid corner.
+- 2.55 m: about 93 mm.
+- 2.65 m: about 143 mm.
+
+Therefore the 2.45 m PSDM-4C stretch objective is now considered a low-margin geometry that likely requires conformal/canted cassettes and highly efficient structural/service routing. The 2.55 m objective remains the preferred compact target. The 2.65 m fallback remains the lower-risk compact envelope. Actual fit remains BLOCKED until CAD represents cassette walls, shock isolation, wiring/fluid routing, deployment motion, tolerances, thermal hardware, and launch restraints.
+
+### PSDM-4L slender air-launch branch
+
+A new air-launch-optimized arrangement uses two PRIME units side-by-side per longitudinal station and two stations in tandem. With a 0.10 m center gap, one two-PRIME station has a 1.74 m x 0.75 m raw cross-section and a 1.895 m circumscribed diagonal. Allowing approximately 0.10 m radial packaging margin screens at about 2.10 m clear diameter. Two 1.60 m folded PRIME lengths plus inter-station and end structure screen at about 3.6-3.7 m axial length.
+
+This does not prove a launch vehicle. It establishes a better geometry trade:
+
+- PSDM-4C: compact/fat, target about 2.55 m clear diameter, short axial package; preferred for vertical launch or larger cargo spacecraft when diameter is available.
+- PSDM-4L: slender, target about 2.10 m clear diameter and 3.6-3.7 m axial length; preferred early air-launch trade because it reduces frontal diameter at the cost of bending, structural length, fore/aft CG migration, and deployment sequencing complexity.
+- PSDM-4S: single-file four-PRIME concept can screen near 1.3-1.4 m diameter but roughly 7 m length; retained as a remote trade only because length/bending penalties are severe.
+
+The air-launch branch now treats PSDM-4L as the leading packaging candidate while preserving PSDM-4C as the common compact module architecture.
+
+## 2. AERO power-area trade
+
+At the current 182 kg PRIME-plus-AERO gross screen, sea-level momentum-theory bookkeeping with figure of merit 0.70, drivetrain efficiency 0.88, and 20% peak reserve produces approximately:
+
+- 6.28 m2 effective disk area: 37.5 kW design-power screen.
+- 8.0 m2: 33.2 kW.
+- 10.0 m2: 29.7 kW.
+
+Four total VTOL minutes at those power levels consume approximately 2.50, 2.21, and 1.98 kWh respectively before other loads.
+
+The baseline AERO trade objective is therefore moved toward >=8 m2 effective deployed lift area if it can close inside the <=90 kg PUMI-H pack mass. This is not a frozen eight-open-rotor layout. Worldshepherd continues to prioritize enclosed, ducted, partially shrouded, embedded, folding, or otherwise protected propulsion where mass and efficiency close. Exposed/open rotors remain a fallback trade rather than the default.
+
+The current AERO mass allocation gives approximately 15 kg to propulsion/inverter hardware. A 33.2 kW peak screen across 15 kg corresponds to about 2.2 kW/kg at that subsystem allocation. This is a design requirement, not a claim. NASA's 2026 TechPort record for the HPDM-30 targets 10 kW/kg continuous for a 30 kW integrated motor drive; NASA also reports a 250 kW converter at 10.6 kW/kg. These external benchmarks indicate that the electric machine/inverter alone need not dominate AERO mass, but fans/rotors, ducts, tilt mechanisms, bearings, cooling, structure, acoustic treatment, and fault containment still must close inside the remaining mass.
+
+The non-energy AERO hardware remains capped at approximately 45 kg unless the mission-energy requirement is independently reclosed. The battery cannot be silently reduced merely to rescue an overweight propulsion structure.
+
+## 3. SPACE thermal architecture
+
+NASA's 2026 small-spacecraft thermal state-of-the-art explicitly treats deployable radiators as a means of increasing radiating area when body area is insufficient, and NASA TechPort includes deployable/freeze-tolerant radiator development. Worldshepherd therefore promotes a deployable radiator from optional trade to baseline SPACE architecture requirement for sustained higher-power operation.
+
+A first v0.7 target is approximately 2.4 m2 total deployable radiator area, implemented as two or more independently survivable panels or equivalent distributed surfaces. Using emissivity 0.9 and an intentionally conservative 70% effective-rejection screen:
+
+- at 330 K, 2.4 m2 screens near 1.02 kW heat rejection;
+- at 350 K, 2.4 m2 screens near 1.29 kW.
+
+This supports the existing 700 W nominal local SPACE thermal target with mathematical margin, but does not make the 2 kW PUMI thermal-transfer capability a continuous SPACE heat-rejection rating.
+
+If a 2 kW transient persists for 15 minutes while the radiator rejects only about 1.29 kW, the thermal buffer must absorb roughly 642 kJ (0.178 kWh) before other losses. SPACE therefore requires a combination of deployable radiator area, thermal storage, load scheduling, power derating, and/or higher-temperature heat rejection. Exact orbital view factors, solar/albedo inputs, surface environment, coatings, coolant temperatures, and radiator deployment reliability remain BLOCKED pending mission-specific thermal analysis.
+
+## 4. HADAL pressure architecture
+
+WHOI deep-ocean practice supports the hybrid architecture already selected by Worldshepherd: spherical/cylindrical pressure housings for sensitive dry equipment, syntactic foam or pressure-tolerant flotation for buoyancy, and oil-filled/pressure-balanced components where enclosed gas volume can be eliminated. WHOI's DEEPSEA CHALLENGER description also documents multiple battery buses and oil-equalized battery packaging; WHOI's Nereus work used hollow ceramic flotation spheres and ceramic pressure-resistant housings to reduce dependence on heavier titanium systems.
+
+Worldshepherd therefore freezes three HADAL physical strategies for baseline trade studies:
+
+1. pressure-balanced/flooded or oil-filled subsystems wherever the component can tolerate ambient pressure;
+2. minimized pressure vessels for components that truly require a dry controlled enclosure;
+3. distributed buoyancy using qualified syntactic and/or ceramic flotation architecture rather than one giant backpack.
+
+HADAL-BUOY-E1 becomes a one-variable experimental article comparing ceramic-sphere distributed flotation against the baseline qualified syntactic-flotation solution for mass, volume, impact tolerance, inspectability, repairability, and repeated pressure-cycle behavior. No material receives full-ocean-depth credit until representative pressure testing closes.
+
+Emergency positive buoyancy remains mechanically available through independently releasable ballast and protected reserve control rather than requiring sustained thruster power for ascent.
+
+## 5. SUBSPACE transition gate
+
+The same serialized PRIME core may transition between mining and SPACE configurations only through a controlled requalification state. The transition record must include decontamination/cleaning, mechanical and NDT inspection where required, connector/insulation checks, seal and lubricant condition, battery health, structural-health review, mission-pack removal/install provenance, and the applicable vacuum/outgassing/environment acceptance tests. Mine hazardous-location qualification and SPACE qualification remain independent evidence states.
+
+## 6. Experimental distribution
+
+The v0.7 experimental matrix adds:
+
+- AERO-E-SINGLE-PWR: high-specific-power integrated electric drive challenger.
+- AERO-E-SINGLE-LIFT: protected/ducted/folding high-disk-area propulsion challenger.
+- SPACE-E-SINGLE-THERM: deployable composite/advanced radiator challenger.
+- HADAL-E-SINGLE-BUOY: ceramic distributed flotation challenger.
+- PSDM-E-SINGLE-MAT: lightweight multifunctional central-spine challenger.
+- PUMI-E-SINGLE-NODE: WS-AlTi graded-node challenger only after material/joint gates.
+
+E-Mix and E-X may combine these only while preserving separate evidence accounting; experimental success does not automatically promote baseline capability.
+
+## 7. External evidence intake and operational use
+
+Evidence class: SUPPORTED BY EXTERNAL GOVERNMENT/LAB OR OCEANOGRAPHIC SOURCE, not Worldshepherd hardware evidence.
+
+- NASA TechPort, HPDM-30, updated 2026-08-20: 30 kW integrated motor-drive project targeting 10 kW/kg continuous. Operational use: AERO experimental motor/inverter benchmark and validation target.
+- NASA Electric Aircraft Propulsion Power Converters, current 2026 page: 250 kW converter reported at 10.6 kW/kg and 99.3% efficiency. Operational use: inverter benchmark; no direct PRIME credit.
+- NASA 2026 Small Spacecraft Thermal Systems state of the art: deployable radiators increase available heat-rejection surface. Operational use: SPACE baseline deployable-radiator requirement.
+- NASA TechPort deployable/freeze-tolerant radiator projects, updated 2026: operational use as SPACE thermal technology benchmark and freeze/deployment failure-mode input.
+- WHOI, How do ocean robots take the pressure?: spherical/cylindrical housings and syntactic foam. Operational use: HADAL baseline architecture.
+- WHOI DEEPSEA CHALLENGER: structural syntactic foam plus pressure-equalized/oil-immersed batteries and redundant battery buses. Operational use: HADAL power/pressure architecture benchmark.
+- WHOI Nereus: hollow ceramic flotation spheres and ceramic pressure-resistant housings. Operational use: HADAL-BUOY-E1 challenger definition.
+
+## 8. Promotion state after v0.7
+
+- PSDM-4C 2.55 m compact objective: PLAUSIBLE BY AREA/MARGIN SCREEN, still BLOCKED pending CAD.
+- PSDM-4L ~2.10 m slender air-launch objective: NEW LEADING AIR-LAUNCH PACKAGING TRADE, still BLOCKED pending CAD/loads.
+- AERO >=8 m2 effective lift-area objective: ENGINEERING TARGET.
+- AERO non-energy hardware <=45 kg: HARD MASS GATE pending detailed BOM.
+- SPACE deployable radiator ~2.4 m2: BASELINE ENGINEERING TARGET.
+- SPACE continuous 2 kW rejection: NOT CLAIMED.
+- HADAL hybrid pressure/buoyancy architecture: SUPPORTED BY EXTERNAL PRACTICE, Worldshepherd hardware still BLOCKED.
+- SUBSPACE dual-environment transition/requalification: ARCHITECTURE DEFINED.
+
+Next closure: parameterized CAD for PSDM-4C versus PSDM-4L, detailed AERO non-energy BOM, SPACE radiator stow/deploy mass and thermal loop, and HADAL dry-volume/pressure/buoyancy accounting.

--- a/docs/WS_PRIME_V0_8_MASS_THERMAL_AND_DEPLOYMENT_CLOSURE_2026-09-10.md
+++ b/docs/WS_PRIME_V0_8_MASS_THERMAL_AND_DEPLOYMENT_CLOSURE_2026-09-10.md
@@ -1,0 +1,120 @@
+# Worldshepherd PRIME v0.8 — Mass, Thermal, and Deployment Closure
+
+Status: engineering screen / architecture target / claims-controlled.
+
+This pass advances the v0.7 PSDM-4L, AERO, SPACE, HADAL, and SUBSPACE branches while preserving the four-PRIME module, PUMI classes, independent reserves, and evidence boundaries. No physical capability is promoted by calculation alone.
+
+## 1. PSDM-4L first mass and CG closure
+
+The air-launch-optimized PSDM-4L remains a two-station module, with two folded PRIME units per longitudinal station. The v0.8 nominal loaded mass screen is 1,100 kg, bounded by the existing 1.0–1.3 tonne program envelope.
+
+Nominal planning breakdown:
+
+- four SPACE-configured PRIME units: 520 kg total, using 130 kg/unit as the midpoint of the existing 120–140 kg launch-planning band;
+- four conformal cassettes and local launch restraints: 100 kg;
+- longitudinal/central primary structure and outer module structure: 150 kg;
+- power and thermal service hardware: 70 kg;
+- four independent deployment/release systems: 60 kg;
+- avionics, timing, communications, and bay health electronics: 25 kg;
+- PSDM protected contingency energy: 25 kg;
+- common wiring/fluid/connectors: 30 kg;
+- structural/integration growth reserve: 120 kg.
+
+Total: 1,100 kg planning mass. This is a target allocation, not achieved mass. Hard loaded-mass ceiling remains 1,300 kg pending structural and launch-environment analysis. No circularization or slender-packaging mass savings are credited yet.
+
+For first CG bookkeeping, place the two occupied longitudinal stations symmetrically about the module center. If the four-PRIME payload is 520 kg, each station carries approximately 260 kg. If the non-PRIME module mass is approximately 580 kg and remains near the module center, releasing one complete two-PRIME station while the opposite station remains roughly 0.85 m from center would shift the remaining module CG by approximately 0.26 m. Therefore PSDM-4L strongly favors paired 2+2 deployment sequencing or active attitude/trim compensation. Individual 1+1+1+1 deployment remains permitted only after the actual mass-property model demonstrates bounded CG and inertia migration.
+
+PSDM-4L v0.8 goals:
+- clear circular diameter target: <=2.10 m;
+- axial length target: 3.6–3.7 m;
+- nominal loaded mass target: <=1.10 tonnes;
+- hard planning ceiling: 1.30 tonnes;
+- post-paired-release axial CG shift target: <=0.30 m before active compensation.
+
+PSDM-4C remains the lower-CG-migration compact alternative where launch diameter is available.
+
+## 2. AERO non-energy BOM gate
+
+AERO retains the <=90 kg PUMI-H pack target with 45 kg reserved for installed energy and protected reserves. The remaining 45 kg becomes a hard, line-item non-energy mass gate rather than a broad allowance.
+
+v0.8 non-energy target allocation:
+
+- lift/cruise effectors, fan/rotor structures, and local ducts/shrouds: 12.0 kg;
+- electric motors and inverters: 6.0 kg;
+- wing and primary load structure: 10.0 kg;
+- fold/tilt/deployment mechanisms: 5.0 kg;
+- thermal hardware: 3.0 kg;
+- avionics, flight control, and sensors: 2.0 kg;
+- power distribution/harness/contactors: 2.0 kg;
+- landing/docking interfaces: 2.0 kg;
+- acoustic/fault-containment shells and local protection: 1.5 kg;
+- growth reserve: 1.5 kg.
+
+Total: 45.0 kg target.
+
+At the current 8 m2 effective-lift-area / 33.2 kW peak design-power screen, a 6 kg motor/inverter allocation corresponds to approximately 5.53 kW/kg at that combined allocation. NASA's HPDM-30 2026 project target of 10 kW/kg continuous for the integrated motor drive shows this is not obviously outside advanced electric-machine research targets, but it does not validate the complete AERO propulsion system. The 12 kg lift-effector/duct allocation is now the highest-risk mass line because large protected/ducted lift area can rapidly consume structural mass.
+
+The next AERO article must therefore close the physical lift-area geometry and mass simultaneously. Candidate layouts include larger folding/partially shrouded effectors and distributed protected fans. The equivalent disk-area calculation does not dictate a rotor count or diameter. Open unprotected rotors remain fallback only where other architectures fail the mass/efficiency gate and operational safety can be controlled.
+
+AERO remains BLOCKED until every non-energy BOM line has a candidate part/geometry, mass estimate with source or CAD basis, thermal path, failure mode, and growth allowance.
+
+## 3. SPACE-S50 thermal mass failure and redesign
+
+The existing SPACE-S50 PUMI-S branch reserves only 8 kg for thermal hardware. The v0.7 2.4 m2 deployable-radiator concept does not close that allocation using a current NASA low-temperature deployable-radiator benchmark: NASA TechPort project 113167 reports an integrated deployable radiator design meeting a solicitation mass requirement below 8 kg/m2. At 2.4 m2, that benchmark permits as much as 19.2 kg of radiator before pumps, plumbing, structure, valves, or thermal interfaces. Therefore a fully deployable 2.4 m2 radiator is FAIL/BLOCKED for the present SPACE-S50 8 kg thermal budget.
+
+The redesign branches are:
+
+### SPACE-S50-TBI — body-integrated plus deployable radiator
+
+Target approximately 1.2 m2 of effective body/multifunctional radiating surface plus approximately 1.2 m2 deployable supplemental radiator. To retain the 8 kg total thermal allocation while reserving about 2 kg for loop/interface/valves/actuation, the deployable 1.2 m2 portion must target <=5 kg/m2, or equivalent mass must be eliminated through multifunctional structure. This is an engineering target, not a current qualified baseline.
+
+The full 2.4 m2 effective area remains subject to view factor and attitude. Body area cannot be credited unless mission thermal analysis shows that it actually views cold space sufficiently and is not defeated by solar/albedo/surface loading.
+
+### SPACE-H70-THERM — heavier thermal configuration
+
+A separate PUMI-H branch may increase thermal-system allocation rather than weakening SPACE-S50. This branch is for higher sustained heat loads and can use a larger/heavier deployable radiator architecture. It must carry its own revised pack mass, CG, inertia, energy, and mobility closure and does not promote the S50 branch.
+
+NASA also reports advanced high-temperature radiator research with lower areal-mass targets, including <3 kg/m2 concepts around 500–600 K. Those conditions are not directly transferable to a 330–350 K PRIME thermal loop; they are retained only as experimental-material/architecture evidence.
+
+## 4. HADAL trim and emergency-buoyancy accounting
+
+Use the current 92 kg PRIME core plus the 150 kg maximum dry-handling HADAL pack for a 242 kg first-order system mass. In 1025 kg/m3 seawater, a system intentionally trimmed to 10 kg apparent negative mass requires approximately 226.3 L total effective displacement. A 15 kg change in carried ballast changes apparent buoyancy by 15 kg-equivalent without requiring powered thrust.
+
+The v0.8 emergency trim rule is therefore:
+
+- nominal seabed operating target: approximately 10 kg apparent negative mass, subject to stability and traction needs;
+- independently releasable ballast allocation target: 15 kg including ballast/release system as a design branch;
+- after full ballast release, first-order target becomes approximately +5 kg apparent positive buoyancy, assuming no material compression/flooding/state change;
+- emergency ascent must not depend on continuous thruster operation.
+
+To keep the HADAL pack at <=150 kg, the prior mass allocation is rebalanced for this branch: 55 kg pressure/buoyancy architecture, 25 kg energy, 20 kg thrusters/drives, 15 kg structure/interface, 10 kg sonar/environment sensing, 15 kg ballast/release, 5 kg controls/comms/thermal interfaces, and 5 kg growth. Total remains 150 kg.
+
+These hydrostatic values are bookkeeping only. Exact displaced volume, compressibility, syntactic/ceramic flotation behavior, trapped/flooded volumes, center of buoyancy, center of gravity, metacentric stability, hydrodynamic drag, sediment interaction, and pressure cycling remain BLOCKED pending CAD and representative testing.
+
+## 5. SUBSPACE qualification custody
+
+The v0.7 mine-to-space transition gate is retained. v0.8 adds a configuration-custody rule: after any hazardous mine or deep-environment mission, the serialized PRIME core enters a QUARANTINED_FOR_REQUALIFICATION state in SARA until decontamination, inspection, electrical integrity, seals/tribology, battery health, structural health, and target-environment acceptance records are complete. A new SPACE pack alone cannot clear this state.
+
+ECHO SENTINEL LINK must preserve the before/after inspection evidence, and PRIME SENTINEL must reject mission-pack activation for a target environment whose independent qualification state is not valid.
+
+## 6. Experimental articles created by this failure-driven pass
+
+- SPACE-E-SINGLE-RAD: <=5 kg/m2 class low-temperature deployable radiator challenger for the S50 branch, without claiming achievement.
+- SPACE-E-SINGLE-MULTITHERM: multifunctional structural/radiating skin challenger intended to reduce dedicated radiator mass.
+- AERO-E-SINGLE-EFFECTOR: protected high-area lift effector evaluated against the 12 kg effector mass gate.
+- PSDM-E-SINGLE-SPINE: lightweight slender central-spine challenger against the baseline PSDM-4L structure.
+- HADAL-E-SINGLE-TRIM: pressure-cycle-qualified lightweight ballast/release architecture; emergency release remains mechanically independent and safety-gated.
+
+## 7. v0.8 promotion state
+
+- PSDM-4L <=2.10 m x 3.6–3.7 m: retained as leading air-launch packaging TARGET.
+- PSDM-4L nominal 1.10 t / hard 1.30 t loaded mass: TARGET, no mass savings claimed.
+- PSDM-4L paired-release CG migration: first-order ~0.26 m screen; actual inertia model required.
+- AERO 45 kg non-energy BOM: CLOSED ARITHMETICALLY, NOT ENGINEERING-CLOSED; lift-effector mass is highest-risk line.
+- SPACE-S50 all-deployable 2.4 m2 radiator: FAIL/BLOCKED against 8 kg thermal allocation using current external benchmark.
+- SPACE-S50-TBI integrated+deployable thermal branch: REDESIGN TARGET.
+- SPACE-H70-THERM: PARALLEL HEAVIER CONFIGURATION TARGET.
+- HADAL -10 kg operating / +5 kg post-ballast-release buoyancy branch: HYDROSTATIC TARGET, representative testing required.
+- SUBSPACE post-hazard QUARANTINED_FOR_REQUALIFICATION state: ARCHITECTURE DEFINED.
+
+Next closure: candidate geometry/part sourcing for the AERO non-energy BOM; SPACE-S50 body-radiator view-factor and radiator mass model; PSDM-4L actual inertia tensor and structural load-case schema; HADAL body/pack displaced-volume ledger; and integration of the new quarantine state into machine-readable SARA configuration custody.


### PR DESCRIPTION
Adds the implementation-facing Worldshepherd PRIME architecture record through v0.8. Scope covers PRIME-4 grouping; PUMI geometry/load/power/thermal/data and pack-inertia screens; PSDM-4C/4L packaging; SUBSPACE/HADAL/AERO/SPACE domain packs; autonomous carrier/orbital insertion structure; baseline/E-Single/E-Mix/E-MULTI/E-X experimental separation; and claims-control boundaries. v0.8 adds a 1.10 t nominal PSDM-4L mass/CG allocation, converts the 45 kg AERO non-energy allowance into a line-item hard BOM gate, records the SPACE-S50 fully deployable radiator as FAIL/BLOCKED against its 8 kg thermal allocation and opens body-integrated plus PUMI-H thermal redesign branches, adds HADAL -10 kg operating/+5 kg post-ballast-release hydrostatic targets, and formalizes SUBSPACE QUARANTINED_FOR_REQUALIFICATION configuration custody. The PR also contains a documented trigger under the existing verified deployment path so the protected `test-and-build` job executes rather than remaining permanently expected for docs/config-only changes. No physical capability is promoted beyond architecture/engineering-screen status; weapon employment and targeting remain outside scope.