### PR TITLE
Integrate PRIME digital passport, registry custody, and provenance

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_prime_passport.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_passport.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from worldshepherd_sara.prime_configuration_custody import (
+    REQUALIFICATION_CHECKS,
+    PrimeActivationDisposition,
+    PrimeCustodyState,
+    PrimeEnvironment,
+    PrimeMissionPackEvidence,
+)
+from worldshepherd_sara.prime_passport import (
+    PRIME_CUSTODY_PROVENANCE_SCHEMA,
+    PrimeMissionCompletionRequest,
+    PrimePackActivationRequest,
+    PrimeRequalificationEvidenceRequest,
+    activate_pack,
+    complete_mission,
+    create_passport,
+    load_passport,
+    passport_registry_patch,
+    update_requalification_evidence,
+)
+
+
+def _qualified_space_pack() -> PrimeMissionPackEvidence:
+    return PrimeMissionPackEvidence(
+        pack_id="SPACE-PACK-001",
+        target_environment=PrimeEnvironment.SPACE,
+        authenticated=True,
+        compatible_with_prime=True,
+        target_environment_qualification_valid=True,
+    )
+
+
+def test_passport_round_trips_through_registry_namespace():
+    passport = create_passport(
+        prime_id="PRIME-001",
+        hardware_revision="HW-A",
+        software_revision="SW-A",
+        evidence_refs=["ECHO:BUILD:001"],
+    )
+    registry = passport_registry_patch({}, passport)
+    restored = load_passport(registry, "PRIME-001")
+    assert restored == passport
+
+
+def test_hazardous_mission_clears_pack_and_enters_quarantine_with_provenance():
+    passport = create_passport(
+        prime_id="PRIME-001",
+        hardware_revision="HW-A",
+        software_revision="SW-A",
+    ).model_copy(update={"installed_pack": _qualified_space_pack()})
+
+    updated, event = complete_mission(
+        passport,
+        PrimeMissionCompletionRequest(
+            environment=PrimeEnvironment.SUBTERRA,
+            evidence_refs=["ECHO:MISSION:SUBTERRA:001"],
+        ),
+    )
+
+    assert updated.custody.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    assert updated.installed_pack is None
+    assert event["schema"] == PRIME_CUSTODY_PROVENANCE_SCHEMA
+    assert event["previous_state"] == "READY"
+    assert event["new_state"] == "QUARANTINED_FOR_REQUALIFICATION"
+    assert event["provenance_channel"] == "SARA_AUDIT_FOR_ECHO_INGEST"
+
+
+def test_complete_evidence_without_authorization_does_not_activate_pack():
+    passport = create_passport(
+        prime_id="PRIME-001",
+        hardware_revision="HW-A",
+        software_revision="SW-A",
+    )
+    passport, _ = complete_mission(
+        passport,
+        PrimeMissionCompletionRequest(environment=PrimeEnvironment.HADAL),
+    )
+    passport, _ = update_requalification_evidence(
+        passport,
+        PrimeRequalificationEvidenceRequest(
+            completed_checks=list(REQUALIFICATION_CHECKS),
+            evidence_refs=["ECHO:REQUAL:001"],
+        ),
+    )
+
+    updated, disposition, reasons, event = activate_pack(
+        passport,
+        PrimePackActivationRequest(pack=_qualified_space_pack()),
+    )
+
+    assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
+    assert updated == passport
+    assert updated.custody.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    assert updated.installed_pack is None
+    assert any("authorization" in reason for reason in reasons)
+    assert event["details"]["disposition"] == "REQUALIFICATION_REQUIRED"
+
+
+def test_authorized_complete_requalification_releases_and_installs_pack():
+    passport = create_passport(
+        prime_id="PRIME-001",
+        hardware_revision="HW-A",
+        software_revision="SW-A",
+    )
+    passport, _ = complete_mission(
+        passport,
+        PrimeMissionCompletionRequest(environment=PrimeEnvironment.SUBTERRA),
+    )
+    passport, evidence_event = update_requalification_evidence(
+        passport,
+        PrimeRequalificationEvidenceRequest(
+            completed_checks=list(REQUALIFICATION_CHECKS),
+            evidence_refs=["ECHO:REQUAL:002"],
+            release_authorization_id="AUTH-REQUAL-001",
+        ),
+    )
+    updated, disposition, reasons, activation_event = activate_pack(
+        passport,
+        PrimePackActivationRequest(
+            pack=_qualified_space_pack(),
+            evidence_refs=["ECHO:PACK:SPACE:001"],
+        ),
+    )
+
+    assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
+    assert reasons
+    assert updated.custody.state == PrimeCustodyState.READY
+    assert updated.installed_pack is not None
+    assert updated.installed_pack.pack_id == "SPACE-PACK-001"
+    assert updated.last_transition_id == activation_event["transition_id"]
+    assert evidence_event["details"]["authorization_id"] == "AUTH-REQUAL-001"
+    assert activation_event["details"]["authorization_id"] == "AUTH-REQUAL-001"
+
+
+def test_unknown_requalification_check_is_rejected():
+    with pytest.raises(ValueError):
+        PrimeRequalificationEvidenceRequest(completed_checks=["NOT_A_REAL_GATE"])
+
+
+def test_corrupt_or_identity_mismatched_registry_passport_fails_closed():
+    registry = {
+        "PRIME_DIGITAL_PASSPORTS": {
+            "PRIME-001": {
+                "prime_id": "PRIME-OTHER",
+                "hardware_revision": "HW-A",
+                "software_revision": "SW-A",
+                "custody": {"prime_id": "PRIME-OTHER"},
+            }
+        }
+    }
+    with pytest.raises(ValueError, match="identity mismatch"):
+        load_passport(registry, "PRIME-001")

