### PR TITLE
Add reproducible PRIME physics engineering-screen engine

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_prime_physics.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_physics.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from worldshepherd_sara.prime_physics import (
+    PointMass,
+    aero_propulsor_trade,
+    axisymmetric_cylinder_inertia,
+    cg_after_removed_point_masses,
+    combine_inertia,
+    hadal_effective_displacement_liters,
+    hadal_post_ballast_positive_buoyancy_kg,
+    hydrostatic_restoring_moment_nm,
+    maximum_buoyancy_loss_fraction_before_minimum_margin,
+    point_mass_inertia,
+    radiator_net_flux_w_m2,
+    radiator_rejection_w,
+    required_body_utilization,
+    rotor_rpm_for_tip_mach,
+    unrejected_heat_j,
+    vector_magnitude,
+)
+
+
+def _psdm_points() -> list[PointMass]:
+    return [
+        PointMass(130.0, 0.85, 0.45),
+        PointMass(130.0, 0.85, -0.45),
+        PointMass(130.0, -0.85, 0.45),
+        PointMass(130.0, -0.85, -0.45),
+    ]
+
+
+def test_psdm_v09_loaded_inertia_screen_matches_record():
+    central = axisymmetric_cylinder_inertia(
+        mass_kg=580.0,
+        radius_m=1.05,
+        length_m=3.65,
+    )
+    result = combine_inertia(central, point_mass_inertia(_psdm_points()))
+    assert result.ix_kg_m2 == pytest.approx(425.025, abs=0.01)
+    assert result.iy_kg_m2 == pytest.approx(1179.483, abs=0.01)
+    assert result.iz_kg_m2 == pytest.approx(1284.783, abs=0.01)
+
+
+def test_psdm_symmetric_pair_removal_preserves_first_order_cg_and_inertia_screen():
+    points = _psdm_points()
+    removed = [points[0], points[3]]
+    cg = cg_after_removed_point_masses(initial_total_mass_kg=1100.0, removed=removed)
+    assert cg == pytest.approx((0.0, 0.0, 0.0), abs=1e-12)
+
+    central = axisymmetric_cylinder_inertia(
+        mass_kg=580.0,
+        radius_m=1.05,
+        length_m=3.65,
+    )
+    remaining = [points[1], points[2]]
+    result = combine_inertia(central, point_mass_inertia(remaining))
+    assert result.ix_kg_m2 == pytest.approx(372.375, abs=0.01)
+    assert result.iy_kg_m2 == pytest.approx(991.633, abs=0.01)
+    assert result.iz_kg_m2 == pytest.approx(1044.283, abs=0.01)
+
+
+def test_psdm_release_mismatch_and_asymmetric_release_cg_screens():
+    points = _psdm_points()
+    fore_station = cg_after_removed_point_masses(
+        initial_total_mass_kg=1100.0,
+        removed=[points[0], points[1]],
+    )
+    lateral_side = cg_after_removed_point_masses(
+        initial_total_mass_kg=1100.0,
+        removed=[points[0], points[2]],
+    )
+    one_unit = cg_after_removed_point_masses(
+        initial_total_mass_kg=1100.0,
+        removed=[points[0]],
+    )
+    assert vector_magnitude(fore_station) == pytest.approx(0.2631, abs=0.0002)
+    assert vector_magnitude(lateral_side) == pytest.approx(0.1393, abs=0.0002)
+    assert vector_magnitude(one_unit) == pytest.approx(0.1289, abs=0.0002)
+
+
+@pytest.mark.parametrize(
+    ("effectors", "diameter", "thrust", "power", "mass_each"),
+    [
+        (4, 1.5958, 446.36, 8.30, 5.75),
+        (6, 1.3029, 297.57, 5.5333, 3.8333),
+        (8, 1.1284, 223.18, 4.15, 2.875),
+        (12, 0.9213, 148.79, 2.7667, 1.9167),
+    ],
+)
+def test_aero_v09_propulsor_trades(effectors, diameter, thrust, power, mass_each):
+    result = aero_propulsor_trade(
+        gross_mass_kg=182.0,
+        total_effective_area_m2=8.0,
+        total_design_power_kw=33.2,
+        effectors=effectors,
+        propulsor_related_mass_kg=23.0,
+    )
+    assert result.equivalent_diameter_m == pytest.approx(diameter, abs=0.0005)
+    assert result.thrust_n_each == pytest.approx(thrust, abs=0.02)
+    assert result.design_power_kw_each == pytest.approx(power, abs=0.001)
+    assert result.disk_loading_n_m2 == pytest.approx(223.1775, abs=0.001)
+    assert result.propulsor_related_mass_kg_each == pytest.approx(mass_each, abs=0.001)
+
+
+def test_aero_b6_tip_mach_rpm_sensitivity():
+    diameter = aero_propulsor_trade(
+        gross_mass_kg=182.0,
+        total_effective_area_m2=8.0,
+        total_design_power_kw=33.2,
+        effectors=6,
+        propulsor_related_mass_kg=23.0,
+    ).equivalent_diameter_m
+    assert rotor_rpm_for_tip_mach(diameter_m=diameter, tip_mach=0.55) == pytest.approx(2741, abs=2)
+    assert rotor_rpm_for_tip_mach(diameter_m=diameter, tip_mach=0.60) == pytest.approx(2990, abs=2)
+    assert rotor_rpm_for_tip_mach(diameter_m=diameter, tip_mach=0.65) == pytest.approx(3239, abs=2)
+
+
+def test_space_s50_tbi_flux_and_body_utilization_match_v09_screen():
+    flux_330 = radiator_net_flux_w_m2(
+        temperature_k=330.0, emissivity=0.9, effectiveness=0.7
+    )
+    flux_350 = radiator_net_flux_w_m2(
+        temperature_k=350.0, emissivity=0.9, effectiveness=0.7
+    )
+    assert flux_330 == pytest.approx(423.6508, abs=0.001)
+    assert flux_350 == pytest.approx(536.0737, abs=0.001)
+
+    utilization = required_body_utilization(
+        required_rejection_w=700.0,
+        temperature_k=330.0,
+        deployable_area_m2=1.2,
+        body_area_m2=1.2,
+        emissivity=0.9,
+        effectiveness=0.7,
+    )
+    assert utilization == pytest.approx(0.37692, abs=0.00001)
+
+
+def test_space_s50_tbi_rejection_and_two_kw_transient_deficit():
+    rejection_330 = radiator_rejection_w(
+        temperature_k=330.0,
+        deployable_area_m2=1.2,
+        body_area_m2=1.2,
+        body_utilization=0.60,
+        emissivity=0.9,
+        effectiveness=0.7,
+    )
+    rejection_350 = radiator_rejection_w(
+        temperature_k=350.0,
+        deployable_area_m2=1.2,
+        body_area_m2=1.2,
+        body_utilization=0.60,
+        emissivity=0.9,
+        effectiveness=0.7,
+    )
+    assert rejection_330 == pytest.approx(813.41, abs=0.02)
+    assert rejection_350 == pytest.approx(1029.26, abs=0.02)
+    assert unrejected_heat_j(
+        heat_load_w=2000.0, rejection_w=rejection_330, duration_s=900.0
+    ) == pytest.approx(1.06793e6, rel=1e-5)
+    assert unrejected_heat_j(
+        heat_load_w=2000.0, rejection_w=rejection_350, duration_s=900.0
+    ) == pytest.approx(0.873665e6, rel=1e-5)
+
+
+def test_hadal_v09_displacement_ballast_margin_and_stability_sensitivity():
+    displacement_l = hadal_effective_displacement_liters(
+        total_mass_kg=242.0,
+        apparent_negative_mass_kg=5.0,
+        seawater_density_kg_m3=1025.0,
+    )
+    assert displacement_l == pytest.approx(231.2195, abs=0.001)
+
+    ideal_positive = hadal_post_ballast_positive_buoyancy_kg(
+        apparent_negative_mass_kg=5.0,
+        released_ballast_kg=15.0,
+    )
+    assert ideal_positive == pytest.approx(10.0)
+
+    loss_fraction = maximum_buoyancy_loss_fraction_before_minimum_margin(
+        buoyancy_equivalent_kg=237.0,
+        ideal_positive_buoyancy_kg=10.0,
+        minimum_required_positive_buoyancy_kg=5.0,
+    )
+    assert loss_fraction == pytest.approx(0.021097, abs=0.000001)
+
+    assert hydrostatic_restoring_moment_nm(
+        buoyancy_equivalent_kg=237.0,
+        cb_cg_separation_m=0.025,
+        angle_deg=10.0,
+    ) == pytest.approx(10.09, abs=0.02)
+    assert hydrostatic_restoring_moment_nm(
+        buoyancy_equivalent_kg=237.0,
+        cb_cg_separation_m=0.050,
+        angle_deg=10.0,
+    ) == pytest.approx(20.18, abs=0.03)
+    assert hydrostatic_restoring_moment_nm(
+        buoyancy_equivalent_kg=237.0,
+        cb_cg_separation_m=0.100,
+        angle_deg=10.0,
+    ) == pytest.approx(40.36, abs=0.05)
+
+
+def test_invalid_engineering_inputs_fail_closed():
+    with pytest.raises(ValueError):
+        axisymmetric_cylinder_inertia(mass_kg=0, radius_m=1, length_m=1)
+    with pytest.raises(ValueError):
+        cg_after_removed_point_masses(
+            initial_total_mass_kg=100,
+            removed=[PointMass(100, 0, 0)],
+        )
+    with pytest.raises(ValueError):
+        aero_propulsor_trade(
+            gross_mass_kg=182,
+            total_effective_area_m2=8,
+            total_design_power_kw=33.2,
+            effectors=0,
+            propulsor_related_mass_kg=23,
+        )
+    with pytest.raises(ValueError):
+        radiator_rejection_w(
+            temperature_k=330,
+            deployable_area_m2=1.2,
+            body_area_m2=1.2,
+            body_utilization=1.1,
+            emissivity=0.9,
+            effectiveness=0.7,
+        )
+    with pytest.raises(ValueError):
+        maximum_buoyancy_loss_fraction_before_minimum_margin(
+            buoyancy_equivalent_kg=237,
+            ideal_positive_buoyancy_kg=4,
+            minimum_required_positive_buoyancy_kg=5,
+        )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_physics.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_physics.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+ENGINEERING_SCREEN_CLAIMS_BOUNDARY = (
+    "Arithmetic/modeling aid only. Results do not establish physical qualification, "
+    "flight performance, launch separation, pressure/depth capability, or thermal-vacuum performance."
+)
+STEFAN_BOLTZMANN_W_M2_K4 = 5.670374419e-8
+
+
+@dataclass(frozen=True)
+class PointMass:
+    mass_kg: float
+    x_m: float
+    y_m: float
+    z_m: float = 0.0
+
+
+@dataclass(frozen=True)
+class InertiaScreen:
+    ix_kg_m2: float
+    iy_kg_m2: float
+    iz_kg_m2: float
+
+
+@dataclass(frozen=True)
+class AeroPropulsorTrade:
+    effectors: int
+    equivalent_diameter_m: float
+    thrust_n_each: float
+    design_power_kw_each: float
+    disk_loading_n_m2: float
+    propulsor_related_mass_kg_each: float
+
+
+def _positive(value: float, name: str) -> float:
+    if value <= 0:
+        raise ValueError(f"{name} must be > 0")
+    return value
+
+
+def _fraction(value: float, name: str) -> float:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be within [0, 1]")
+    return value
+
+
+def axisymmetric_cylinder_inertia(
+    *, mass_kg: float, radius_m: float, length_m: float
+) -> InertiaScreen:
+    """Approximate a cylinder with its longitudinal axis aligned to +X."""
+    _positive(mass_kg, "mass_kg")
+    _positive(radius_m, "radius_m")
+    _positive(length_m, "length_m")
+    ix = 0.5 * mass_kg * radius_m**2
+    transverse = (mass_kg / 12.0) * (3.0 * radius_m**2 + length_m**2)
+    return InertiaScreen(ix, transverse, transverse)
+
+
+def point_mass_inertia(points: list[PointMass]) -> InertiaScreen:
+    ix = sum(p.mass_kg * (p.y_m**2 + p.z_m**2) for p in points)
+    iy = sum(p.mass_kg * (p.x_m**2 + p.z_m**2) for p in points)
+    iz = sum(p.mass_kg * (p.x_m**2 + p.y_m**2) for p in points)
+    if any(p.mass_kg <= 0 for p in points):
+        raise ValueError("point masses must be > 0")
+    return InertiaScreen(ix, iy, iz)
+
+
+def combine_inertia(*screens: InertiaScreen) -> InertiaScreen:
+    return InertiaScreen(
+        sum(item.ix_kg_m2 for item in screens),
+        sum(item.iy_kg_m2 for item in screens),
+        sum(item.iz_kg_m2 for item in screens),
+    )
+
+
+def cg_after_removed_point_masses(
+    *, initial_total_mass_kg: float, removed: list[PointMass]
+) -> tuple[float, float, float]:
+    """CG after removals from an initially zero-CG assembly.
+
+    The function intentionally assumes the complete initial assembly has CG=(0,0,0).
+    It is a first-order release screen, not a multibody separation simulation.
+    """
+    _positive(initial_total_mass_kg, "initial_total_mass_kg")
+    removed_mass = sum(item.mass_kg for item in removed)
+    if any(item.mass_kg <= 0 for item in removed):
+        raise ValueError("removed point masses must be > 0")
+    remaining_mass = initial_total_mass_kg - removed_mass
+    if remaining_mass <= 0:
+        raise ValueError("removed mass must be less than initial total mass")
+    return (
+        -sum(item.mass_kg * item.x_m for item in removed) / remaining_mass,
+        -sum(item.mass_kg * item.y_m for item in removed) / remaining_mass,
+        -sum(item.mass_kg * item.z_m for item in removed) / remaining_mass,
+    )
+
+
+def vector_magnitude(vector: tuple[float, float, float]) -> float:
+    return math.sqrt(sum(component**2 for component in vector))
+
+
+def aero_propulsor_trade(
+    *,
+    gross_mass_kg: float,
+    total_effective_area_m2: float,
+    total_design_power_kw: float,
+    effectors: int,
+    propulsor_related_mass_kg: float,
+    gravity_m_s2: float = 9.81,
+) -> AeroPropulsorTrade:
+    _positive(gross_mass_kg, "gross_mass_kg")
+    _positive(total_effective_area_m2, "total_effective_area_m2")
+    _positive(total_design_power_kw, "total_design_power_kw")
+    _positive(propulsor_related_mass_kg, "propulsor_related_mass_kg")
+    _positive(gravity_m_s2, "gravity_m_s2")
+    if effectors <= 0:
+        raise ValueError("effectors must be > 0")
+
+    area_each = total_effective_area_m2 / effectors
+    diameter = math.sqrt(4.0 * area_each / math.pi)
+    total_thrust = gross_mass_kg * gravity_m_s2
+    return AeroPropulsorTrade(
+        effectors=effectors,
+        equivalent_diameter_m=diameter,
+        thrust_n_each=total_thrust / effectors,
+        design_power_kw_each=total_design_power_kw / effectors,
+        disk_loading_n_m2=total_thrust / total_effective_area_m2,
+        propulsor_related_mass_kg_each=propulsor_related_mass_kg / effectors,
+    )
+
+
+def rotor_rpm_for_tip_mach(
+    *, diameter_m: float, tip_mach: float, speed_of_sound_m_s: float = 340.0
+) -> float:
+    _positive(diameter_m, "diameter_m")
+    _positive(tip_mach, "tip_mach")
+    _positive(speed_of_sound_m_s, "speed_of_sound_m_s")
+    tip_speed = tip_mach * speed_of_sound_m_s
+    return tip_speed * 60.0 / (math.pi * diameter_m)
+
+
+def radiator_net_flux_w_m2(
+    *, temperature_k: float, emissivity: float, effectiveness: float
+) -> float:
+    _positive(temperature_k, "temperature_k")
+    _fraction(emissivity, "emissivity")
+    _fraction(effectiveness, "effectiveness")
+    return (
+        STEFAN_BOLTZMANN_W_M2_K4
+        * emissivity
+        * temperature_k**4
+        * effectiveness
+    )
+
+
+def radiator_rejection_w(
+    *,
+    temperature_k: float,
+    deployable_area_m2: float,
+    body_area_m2: float,
+    body_utilization: float,
+    emissivity: float,
+    effectiveness: float,
+) -> float:
+    if deployable_area_m2 < 0 or body_area_m2 < 0:
+        raise ValueError("radiator areas must be >= 0")
+    _fraction(body_utilization, "body_utilization")
+    effective_area = deployable_area_m2 + body_area_m2 * body_utilization
+    return radiator_net_flux_w_m2(
+        temperature_k=temperature_k,
+        emissivity=emissivity,
+        effectiveness=effectiveness,
+    ) * effective_area
+
+
+def required_body_utilization(
+    *,
+    required_rejection_w: float,
+    temperature_k: float,
+    deployable_area_m2: float,
+    body_area_m2: float,
+    emissivity: float,
+    effectiveness: float,
+) -> float:
+    _positive(required_rejection_w, "required_rejection_w")
+    if deployable_area_m2 < 0:
+        raise ValueError("deployable_area_m2 must be >= 0")
+    _positive(body_area_m2, "body_area_m2")
+    flux = radiator_net_flux_w_m2(
+        temperature_k=temperature_k,
+        emissivity=emissivity,
+        effectiveness=effectiveness,
+    )
+    utilization = (required_rejection_w / flux - deployable_area_m2) / body_area_m2
+    return utilization
+
+
+def unrejected_heat_j(
+    *, heat_load_w: float, rejection_w: float, duration_s: float
+) -> float:
+    _positive(heat_load_w, "heat_load_w")
+    if rejection_w < 0:
+        raise ValueError("rejection_w must be >= 0")
+    _positive(duration_s, "duration_s")
+    return max(0.0, heat_load_w - rejection_w) * duration_s
+
+
+def hadal_effective_displacement_liters(
+    *,
+    total_mass_kg: float,
+    apparent_negative_mass_kg: float,
+    seawater_density_kg_m3: float,
+) -> float:
+    _positive(total_mass_kg, "total_mass_kg")
+    _positive(seawater_density_kg_m3, "seawater_density_kg_m3")
+    if apparent_negative_mass_kg < 0 or apparent_negative_mass_kg >= total_mass_kg:
+        raise ValueError("apparent_negative_mass_kg must be within [0, total_mass_kg)")
+    buoyancy_equivalent_kg = total_mass_kg - apparent_negative_mass_kg
+    return 1000.0 * buoyancy_equivalent_kg / seawater_density_kg_m3
+
+
+def hadal_post_ballast_positive_buoyancy_kg(
+    *, apparent_negative_mass_kg: float, released_ballast_kg: float
+) -> float:
+    if apparent_negative_mass_kg < 0:
+        raise ValueError("apparent_negative_mass_kg must be >= 0")
+    _positive(released_ballast_kg, "released_ballast_kg")
+    return released_ballast_kg - apparent_negative_mass_kg
+
+
+def maximum_buoyancy_loss_fraction_before_minimum_margin(
+    *,
+    buoyancy_equivalent_kg: float,
+    ideal_positive_buoyancy_kg: float,
+    minimum_required_positive_buoyancy_kg: float,
+) -> float:
+    _positive(buoyancy_equivalent_kg, "buoyancy_equivalent_kg")
+    if minimum_required_positive_buoyancy_kg < 0:
+        raise ValueError("minimum_required_positive_buoyancy_kg must be >= 0")
+    if ideal_positive_buoyancy_kg < minimum_required_positive_buoyancy_kg:
+        raise ValueError("ideal margin must be >= minimum required margin")
+    return (
+        ideal_positive_buoyancy_kg - minimum_required_positive_buoyancy_kg
+    ) / buoyancy_equivalent_kg
+
+
+def hydrostatic_restoring_moment_nm(
+    *,
+    buoyancy_equivalent_kg: float,
+    cb_cg_separation_m: float,
+    angle_deg: float,
+    gravity_m_s2: float = 9.81,
+) -> float:
+    _positive(buoyancy_equivalent_kg, "buoyancy_equivalent_kg")
+    _positive(cb_cg_separation_m, "cb_cg_separation_m")
+    _positive(gravity_m_s2, "gravity_m_s2")
+    if not 0.0 <= angle_deg <= 180.0:
+        raise ValueError("angle_deg must be within [0, 180]")
+    return (
+        buoyancy_equivalent_kg
+        * gravity_m_s2
+        * cb_cg_separation_m
+        * math.sin(math.radians(angle_deg))
+    )


### PR DESCRIPTION
Implements pure, unit-testable arithmetic functions for the claims-controlled PRIME v0.9 engineering screens: PSDM point-mass CG and approximate inertia, AERO propulsor-count/diameter/thrust/power/mass trades and tip-Mach RPM screening, SPACE radiator flux/rejection/body-utilization/transient-heat calculations, and HADAL displacement/ballast/emergency-margin/restoring-moment sensitivity. Regression tests reproduce the v0.9 published arithmetic and reject invalid inputs. The module explicitly labels itself an engineering/modeling aid only; successful software tests do not establish physical launch separation, flight performance, thermal-vacuum performance, or pressure/depth qualification.