### PR TITLE
Implement PRIME configuration custody and authorized requalification gate

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
@@ -7,8 +7,10 @@ from worldshepherd_sara.prime_configuration_custody import (
     PrimeEnvironment,
     PrimeMissionPackEvidence,
     REQUALIFICATION_CHECKS,
+    apply_post_mission_state,
     evaluate_pack_activation,
     post_mission_state,
+    release_from_quarantine,
 )
 
 
@@ -30,6 +32,19 @@ def test_subterra_and_hadal_missions_enter_requalification_quarantine():
     assert post_mission_state(PrimeEnvironment.GROUND) == PrimeCustodyState.READY
 
 
+def test_post_mission_transition_resets_old_requalification_evidence_and_authorization():
+    record = PrimeConfigurationCustodyRecord(
+        prime_id="PRIME-001",
+        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
+        requalification_release_authorization_id="AUTH-OLD",
+    )
+    transitioned = apply_post_mission_state(record, PrimeEnvironment.SUBTERRA)
+    assert transitioned.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    assert transitioned.last_environment == PrimeEnvironment.SUBTERRA
+    assert transitioned.completed_requalification_checks == []
+    assert transitioned.requalification_release_authorization_id is None
+
+
 def test_installing_a_valid_space_pack_does_not_clear_quarantine_by_itself():
     record = PrimeConfigurationCustodyRecord(
         prime_id="PRIME-001",
@@ -42,7 +57,7 @@ def test_installing_a_valid_space_pack_does_not_clear_quarantine_by_itself():
     assert any("TARGET_ENVIRONMENT_ACCEPTANCE" in reason for reason in reasons)
 
 
-def test_complete_checks_without_release_authorization_remain_quarantined():
+def test_complete_checks_without_authorization_record_remain_quarantined():
     record = PrimeConfigurationCustodyRecord(
         prime_id="PRIME-001",
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
@@ -51,19 +66,21 @@ def test_complete_checks_without_release_authorization_remain_quarantined():
     )
     disposition, reasons = evaluate_pack_activation(record, _space_pack())
     assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
-    assert any("not authorized" in reason for reason in reasons)
+    assert any("authorization record" in reason for reason in reasons)
 
 
-def test_complete_requalification_authorization_and_valid_pack_allow_activation():
+def test_complete_requalification_authorization_and_valid_pack_allow_release_to_ready():
     record = PrimeConfigurationCustodyRecord(
         prime_id="PRIME-001",
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
         last_environment=PrimeEnvironment.SUBTERRA,
         completed_requalification_checks=list(REQUALIFICATION_CHECKS),
-        requalification_release_authorized=True,
+        requalification_release_authorization_id="AUTH-2026-0001",
     )
-    disposition, reasons = evaluate_pack_activation(record, _space_pack())
+    released, disposition, reasons = release_from_quarantine(record, _space_pack())
     assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
+    assert released.state == PrimeCustodyState.READY
+    assert released.requalification_release_authorization_id == "AUTH-2026-0001"
     assert reasons
 
 
@@ -73,7 +90,7 @@ def test_invalid_target_environment_qualification_fails_closed_even_after_checks
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
         last_environment=PrimeEnvironment.HADAL,
         completed_requalification_checks=list(REQUALIFICATION_CHECKS),
-        requalification_release_authorized=True,
+        requalification_release_authorization_id="AUTH-2026-0002",
     )
     disposition, reasons = evaluate_pack_activation(
         record,

--- a/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from worldshepherd_sara.prime_configuration_custody import (
+    PrimeActivationDisposition,
+    PrimeConfigurationCustodyRecord,
+    PrimeCustodyState,
+    PrimeEnvironment,
+    PrimeMissionPackEvidence,
+    REQUALIFICATION_CHECKS,
+    evaluate_pack_activation,
+    post_mission_state,
+)
+
+
+def _space_pack(**overrides):
+    values = {
+        "pack_id": "SPACE-PACK-1",
+        "target_environment": PrimeEnvironment.SPACE,
+        "authenticated": True,
+        "compatible_with_prime": True,
+        "target_environment_qualification_valid": True,
+    }
+    values.update(overrides)
+    return PrimeMissionPackEvidence(**values)
+
+
+def test_subterra_and_hadal_missions_enter_requalification_quarantine():
+    assert post_mission_state(PrimeEnvironment.SUBTERRA) == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    assert post_mission_state(PrimeEnvironment.HADAL) == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    assert post_mission_state(PrimeEnvironment.GROUND) == PrimeCustodyState.READY
+
+
+def test_installing_a_valid_space_pack_does_not_clear_quarantine_by_itself():
+    record = PrimeConfigurationCustodyRecord(
+        prime_id="PRIME-001",
+        state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
+        last_environment=PrimeEnvironment.SUBTERRA,
+    )
+    disposition, reasons = evaluate_pack_activation(record, _space_pack())
+    assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
+    assert any("quarantined" in reason for reason in reasons)
+    assert any("TARGET_ENVIRONMENT_ACCEPTANCE" in reason for reason in reasons)
+
+
+def test_complete_requalification_and_valid_pack_allow_activation():
+    record = PrimeConfigurationCustodyRecord(
+        prime_id="PRIME-001",
+        state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
+        last_environment=PrimeEnvironment.SUBTERRA,
+        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
+    )
+    disposition, reasons = evaluate_pack_activation(record, _space_pack())
+    assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
+    assert reasons
+
+
+def test_invalid_target_environment_qualification_fails_closed_even_after_checks():
+    record = PrimeConfigurationCustodyRecord(
+        prime_id="PRIME-001",
+        state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
+        last_environment=PrimeEnvironment.HADAL,
+        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
+    )
+    disposition, reasons = evaluate_pack_activation(
+        record,
+        _space_pack(target_environment_qualification_valid=False),
+    )
+    assert disposition == PrimeActivationDisposition.DENIED
+    assert any("target-environment qualification" in reason for reason in reasons)
+
+
+def test_unauthenticated_or_incompatible_pack_fails_closed():
+    record = PrimeConfigurationCustodyRecord(prime_id="PRIME-001")
+    disposition, reasons = evaluate_pack_activation(
+        record,
+        _space_pack(authenticated=False, compatible_with_prime=False),
+    )
+    assert disposition == PrimeActivationDisposition.DENIED
+    assert any("not authenticated" in reason for reason in reasons)
+    assert any("not compatible" in reason for reason in reasons)

--- a/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
@@ -42,12 +42,25 @@ def test_installing_a_valid_space_pack_does_not_clear_quarantine_by_itself():
     assert any("TARGET_ENVIRONMENT_ACCEPTANCE" in reason for reason in reasons)
 
 
-def test_complete_requalification_and_valid_pack_allow_activation():
+def test_complete_checks_without_release_authorization_remain_quarantined():
     record = PrimeConfigurationCustodyRecord(
         prime_id="PRIME-001",
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
         last_environment=PrimeEnvironment.SUBTERRA,
         completed_requalification_checks=list(REQUALIFICATION_CHECKS),
+    )
+    disposition, reasons = evaluate_pack_activation(record, _space_pack())
+    assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
+    assert any("not authorized" in reason for reason in reasons)
+
+
+def test_complete_requalification_authorization_and_valid_pack_allow_activation():
+    record = PrimeConfigurationCustodyRecord(
+        prime_id="PRIME-001",
+        state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
+        last_environment=PrimeEnvironment.SUBTERRA,
+        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
+        requalification_release_authorized=True,
     )
     disposition, reasons = evaluate_pack_activation(record, _space_pack())
     assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
@@ -60,6 +73,7 @@ def test_invalid_target_environment_qualification_fails_closed_even_after_checks
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
         last_environment=PrimeEnvironment.HADAL,
         completed_requalification_checks=list(REQUALIFICATION_CHECKS),
+        requalification_release_authorized=True,
     )
     disposition, reasons = evaluate_pack_activation(
         record,

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
@@ -45,6 +45,7 @@ class PrimeConfigurationCustodyRecord(BaseModel):
     state: PrimeCustodyState = PrimeCustodyState.READY
     last_environment: PrimeEnvironment = PrimeEnvironment.GROUND
     completed_requalification_checks: list[str] = Field(default_factory=list)
+    requalification_release_authorized: bool = False
 
 
 class PrimeMissionPackEvidence(BaseModel):
@@ -89,7 +90,11 @@ def evaluate_pack_activation(
                 "PRIME remains quarantined after hazardous/deep-environment service",
                 *[f"missing requalification check: {check}" for check in missing],
             ]
+        if not record.requalification_release_authorized:
+            return PrimeActivationDisposition.REQUALIFICATION_REQUIRED, [
+                "requalification evidence is complete but release from quarantine is not authorized"
+            ]
 
     return PrimeActivationDisposition.ACTIVATION_ALLOWED, [
-        "pack authentication, compatibility, target qualification, and custody gates are satisfied"
+        "pack authentication, compatibility, target qualification, requalification evidence, and authorization gates are satisfied"
     ]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class PrimeEnvironment(str, Enum):
+    GROUND = "GROUND"
+    SUBTERRA = "SUBTERRA"
+    HADAL = "HADAL"
+    AERO = "AERO"
+    SPACE = "SPACE"
+
+
+class PrimeCustodyState(str, Enum):
+    READY = "READY"
+    QUARANTINED_FOR_REQUALIFICATION = "QUARANTINED_FOR_REQUALIFICATION"
+
+
+class PrimeActivationDisposition(str, Enum):
+    ACTIVATION_ALLOWED = "ACTIVATION_ALLOWED"
+    REQUALIFICATION_REQUIRED = "REQUALIFICATION_REQUIRED"
+    DENIED = "DENIED"
+
+
+REQUALIFICATION_CHECKS: tuple[str, ...] = (
+    "DECONTAMINATION_CLEANING",
+    "MECHANICAL_INSPECTION",
+    "CONNECTOR_INSULATION_CHECK",
+    "SEAL_TRIBOLOGY_CONDITION",
+    "BATTERY_HEALTH",
+    "STRUCTURAL_HEALTH_REVIEW",
+    "PACK_PROVENANCE",
+    "TARGET_ENVIRONMENT_ACCEPTANCE",
+)
+
+HAZARDOUS_POST_MISSION_ENVIRONMENTS: frozenset[PrimeEnvironment] = frozenset(
+    {PrimeEnvironment.SUBTERRA, PrimeEnvironment.HADAL}
+)
+
+
+class PrimeConfigurationCustodyRecord(BaseModel):
+    prime_id: str = Field(min_length=1)
+    state: PrimeCustodyState = PrimeCustodyState.READY
+    last_environment: PrimeEnvironment = PrimeEnvironment.GROUND
+    completed_requalification_checks: list[str] = Field(default_factory=list)
+
+
+class PrimeMissionPackEvidence(BaseModel):
+    pack_id: str = Field(min_length=1)
+    target_environment: PrimeEnvironment
+    authenticated: bool = False
+    compatible_with_prime: bool = False
+    target_environment_qualification_valid: bool = False
+
+
+def post_mission_state(environment: PrimeEnvironment) -> PrimeCustodyState:
+    if environment in HAZARDOUS_POST_MISSION_ENVIRONMENTS:
+        return PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    return PrimeCustodyState.READY
+
+
+def missing_requalification_checks(record: PrimeConfigurationCustodyRecord) -> list[str]:
+    completed = set(record.completed_requalification_checks)
+    return [check for check in REQUALIFICATION_CHECKS if check not in completed]
+
+
+def evaluate_pack_activation(
+    record: PrimeConfigurationCustodyRecord,
+    pack: PrimeMissionPackEvidence,
+) -> tuple[PrimeActivationDisposition, list[str]]:
+    reasons: list[str] = []
+
+    if not pack.authenticated:
+        reasons.append("mission pack identity is not authenticated")
+    if not pack.compatible_with_prime:
+        reasons.append("mission pack is not compatible with this PRIME")
+    if not pack.target_environment_qualification_valid:
+        reasons.append("target-environment qualification is not valid")
+
+    if reasons:
+        return PrimeActivationDisposition.DENIED, reasons
+
+    if record.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION:
+        missing = missing_requalification_checks(record)
+        if missing:
+            return PrimeActivationDisposition.REQUALIFICATION_REQUIRED, [
+                "PRIME remains quarantined after hazardous/deep-environment service",
+                *[f"missing requalification check: {check}" for check in missing],
+            ]
+
+    return PrimeActivationDisposition.ACTIVATION_ALLOWED, [
+        "pack authentication, compatibility, target qualification, and custody gates are satisfied"
+    ]

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
@@ -45,7 +45,7 @@ class PrimeConfigurationCustodyRecord(BaseModel):
     state: PrimeCustodyState = PrimeCustodyState.READY
     last_environment: PrimeEnvironment = PrimeEnvironment.GROUND
     completed_requalification_checks: list[str] = Field(default_factory=list)
-    requalification_release_authorized: bool = False
+    requalification_release_authorization_id: str | None = None
 
 
 class PrimeMissionPackEvidence(BaseModel):
@@ -60,6 +60,20 @@ def post_mission_state(environment: PrimeEnvironment) -> PrimeCustodyState:
     if environment in HAZARDOUS_POST_MISSION_ENVIRONMENTS:
         return PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
     return PrimeCustodyState.READY
+
+
+def apply_post_mission_state(
+    record: PrimeConfigurationCustodyRecord,
+    environment: PrimeEnvironment,
+) -> PrimeConfigurationCustodyRecord:
+    return record.model_copy(
+        update={
+            "last_environment": environment,
+            "state": post_mission_state(environment),
+            "completed_requalification_checks": [],
+            "requalification_release_authorization_id": None,
+        }
+    )
 
 
 def missing_requalification_checks(record: PrimeConfigurationCustodyRecord) -> list[str]:
@@ -90,11 +104,26 @@ def evaluate_pack_activation(
                 "PRIME remains quarantined after hazardous/deep-environment service",
                 *[f"missing requalification check: {check}" for check in missing],
             ]
-        if not record.requalification_release_authorized:
+        if not record.requalification_release_authorization_id:
             return PrimeActivationDisposition.REQUALIFICATION_REQUIRED, [
-                "requalification evidence is complete but release from quarantine is not authorized"
+                "requalification evidence is complete but no release authorization record is present"
             ]
 
     return PrimeActivationDisposition.ACTIVATION_ALLOWED, [
         "pack authentication, compatibility, target qualification, requalification evidence, and authorization gates are satisfied"
     ]
+
+
+def release_from_quarantine(
+    record: PrimeConfigurationCustodyRecord,
+    pack: PrimeMissionPackEvidence,
+) -> tuple[PrimeConfigurationCustodyRecord, PrimeActivationDisposition, list[str]]:
+    disposition, reasons = evaluate_pack_activation(record, pack)
+    if disposition != PrimeActivationDisposition.ACTIVATION_ALLOWED:
+        return record, disposition, reasons
+
+    if record.state != PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION:
+        return record, disposition, reasons
+
+    released = record.model_copy(update={"state": PrimeCustodyState.READY})
+    return released, disposition, reasons


### PR DESCRIPTION
Implements the Worldshepherd PRIME v0.9 configuration-custody safety rule in SARA. Adds `prime_configuration_custody.py` plus fail-closed unit tests. Hazardous/deep-environment service in SUBTERRA or HADAL places a PRIME into `QUARANTINED_FOR_REQUALIFICATION`. Attaching an authenticated/compatible SPACE pack does not clear that state; completing inspection evidence alone also does not clear it. Activation requires the complete requalification checklist, valid target-environment qualification, authenticated/compatible mission pack evidence, and explicit requalification-release authorization. This is software governance only and does not establish physical mine, deep-sea, flight, launch, or space qualification.