--- a/deployments/sara_verified_local_v1/tests/test_prime_passport_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_passport_api.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from worldshepherd_sara.prime_configuration_custody import REQUALIFICATION_CHECKS
+
+
+def auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _qualified_space_pack() -> dict[str, object]:
+    return {
+        "pack": {
+            "pack_id": "SPACE-PACK-001",
+            "target_environment": "SPACE",
+            "authenticated": True,
+            "compatible_with_prime": True,
+            "target_environment_qualification_valid": True,
+        },
+        "evidence_refs": ["ECHO:PACK:SPACE:001"],
+    }
+
+
+def _create_passport(client, admin: str):
+    return client.post(
+        "/admin/prime/PRIME-001/passport",
+        headers=auth(admin),
+        json={
+            "hardware_revision": "HW-A",
+            "software_revision": "SW-A",
+            "evidence_refs": ["ECHO:BUILD:001"],
+        },
+    )
+
+
+def test_prime_passport_endpoints_are_admin_only(client, tokens):
+    relay, _ = tokens
+    response = client.get(
+        "/admin/prime/PRIME-001/passport",
+        headers=auth(relay),
+    )
+    assert response.status_code == 403
+
+
+def test_prime_passport_full_quarantine_requalification_activation_lifecycle(client, tokens):
+    _, admin = tokens
+
+    created = _create_passport(client, admin)
+    assert created.status_code == 201
+    assert created.json()["passport"]["custody"]["state"] == "READY"
+    assert created.json()["provenance"]["provenance_channel"] == "SARA_AUDIT_FOR_ECHO_INGEST"
+
+    duplicate = _create_passport(client, admin)
+    assert duplicate.status_code == 409
+
+    mission = client.post(
+        "/admin/prime/PRIME-001/mission-complete",
+        headers=auth(admin),
+        json={
+            "environment": "HADAL",
+            "evidence_refs": ["ECHO:MISSION:HADAL:001"],
+        },
+    )
+    assert mission.status_code == 200
+    assert mission.json()["passport"]["custody"]["state"] == "QUARANTINED_FOR_REQUALIFICATION"
+
+    evidence_only = client.patch(
+        "/admin/prime/PRIME-001/requalification",
+        headers=auth(admin),
+        json={
+            "completed_checks": list(REQUALIFICATION_CHECKS),
+            "evidence_refs": ["ECHO:REQUAL:001"],
+        },
+    )
+    assert evidence_only.status_code == 200
+
+    blocked = client.post(
+        "/admin/prime/PRIME-001/activate-pack",
+        headers=auth(admin),
+        json=_qualified_space_pack(),
+    )
+    assert blocked.status_code == 409
+    assert blocked.json()["disposition"] == "REQUALIFICATION_REQUIRED"
+    assert blocked.json()["passport"]["installed_pack"] is None
+
+    authorized = client.patch(
+        "/admin/prime/PRIME-001/requalification",
+        headers=auth(admin),
+        json={
+            "completed_checks": list(REQUALIFICATION_CHECKS),
+            "evidence_refs": ["ECHO:REQUAL:002"],
+            "release_authorization_id": "AUTH-REQUAL-001",
+        },
+    )
+    assert authorized.status_code == 200
+
+    activated = client.post(
+        "/admin/prime/PRIME-001/activate-pack",
+        headers=auth(admin),
+        json=_qualified_space_pack(),
+    )
+    assert activated.status_code == 200
+    body = activated.json()
+    assert body["disposition"] == "ACTIVATION_ALLOWED"
+    assert body["passport"]["custody"]["state"] == "READY"
+    assert body["passport"]["installed_pack"]["pack_id"] == "SPACE-PACK-001"
+
+    fetched = client.get(
+        "/admin/prime/PRIME-001/passport",
+        headers=auth(admin),
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["passport"]["installed_pack"]["pack_id"] == "SPACE-PACK-001"
+
+    registry = client.get("/admin/registry", headers=auth(admin)).json()["registry"]
+    assert registry["PRIME_DIGITAL_PASSPORTS"]["PRIME-001"]["custody"]["state"] == "READY"
+
+    audit = client.get("/v1/audit?limit=100", headers=auth(admin))
+    assert audit.status_code == 200
+    provenance = [
+        item for item in audit.json()["records"]
+        if item.get("event") == "prime_custody_provenance"
+    ]
+    assert len(provenance) >= 5
+    assert all(
+        item["payload"]["schema"] == "WS-ECHO-PRIME-CUSTODY-V1"
+        for item in provenance
+    )
+
+
+def test_denied_pack_activation_is_audited_but_does_not_mutate_passport(client, tokens):
+    _, admin = tokens
+    assert _create_passport(client, admin).status_code == 201
+
+    before = client.get(
+        "/admin/prime/PRIME-001/passport", headers=auth(admin)
+    ).json()["passport"]
+
+    denied_body = _qualified_space_pack()
+    denied_body["pack"]["target_environment_qualification_valid"] = False
+    denied = client.post(
+        "/admin/prime/PRIME-001/activate-pack",
+        headers=auth(admin),
+        json=denied_body,
+    )
+    assert denied.status_code == 403
+    assert denied.json()["disposition"] == "DENIED"
+
+    after = client.get(
+        "/admin/prime/PRIME-001/passport", headers=auth(admin)
+    ).json()["passport"]
+    assert after == before
+
+    audit = client.get("/v1/audit?limit=50", headers=auth(admin)).json()["records"]
+    events = [item for item in audit if item.get("event") == "prime_custody_provenance"]
+    assert any(
+        item["payload"]["details"].get("disposition") == "DENIED"
+        for item in events
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
@@ -15,6 +15,7 @@ from .auth import Role, require_admin, resolve_role, validate_runtime_secrets
 from .hmaa_storage import HMAAEvidenceStore
 from .limits import MAX_REQUEST_BYTES
 from .models import AuditRecord, RegistryPatch, RelayRequest, RelayResponse
+from .prime_passport_api import router as prime_passport_router
 from .storage import DurableStore
 
 
@@ -105,6 +106,7 @@ app = FastAPI(
     redoc_url=None,
 )
 app.add_middleware(RequestSizeLimitMiddleware)
+app.include_router(prime_passport_router)
 
 
 @app.middleware("http")
@@ -141,6 +143,7 @@ def health() -> dict[str, object]:
             "hmaa_status": "/v1/hmaa/status",
             "hmaa_evidence": "/v1/hmaa/evidence?limit=50",
             "registry": "/admin/registry",
+            "prime_passport": "/admin/prime/{prime_id}/passport",
             "relay": "/v1/relay",
             "selftest": "/admin/selftest",
         },
@@ -172,7 +175,7 @@ code{color:#9ad5ff} .ok{color:#96e6a1}
 </style></head><body><h1>Worldshepherd SARA</h1>
 <p class="ok">Local administration interface is online.</p>
 <div class="card"><strong>Authority separation</strong><p>CRE1AWS approves high-impact releases. SSPADAWANZZ operates the local service.</p></div>
-<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/v1/hmaa/status</code>, <code>/v1/hmaa/evidence</code>, <code>/admin/registry</code>, <code>/admin/selftest</code></p></div>
+<div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/v1/hmaa/status</code>, <code>/v1/hmaa/evidence</code>, <code>/admin/registry</code>, <code>/admin/prime/{prime_id}/passport</code>, <code>/admin/selftest</code></p></div>
 <div class="card"><strong>Security boundary</strong><p>Tokens are never stored in this page. Use Bearer authentication from an approved local client.</p></div>
 </body></html>"""
 

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator
+
+from .prime_configuration_custody import (
+    REQUALIFICATION_CHECKS,
+    PrimeActivationDisposition,
+    PrimeConfigurationCustodyRecord,
+    PrimeEnvironment,
+    PrimeMissionPackEvidence,
+    apply_post_mission_state,
+    evaluate_pack_activation,
+    release_from_quarantine,
+)
+
+
+PRIME_PASSPORTS_REGISTRY_KEY = "PRIME_DIGITAL_PASSPORTS"
+PRIME_CUSTODY_PROVENANCE_SCHEMA = "WS-ECHO-PRIME-CUSTODY-V1"
+
+
+class PrimeDigitalPassport(BaseModel):
+    prime_id: str = Field(min_length=1, max_length=128)
+    hardware_revision: str = Field(min_length=1, max_length=128)
+    software_revision: str = Field(min_length=1, max_length=128)
+    custody: PrimeConfigurationCustodyRecord
+    installed_pack: PrimeMissionPackEvidence | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
+    last_transition_id: str | None = Field(default=None, max_length=128)
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def evidence_refs_are_bounded(cls, value: list[str]) -> list[str]:
+        if len(value) > 128:
+            raise ValueError("evidence_refs exceeds 128 entries")
+        for item in value:
+            if not item or len(item) > 256:
+                raise ValueError("each evidence reference must contain 1-256 characters")
+        return value
+
+
+class PrimePassportCreateRequest(BaseModel):
+    hardware_revision: str = Field(min_length=1, max_length=128)
+    software_revision: str = Field(min_length=1, max_length=128)
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class PrimeMissionCompletionRequest(BaseModel):
+    environment: PrimeEnvironment
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class PrimeRequalificationEvidenceRequest(BaseModel):
+    completed_checks: list[str] = Field(default_factory=list)
+    evidence_refs: list[str] = Field(default_factory=list)
+    release_authorization_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+    @field_validator("completed_checks")
+    @classmethod
+    def checks_are_known_and_unique(cls, value: list[str]) -> list[str]:
+        unknown = sorted(set(value) - set(REQUALIFICATION_CHECKS))
+        if unknown:
+            raise ValueError(f"unknown requalification checks: {', '.join(unknown)}")
+        if len(value) != len(set(value)):
+            raise ValueError("completed_checks contains duplicates")
+        return value
+
+
+class PrimePackActivationRequest(BaseModel):
+    pack: PrimeMissionPackEvidence
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+def new_transition_id() -> str:
+    return f"PRIME-CUSTODY-{uuid4()}"
+
+
+def create_passport(
+    *,
+    prime_id: str,
+    hardware_revision: str,
+    software_revision: str,
+    evidence_refs: list[str] | None = None,
+) -> PrimeDigitalPassport:
+    return PrimeDigitalPassport(
+        prime_id=prime_id,
+        hardware_revision=hardware_revision,
+        software_revision=software_revision,
+        custody=PrimeConfigurationCustodyRecord(prime_id=prime_id),
+        evidence_refs=list(evidence_refs or []),
+    )
+
+
+def _passport_map(registry: dict[str, Any]) -> dict[str, Any]:
+    raw = registry.get(PRIME_PASSPORTS_REGISTRY_KEY, {})
+    if not isinstance(raw, dict):
+        raise ValueError(f"{PRIME_PASSPORTS_REGISTRY_KEY} must be a JSON object")
+    return dict(raw)
+
+
+def load_passport(registry: dict[str, Any], prime_id: str) -> PrimeDigitalPassport | None:
+    raw = _passport_map(registry).get(prime_id)
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(f"passport entry for {prime_id} must be a JSON object")
+    passport = PrimeDigitalPassport.model_validate(raw)
+    if passport.prime_id != prime_id or passport.custody.prime_id != prime_id:
+        raise ValueError(f"passport identity mismatch for {prime_id}")
+    return passport
+
+
+def passport_registry_patch(
+    registry: dict[str, Any], passport: PrimeDigitalPassport
+) -> dict[str, Any]:
+    passports = _passport_map(registry)
+    passports[passport.prime_id] = passport.model_dump(mode="json")
+    return {PRIME_PASSPORTS_REGISTRY_KEY: passports}
+
+
+def _merge_evidence(existing: list[str], additions: list[str]) -> list[str]:
+    merged = list(existing)
+    for item in additions:
+        if item not in merged:
+            merged.append(item)
+    return merged
+
+
+def complete_mission(
+    passport: PrimeDigitalPassport,
+    request: PrimeMissionCompletionRequest,
+) -> tuple[PrimeDigitalPassport, dict[str, Any]]:
+    transition_id = new_transition_id()
+    previous_state = passport.custody.state.value
+    updated_custody = apply_post_mission_state(passport.custody, request.environment)
+    updated = passport.model_copy(
+        update={
+            "custody": updated_custody,
+            "installed_pack": None,
+            "evidence_refs": _merge_evidence(passport.evidence_refs, request.evidence_refs),
+            "last_transition_id": transition_id,
+        }
+    )
+    payload = custody_provenance_payload(
+        transition_id=transition_id,
+        prime_id=passport.prime_id,
+        action="MISSION_COMPLETED",
+        previous_state=previous_state,
+        new_state=updated.custody.state.value,
+        evidence_refs=request.evidence_refs,
+        environment=request.environment.value,
+    )
+    return updated, payload
+
+
+def update_requalification_evidence(
+    passport: PrimeDigitalPassport,
+    request: PrimeRequalificationEvidenceRequest,
+) -> tuple[PrimeDigitalPassport, dict[str, Any]]:
+    transition_id = new_transition_id()
+    previous_state = passport.custody.state.value
+    updated_custody = passport.custody.model_copy(
+        update={
+            "completed_requalification_checks": list(request.completed_checks),
+            "requalification_release_authorization_id": request.release_authorization_id,
+        }
+    )
+    updated = passport.model_copy(
+        update={
+            "custody": updated_custody,
+            "evidence_refs": _merge_evidence(passport.evidence_refs, request.evidence_refs),
+            "last_transition_id": transition_id,
+        }
+    )
+    payload = custody_provenance_payload(
+        transition_id=transition_id,
+        prime_id=passport.prime_id,
+        action="REQUALIFICATION_EVIDENCE_UPDATED",
+        previous_state=previous_state,
+        new_state=updated.custody.state.value,
+        evidence_refs=request.evidence_refs,
+        authorization_id=request.release_authorization_id,
+        completed_checks=list(request.completed_checks),
+    )
+    return updated, payload
+
+
+def activate_pack(
+    passport: PrimeDigitalPassport,
+    request: PrimePackActivationRequest,
+) -> tuple[PrimeDigitalPassport, PrimeActivationDisposition, list[str], dict[str, Any]]:
+    transition_id = new_transition_id()
+    previous_state = passport.custody.state.value
+    disposition, reasons = evaluate_pack_activation(passport.custody, request.pack)
+    updated = passport
+
+    if disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED:
+        released_custody, _, _ = release_from_quarantine(passport.custody, request.pack)
+        updated = passport.model_copy(
+            update={
+                "custody": released_custody,
+                "installed_pack": request.pack,
+                "evidence_refs": _merge_evidence(passport.evidence_refs, request.evidence_refs),
+                "last_transition_id": transition_id,
+            }
+        )
+
+    payload = custody_provenance_payload(
+        transition_id=transition_id,
+        prime_id=passport.prime_id,
+        action="PACK_ACTIVATION_EVALUATED",
+        previous_state=previous_state,
+        new_state=updated.custody.state.value,
+        evidence_refs=request.evidence_refs,
+        authorization_id=passport.custody.requalification_release_authorization_id,
+        pack_id=request.pack.pack_id,
+        target_environment=request.pack.target_environment.value,
+        disposition=disposition.value,
+        reasons=reasons,
+    )
+    return updated, disposition, reasons, payload
+
+
+def custody_provenance_payload(
+    *,
+    transition_id: str,
+    prime_id: str,
+    action: str,
+    previous_state: str,
+    new_state: str,
+    evidence_refs: list[str],
+    **details: Any,
+) -> dict[str, Any]:
+    return {
+        "schema": PRIME_CUSTODY_PROVENANCE_SCHEMA,
+        "provenance_channel": "SARA_AUDIT_FOR_ECHO_INGEST",
+        "transition_id": transition_id,
+        "prime_id": prime_id,
+        "action": action,
+        "previous_state": previous_state,
+        "new_state": new_state,
+        "evidence_refs": list(evidence_refs),
+        "details": details,
+        "claims_boundary": (
+            "Software custody/provenance evidence only; does not establish physical "
+            "mine, deep-sea, flight, launch, or space qualification."
+        ),
+    }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .auth import Role, require_admin, resolve_role
+from .models import AuditRecord
+from .prime_configuration_custody import PrimeActivationDisposition
+from .prime_passport import (
+    PrimeDigitalPassport,
+    PrimeMissionCompletionRequest,
+    PrimePackActivationRequest,
+    PrimePassportCreateRequest,
+    PrimeRequalificationEvidenceRequest,
+    activate_pack,
+    complete_mission,
+    create_passport,
+    custody_provenance_payload,
+    load_passport,
+    new_transition_id,
+    passport_registry_patch,
+    update_requalification_evidence,
+)
+from .storage import DurableStore
+
+
+router = APIRouter(prefix="/admin/prime", tags=["prime-custody"])
+
+
+def _store(request: Request) -> DurableStore:
+    return request.app.state.store
+
+
+def _load_or_404(durable_store: DurableStore, prime_id: str) -> PrimeDigitalPassport:
+    try:
+        passport = load_passport(durable_store.get_registry(), prime_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail="PRIME passport registry validation failed") from exc
+    if passport is None:
+        raise HTTPException(status_code=404, detail="PRIME passport not found")
+    return passport
+
+
+def _persist(durable_store: DurableStore, passport: PrimeDigitalPassport) -> None:
+    registry = durable_store.get_registry()
+    durable_store.patch_registry(passport_registry_patch(registry, passport))
+
+
+def _append_provenance(
+    durable_store: DurableStore,
+    role: Role,
+    payload: dict[str, Any],
+) -> None:
+    durable_store.append_audit(
+        AuditRecord.create(
+            event="prime_custody_provenance",
+            actor=role.value,
+            payload=payload,
+        )
+    )
+
+
+@router.get("/{prime_id}/passport")
+def get_prime_passport(
+    prime_id: str,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, Any]:
+    require_admin(role)
+    passport = _load_or_404(_store(request), prime_id)
+    return {"passport": passport.model_dump(mode="json")}
+
+
+@router.post("/{prime_id}/passport", status_code=201)
+def create_prime_passport(
+    prime_id: str,
+    body: PrimePassportCreateRequest,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, Any]:
+    require_admin(role)
+    durable_store = _store(request)
+    try:
+        existing = load_passport(durable_store.get_registry(), prime_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail="PRIME passport registry validation failed") from exc
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="PRIME passport already exists")
+
+    passport = create_passport(
+        prime_id=prime_id,
+        hardware_revision=body.hardware_revision,
+        software_revision=body.software_revision,
+        evidence_refs=body.evidence_refs,
+    )
+    _persist(durable_store, passport)
+    payload = custody_provenance_payload(
+        transition_id=new_transition_id(),
+        prime_id=prime_id,
+        action="PASSPORT_CREATED",
+        previous_state="UNREGISTERED",
+        new_state=passport.custody.state.value,
+        evidence_refs=body.evidence_refs,
+        hardware_revision=body.hardware_revision,
+        software_revision=body.software_revision,
+    )
+    _append_provenance(durable_store, role, payload)
+    return {"passport": passport.model_dump(mode="json"), "provenance": payload}
+
+
+@router.post("/{prime_id}/mission-complete")
+def complete_prime_mission(
+    prime_id: str,
+    body: PrimeMissionCompletionRequest,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, Any]:
+    require_admin(role)
+    durable_store = _store(request)
+    passport = _load_or_404(durable_store, prime_id)
+    updated, payload = complete_mission(passport, body)
+    _persist(durable_store, updated)
+    _append_provenance(durable_store, role, payload)
+    return {"passport": updated.model_dump(mode="json"), "provenance": payload}
+
+
+@router.patch("/{prime_id}/requalification")
+def patch_prime_requalification(
+    prime_id: str,
+    body: PrimeRequalificationEvidenceRequest,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, Any]:
+    require_admin(role)
+    durable_store = _store(request)
+    passport = _load_or_404(durable_store, prime_id)
+    updated, payload = update_requalification_evidence(passport, body)
+    _persist(durable_store, updated)
+    _append_provenance(durable_store, role, payload)
+    return {"passport": updated.model_dump(mode="json"), "provenance": payload}
+
+
+@router.post("/{prime_id}/activate-pack")
+def activate_prime_pack(
+    prime_id: str,
+    body: PrimePackActivationRequest,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> JSONResponse:
+    require_admin(role)
+    durable_store = _store(request)
+    passport = _load_or_404(durable_store, prime_id)
+    updated, disposition, reasons, payload = activate_pack(passport, body)
+    _append_provenance(durable_store, role, payload)
+
+    response: dict[str, Any] = {
+        "disposition": disposition.value,
+        "reasons": reasons,
+        "passport": updated.model_dump(mode="json"),
+        "provenance": payload,
+    }
+
+    if disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED:
+        _persist(durable_store, updated)
+        return JSONResponse(response, status_code=200)
+    if disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED:
+        return JSONResponse(response, status_code=409)
+    return JSONResponse(response, status_code=403)


### PR DESCRIPTION
Advances Worldshepherd PRIME software governance to v1.0 by connecting the v0.9 configuration-custody state machine to the existing durable SARA registry and audit path. Adds PRIME digital-passport models, namespaced registry serialization, mission-completion quarantine, requalification-evidence capture, governed pack-activation evaluation, admin-only API routes, and `WS-ECHO-PRIME-CUSTODY-V1` provenance envelopes written as `SARA_AUDIT_FOR_ECHO_INGEST`. Denied or requalification-required activation attempts are audited without mutating the stored passport. Release from hazardous/deep-environment quarantine still requires complete evidence, valid target-environment pack qualification, compatibility/authentication, and an explicit release-authorization record ID. This remains software governance evidence only; it does not establish physical mine, deep-sea, flight, launch, or space qualification, and the authorization record ID is not yet cryptographically verified by an independent PRIME SENTINEL service.