### PR TITLE
Add Ed25519 PRIME SENTINEL requalification authorization

### DIFF
--- a/deployments/sara_verified_local_v1/.env.example
+++ b/deployments/sara_verified_local_v1/.env.example
@@ -1,4 +1,4 @@
-# Generate each value independently, for example:
+# Generate each SARA bearer-token value independently, for example:
 # python -c 'import secrets; print(secrets.token_urlsafe(32))'
 SARA_RELAY_TOKEN=replace-with-an-independent-random-token-at-least-24-characters
 SARA_ADMIN_TOKEN=replace-with-a-different-random-token-at-least-24-characters
@@ -12,3 +12,11 @@ SARA_LOG_LEVEL=info
 # UNKNOWN/UNVERIFIED must never be represented as an approved release identity.
 SARA_BUILD_COMMIT=UNKNOWN
 SARA_RELEASE_ID=UNVERIFIED
+
+# PRIME SENTINEL asymmetric authorization verification.
+# SARA receives PUBLIC keys only. Never put a PRIME SENTINEL private signing key here.
+# Values are unpadded base64url-encoded raw 32-byte Ed25519 public keys keyed by stable key ID.
+# Example shape only; replace with an independently generated PRIME SENTINEL public key before enabling release authorization.
+PRIME_SENTINEL_PUBLIC_KEYS_JSON={}
+# Comma-separated key IDs that SARA must reject immediately even if previously trusted.
+PRIME_SENTINEL_REVOKED_KEY_IDS=

--- a/deployments/sara_verified_local_v1/constraints-runtime.txt
+++ b/deployments/sara_verified_local_v1/constraints-runtime.txt
@@ -4,6 +4,7 @@ annotated-doc==0.0.5
 annotated-types==0.8.0
 anyio==4.14.2
 click==8.5.0
+cryptography==50.0.1
 fastapi==0.141.1
 h11==0.16.0
 httptools==0.8.0

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "fastapi>=0.110,<1",
   "uvicorn[standard]>=0.27,<1",
   "pydantic>=2.6,<3",
+  "cryptography>=50,<51",
 ]
 
 [project.optional-dependencies]

--- a/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
@@ -26,6 +26,20 @@ def _space_pack(**overrides):
     return PrimeMissionPackEvidence(**values)
 
 
+def _authorized_record(**overrides):
+    values = {
+        "prime_id": "PRIME-001",
+        "state": PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
+        "last_environment": PrimeEnvironment.SUBTERRA,
+        "completed_requalification_checks": list(REQUALIFICATION_CHECKS),
+        "requalification_release_authorization_id": "AUTH-2026-0001",
+        "requalification_release_target_environment": PrimeEnvironment.SPACE,
+        "requalification_release_key_id": "PS-K1",
+    }
+    values.update(overrides)
+    return PrimeConfigurationCustodyRecord(**values)
+
+
 def test_subterra_and_hadal_missions_enter_requalification_quarantine():
     assert post_mission_state(PrimeEnvironment.SUBTERRA) == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
     assert post_mission_state(PrimeEnvironment.HADAL) == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
@@ -33,19 +47,15 @@ def test_subterra_and_hadal_missions_enter_requalification_quarantine():
 
 
 def test_post_mission_transition_resets_old_requalification_evidence_and_authorization():
-    record = PrimeConfigurationCustodyRecord(
-        prime_id="PRIME-001",
-        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
-        requalification_release_authorization_id="AUTH-OLD",
-    )
-    transitioned = apply_post_mission_state(record, PrimeEnvironment.SUBTERRA)
+    transitioned = apply_post_mission_state(_authorized_record(), PrimeEnvironment.SUBTERRA)
     assert transitioned.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
-    assert transitioned.last_environment == PrimeEnvironment.SUBTERRA
     assert transitioned.completed_requalification_checks == []
     assert transitioned.requalification_release_authorization_id is None
+    assert transitioned.requalification_release_target_environment is None
+    assert transitioned.requalification_release_key_id is None
 
 
-def test_installing_a_valid_space_pack_does_not_clear_quarantine_by_itself():
+def test_installing_valid_pack_does_not_clear_quarantine_without_evidence():
     record = PrimeConfigurationCustodyRecord(
         prime_id="PRIME-001",
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
@@ -53,15 +63,13 @@ def test_installing_a_valid_space_pack_does_not_clear_quarantine_by_itself():
     )
     disposition, reasons = evaluate_pack_activation(record, _space_pack())
     assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
-    assert any("quarantined" in reason for reason in reasons)
     assert any("TARGET_ENVIRONMENT_ACCEPTANCE" in reason for reason in reasons)
 
 
-def test_complete_checks_without_authorization_record_remain_quarantined():
+def test_complete_checks_without_authorization_remain_quarantined():
     record = PrimeConfigurationCustodyRecord(
         prime_id="PRIME-001",
         state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
-        last_environment=PrimeEnvironment.SUBTERRA,
         completed_requalification_checks=list(REQUALIFICATION_CHECKS),
     )
     disposition, reasons = evaluate_pack_activation(record, _space_pack())
@@ -69,14 +77,8 @@ def test_complete_checks_without_authorization_record_remain_quarantined():
     assert any("authorization record" in reason for reason in reasons)
 
 
-def test_complete_requalification_authorization_and_valid_pack_allow_release_to_ready():
-    record = PrimeConfigurationCustodyRecord(
-        prime_id="PRIME-001",
-        state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
-        last_environment=PrimeEnvironment.SUBTERRA,
-        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
-        requalification_release_authorization_id="AUTH-2026-0001",
-    )
+def test_target_bound_authorization_and_valid_pack_allow_release():
+    record = _authorized_record()
     released, disposition, reasons = release_from_quarantine(record, _space_pack())
     assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
     assert released.state == PrimeCustodyState.READY
@@ -84,16 +86,25 @@ def test_complete_requalification_authorization_and_valid_pack_allow_release_to_
     assert reasons
 
 
-def test_invalid_target_environment_qualification_fails_closed_even_after_checks():
-    record = PrimeConfigurationCustodyRecord(
-        prime_id="PRIME-001",
-        state=PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION,
-        last_environment=PrimeEnvironment.HADAL,
-        completed_requalification_checks=list(REQUALIFICATION_CHECKS),
-        requalification_release_authorization_id="AUTH-2026-0002",
+def test_authorization_target_mismatch_fails_closed():
+    record = _authorized_record(
+        requalification_release_target_environment=PrimeEnvironment.AERO
     )
+    disposition, reasons = evaluate_pack_activation(record, _space_pack())
+    assert disposition == PrimeActivationDisposition.DENIED
+    assert any("target environment" in reason for reason in reasons)
+
+
+def test_authorization_without_signing_key_binding_fails_closed():
+    record = _authorized_record(requalification_release_key_id=None)
+    disposition, reasons = evaluate_pack_activation(record, _space_pack())
+    assert disposition == PrimeActivationDisposition.DENIED
+    assert any("signing key" in reason for reason in reasons)
+
+
+def test_invalid_target_environment_qualification_fails_closed():
     disposition, reasons = evaluate_pack_activation(
-        record,
+        _authorized_record(),
         _space_pack(target_environment_qualification_valid=False),
     )
     assert disposition == PrimeActivationDisposition.DENIED

--- a/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_configuration_custody.py
@@ -77,12 +77,14 @@ def test_complete_checks_without_authorization_remain_quarantined():
     assert any("authorization record" in reason for reason in reasons)
 
 
-def test_target_bound_authorization_and_valid_pack_allow_release():
+def test_target_bound_authorization_and_valid_pack_allow_release_and_clear_one_time_binding():
     record = _authorized_record()
     released, disposition, reasons = release_from_quarantine(record, _space_pack())
     assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
     assert released.state == PrimeCustodyState.READY
-    assert released.requalification_release_authorization_id == "AUTH-2026-0001"
+    assert released.requalification_release_authorization_id is None
+    assert released.requalification_release_target_environment is None
+    assert released.requalification_release_key_id is None
     assert reasons
 
 

--- a/deployments/sara_verified_local_v1/tests/test_prime_passport.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_passport.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from worldshepherd_sara.prime_configuration_custody import (
@@ -15,11 +17,15 @@ from worldshepherd_sara.prime_passport import (
     PrimePackActivationRequest,
     PrimeRequalificationEvidenceRequest,
     activate_pack,
+    apply_verified_requalification_authorization,
     complete_mission,
     create_passport,
     load_passport,
     passport_registry_patch,
     update_requalification_evidence,
+)
+from worldshepherd_sara.prime_sentinel_authorization import (
+    VerifiedPrimeSentinelAuthorization,
 )
 
 
@@ -33,73 +39,21 @@ def _qualified_space_pack() -> PrimeMissionPackEvidence:
     )
 
 
-def test_passport_round_trips_through_registry_namespace():
-    passport = create_passport(
+def _verified_authorization() -> VerifiedPrimeSentinelAuthorization:
+    now = datetime.now(timezone.utc)
+    return VerifiedPrimeSentinelAuthorization(
+        authorization_id="AUTH-REQUAL-001",
         prime_id="PRIME-001",
-        hardware_revision="HW-A",
-        software_revision="SW-A",
-        evidence_refs=["ECHO:BUILD:001"],
-    )
-    registry = passport_registry_patch({}, passport)
-    restored = load_passport(registry, "PRIME-001")
-    assert restored == passport
-
-
-def test_hazardous_mission_clears_pack_and_enters_quarantine_with_provenance():
-    passport = create_passport(
-        prime_id="PRIME-001",
-        hardware_revision="HW-A",
-        software_revision="SW-A",
-    ).model_copy(update={"installed_pack": _qualified_space_pack()})
-
-    updated, event = complete_mission(
-        passport,
-        PrimeMissionCompletionRequest(
-            environment=PrimeEnvironment.SUBTERRA,
-            evidence_refs=["ECHO:MISSION:SUBTERRA:001"],
-        ),
+        target_environment=PrimeEnvironment.SPACE,
+        key_id="PS-K1",
+        key_fingerprint_sha256="a" * 64,
+        nonce="nonce-0123456789abcdef",
+        issued_at=now,
+        expires_at=now + timedelta(minutes=5),
     )
 
-    assert updated.custody.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
-    assert updated.installed_pack is None
-    assert event["schema"] == PRIME_CUSTODY_PROVENANCE_SCHEMA
-    assert event["previous_state"] == "READY"
-    assert event["new_state"] == "QUARANTINED_FOR_REQUALIFICATION"
-    assert event["provenance_channel"] == "SARA_AUDIT_FOR_ECHO_INGEST"
 
-
-def test_complete_evidence_without_authorization_does_not_activate_pack():
-    passport = create_passport(
-        prime_id="PRIME-001",
-        hardware_revision="HW-A",
-        software_revision="SW-A",
-    )
-    passport, _ = complete_mission(
-        passport,
-        PrimeMissionCompletionRequest(environment=PrimeEnvironment.HADAL),
-    )
-    passport, _ = update_requalification_evidence(
-        passport,
-        PrimeRequalificationEvidenceRequest(
-            completed_checks=list(REQUALIFICATION_CHECKS),
-            evidence_refs=["ECHO:REQUAL:001"],
-        ),
-    )
-
-    updated, disposition, reasons, event = activate_pack(
-        passport,
-        PrimePackActivationRequest(pack=_qualified_space_pack()),
-    )
-
-    assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
-    assert updated == passport
-    assert updated.custody.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
-    assert updated.installed_pack is None
-    assert any("authorization" in reason for reason in reasons)
-    assert event["details"]["disposition"] == "REQUALIFICATION_REQUIRED"
-
-
-def test_authorized_complete_requalification_releases_and_installs_pack():
+def _quarantined_complete_passport():
     passport = create_passport(
         prime_id="PRIME-001",
         hardware_revision="HW-A",
@@ -109,14 +63,69 @@ def test_authorized_complete_requalification_releases_and_installs_pack():
         passport,
         PrimeMissionCompletionRequest(environment=PrimeEnvironment.SUBTERRA),
     )
-    passport, evidence_event = update_requalification_evidence(
+    passport, _ = update_requalification_evidence(
         passport,
         PrimeRequalificationEvidenceRequest(
             completed_checks=list(REQUALIFICATION_CHECKS),
             evidence_refs=["ECHO:REQUAL:002"],
-            release_authorization_id="AUTH-REQUAL-001",
         ),
     )
+    return passport
+
+
+def test_passport_round_trips_through_registry_namespace():
+    passport = create_passport(
+        prime_id="PRIME-001",
+        hardware_revision="HW-A",
+        software_revision="SW-A",
+        evidence_refs=["ECHO:BUILD:001"],
+    )
+    registry = passport_registry_patch({}, passport)
+    assert load_passport(registry, "PRIME-001") == passport
+
+
+def test_hazardous_mission_clears_pack_and_enters_quarantine_with_provenance():
+    passport = create_passport(
+        prime_id="PRIME-001",
+        hardware_revision="HW-A",
+        software_revision="SW-A",
+    ).model_copy(update={"installed_pack": _qualified_space_pack()})
+    updated, event = complete_mission(
+        passport,
+        PrimeMissionCompletionRequest(
+            environment=PrimeEnvironment.SUBTERRA,
+            evidence_refs=["ECHO:MISSION:SUBTERRA:001"],
+        ),
+    )
+    assert updated.custody.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION
+    assert updated.installed_pack is None
+    assert event["schema"] == PRIME_CUSTODY_PROVENANCE_SCHEMA
+    assert event["previous_state"] == "READY"
+    assert event["new_state"] == "QUARANTINED_FOR_REQUALIFICATION"
+
+
+def test_complete_evidence_without_authorization_does_not_activate_pack():
+    passport = _quarantined_complete_passport()
+    updated, disposition, reasons, event = activate_pack(
+        passport,
+        PrimePackActivationRequest(pack=_qualified_space_pack()),
+    )
+    assert disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED
+    assert updated == passport
+    assert any("authorization" in reason for reason in reasons)
+    assert event["details"]["disposition"] == "REQUALIFICATION_REQUIRED"
+
+
+def test_verified_authorization_binds_target_and_key_then_allows_release():
+    passport = _quarantined_complete_passport()
+    passport, authorization_event = apply_verified_requalification_authorization(
+        passport, _verified_authorization()
+    )
+    assert passport.custody.requalification_release_authorization_id == "AUTH-REQUAL-001"
+    assert passport.custody.requalification_release_target_environment == PrimeEnvironment.SPACE
+    assert passport.custody.requalification_release_key_id == "PS-K1"
+    assert authorization_event["details"]["key_id"] == "PS-K1"
+
     updated, disposition, reasons, activation_event = activate_pack(
         passport,
         PrimePackActivationRequest(
@@ -124,15 +133,48 @@ def test_authorized_complete_requalification_releases_and_installs_pack():
             evidence_refs=["ECHO:PACK:SPACE:001"],
         ),
     )
-
     assert disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED
     assert reasons
     assert updated.custody.state == PrimeCustodyState.READY
     assert updated.installed_pack is not None
-    assert updated.installed_pack.pack_id == "SPACE-PACK-001"
     assert updated.last_transition_id == activation_event["transition_id"]
-    assert evidence_event["details"]["authorization_id"] == "AUTH-REQUAL-001"
-    assert activation_event["details"]["authorization_id"] == "AUTH-REQUAL-001"
+
+
+def test_requalification_evidence_change_clears_prior_authorization():
+    passport = _quarantined_complete_passport()
+    passport, _ = apply_verified_requalification_authorization(
+        passport, _verified_authorization()
+    )
+    updated, event = update_requalification_evidence(
+        passport,
+        PrimeRequalificationEvidenceRequest(
+            completed_checks=list(REQUALIFICATION_CHECKS),
+            evidence_refs=["ECHO:REQUAL:CHANGED"],
+        ),
+    )
+    assert updated.custody.requalification_release_authorization_id is None
+    assert updated.custody.requalification_release_target_environment is None
+    assert updated.custody.requalification_release_key_id is None
+    assert event["details"]["prior_authorization_cleared"] is True
+
+
+def test_authorization_cannot_be_applied_before_evidence_is_complete():
+    passport = create_passport(
+        prime_id="PRIME-001", hardware_revision="HW-A", software_revision="SW-A"
+    )
+    passport, _ = complete_mission(
+        passport, PrimeMissionCompletionRequest(environment=PrimeEnvironment.HADAL)
+    )
+    with pytest.raises(ValueError, match="incomplete"):
+        apply_verified_requalification_authorization(passport, _verified_authorization())
+
+
+def test_arbitrary_authorization_id_is_not_accepted_as_requalification_evidence():
+    with pytest.raises(ValueError):
+        PrimeRequalificationEvidenceRequest(
+            completed_checks=list(REQUALIFICATION_CHECKS),
+            release_authorization_id="UNVERIFIED-BYPASS",
+        )
 
 
 def test_unknown_requalification_check_is_rejected():

--- a/deployments/sara_verified_local_v1/tests/test_prime_passport_api.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_passport_api.py
@@ -1,10 +1,52 @@
 from __future__ import annotations
 
+import base64
+from datetime import datetime, timedelta, timezone
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 from worldshepherd_sara.prime_configuration_custody import REQUALIFICATION_CHECKS
+from worldshepherd_sara.prime_sentinel_authorization import (
+    PrimeSentinelAuthorizationAssertion,
+    PrimeSentinelVerifier,
+    canonical_authorization_message,
+)
 
 
 def auth(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _configure_sentinel(client):
+    private = Ed25519PrivateKey.generate()
+    client.app.state.prime_sentinel_verifier = PrimeSentinelVerifier(
+        public_keys_b64url={"PS-K1": _b64url(private.public_key().public_bytes_raw())}
+    )
+    return private
+
+
+def _signed_authorization(private: Ed25519PrivateKey, **overrides) -> dict[str, object]:
+    now = datetime.now(timezone.utc)
+    values = {
+        "key_id": "PS-K1",
+        "authorization_id": "AUTH-REQUAL-001",
+        "prime_id": "PRIME-001",
+        "target_environment": "SPACE",
+        "issued_at": now,
+        "expires_at": now + timedelta(minutes=5),
+        "nonce": "nonce-0123456789abcdef",
+        "signature_b64url": _b64url(b"0" * 64),
+    }
+    values.update(overrides)
+    assertion = PrimeSentinelAuthorizationAssertion(**values)
+    signature = private.sign(canonical_authorization_message(assertion))
+    return assertion.model_copy(
+        update={"signature_b64url": _b64url(signature)}
+    ).model_dump(mode="json")
 
 
 def _qualified_space_pack() -> dict[str, object]:
@@ -41,29 +83,23 @@ def test_prime_passport_endpoints_are_admin_only(client, tokens):
     assert response.status_code == 403
 
 
-def test_prime_passport_full_quarantine_requalification_activation_lifecycle(client, tokens):
+def test_signed_sentinel_quarantine_requalification_activation_lifecycle(client, tokens):
     _, admin = tokens
+    private = _configure_sentinel(client)
 
     created = _create_passport(client, admin)
     assert created.status_code == 201
     assert created.json()["passport"]["custody"]["state"] == "READY"
-    assert created.json()["provenance"]["provenance_channel"] == "SARA_AUDIT_FOR_ECHO_INGEST"
-
-    duplicate = _create_passport(client, admin)
-    assert duplicate.status_code == 409
 
     mission = client.post(
         "/admin/prime/PRIME-001/mission-complete",
         headers=auth(admin),
-        json={
-            "environment": "HADAL",
-            "evidence_refs": ["ECHO:MISSION:HADAL:001"],
-        },
+        json={"environment": "HADAL", "evidence_refs": ["ECHO:MISSION:HADAL:001"]},
     )
     assert mission.status_code == 200
     assert mission.json()["passport"]["custody"]["state"] == "QUARANTINED_FOR_REQUALIFICATION"
 
-    evidence_only = client.patch(
+    evidence = client.patch(
         "/admin/prime/PRIME-001/requalification",
         headers=auth(admin),
         json={
@@ -71,7 +107,17 @@ def test_prime_passport_full_quarantine_requalification_activation_lifecycle(cli
             "evidence_refs": ["ECHO:REQUAL:001"],
         },
     )
-    assert evidence_only.status_code == 200
+    assert evidence.status_code == 200
+
+    bypass = client.patch(
+        "/admin/prime/PRIME-001/requalification",
+        headers=auth(admin),
+        json={
+            "completed_checks": list(REQUALIFICATION_CHECKS),
+            "release_authorization_id": "UNVERIFIED-BYPASS",
+        },
+    )
+    assert bypass.status_code == 422
 
     blocked = client.post(
         "/admin/prime/PRIME-001/activate-pack",
@@ -80,18 +126,25 @@ def test_prime_passport_full_quarantine_requalification_activation_lifecycle(cli
     )
     assert blocked.status_code == 409
     assert blocked.json()["disposition"] == "REQUALIFICATION_REQUIRED"
-    assert blocked.json()["passport"]["installed_pack"] is None
 
-    authorized = client.patch(
-        "/admin/prime/PRIME-001/requalification",
+    assertion = _signed_authorization(private)
+    authorized = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
         headers=auth(admin),
-        json={
-            "completed_checks": list(REQUALIFICATION_CHECKS),
-            "evidence_refs": ["ECHO:REQUAL:002"],
-            "release_authorization_id": "AUTH-REQUAL-001",
-        },
+        json=assertion,
     )
     assert authorized.status_code == 200
+    custody = authorized.json()["passport"]["custody"]
+    assert custody["requalification_release_authorization_id"] == "AUTH-REQUAL-001"
+    assert custody["requalification_release_target_environment"] == "SPACE"
+    assert custody["requalification_release_key_id"] == "PS-K1"
+
+    replay = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
+        headers=auth(admin),
+        json=assertion,
+    )
+    assert replay.status_code == 403
 
     activated = client.post(
         "/admin/prime/PRIME-001/activate-pack",
@@ -102,35 +155,82 @@ def test_prime_passport_full_quarantine_requalification_activation_lifecycle(cli
     body = activated.json()
     assert body["disposition"] == "ACTIVATION_ALLOWED"
     assert body["passport"]["custody"]["state"] == "READY"
+    assert body["passport"]["custody"]["requalification_release_authorization_id"] is None
     assert body["passport"]["installed_pack"]["pack_id"] == "SPACE-PACK-001"
 
-    fetched = client.get(
-        "/admin/prime/PRIME-001/passport",
-        headers=auth(admin),
-    )
-    assert fetched.status_code == 200
-    assert fetched.json()["passport"]["installed_pack"]["pack_id"] == "SPACE-PACK-001"
-
     registry = client.get("/admin/registry", headers=auth(admin)).json()["registry"]
-    assert registry["PRIME_DIGITAL_PASSPORTS"]["PRIME-001"]["custody"]["state"] == "READY"
+    auth_record = registry["PRIME_SENTINEL_AUTHORIZATIONS"]["AUTH-REQUAL-001"]
+    assert auth_record["status"] == "CONSUMED"
+    assert auth_record["consumed_transition_id"] == body["provenance"]["transition_id"]
 
-    audit = client.get("/v1/audit?limit=100", headers=auth(admin))
-    assert audit.status_code == 200
-    provenance = [
-        item for item in audit.json()["records"]
-        if item.get("event") == "prime_custody_provenance"
-    ]
-    assert len(provenance) >= 5
-    assert all(
-        item["payload"]["schema"] == "WS-ECHO-PRIME-CUSTODY-V1"
-        for item in provenance
+    audit = client.get("/v1/audit?limit=100", headers=auth(admin)).json()["records"]
+    assert any(
+        item.get("event") == "prime_sentinel_authorization_rejected"
+        for item in audit
+    )
+    assert any(
+        item.get("event") == "prime_custody_provenance"
+        and item["payload"].get("action") == "REQUALIFICATION_AUTHORIZATION_VERIFIED"
+        for item in audit
     )
 
 
-def test_denied_pack_activation_is_audited_but_does_not_mutate_passport(client, tokens):
+def test_tampered_signed_assertion_is_rejected_and_passport_remains_quarantined(client, tokens):
+    _, admin = tokens
+    private = _configure_sentinel(client)
+    assert _create_passport(client, admin).status_code == 201
+    assert client.post(
+        "/admin/prime/PRIME-001/mission-complete",
+        headers=auth(admin),
+        json={"environment": "SUBTERRA"},
+    ).status_code == 200
+    assert client.patch(
+        "/admin/prime/PRIME-001/requalification",
+        headers=auth(admin),
+        json={"completed_checks": list(REQUALIFICATION_CHECKS)},
+    ).status_code == 200
+
+    assertion = _signed_authorization(private)
+    assertion["target_environment"] = "AERO"
+    rejected = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
+        headers=auth(admin),
+        json=assertion,
+    )
+    assert rejected.status_code == 403
+    passport = client.get(
+        "/admin/prime/PRIME-001/passport", headers=auth(admin)
+    ).json()["passport"]
+    assert passport["custody"]["state"] == "QUARANTINED_FOR_REQUALIFICATION"
+    assert passport["custody"]["requalification_release_authorization_id"] is None
+
+
+def test_authorization_route_fails_closed_when_no_public_keys_are_configured(client, tokens):
+    _, admin = tokens
+    private = Ed25519PrivateKey.generate()
+    assert _create_passport(client, admin).status_code == 201
+    response = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
+        headers=auth(admin),
+        json=_signed_authorization(private),
+    )
+    assert response.status_code == 503
+
+
+def test_protected_registry_namespaces_cannot_be_patched_through_generic_admin_api(client, tokens):
+    _, admin = tokens
+    for key in ("PRIME_DIGITAL_PASSPORTS", "PRIME_SENTINEL_AUTHORIZATIONS"):
+        response = client.patch(
+            "/admin/registry",
+            headers=auth(admin),
+            json={"values": {key: {}}},
+        )
+        assert response.status_code == 403
+
+
+def test_denied_pack_activation_is_audited_but_does_not_mutate_ready_passport(client, tokens):
     _, admin = tokens
     assert _create_passport(client, admin).status_code == 201
-
     before = client.get(
         "/admin/prime/PRIME-001/passport", headers=auth(admin)
     ).json()["passport"]
@@ -149,10 +249,3 @@ def test_denied_pack_activation_is_audited_but_does_not_mutate_passport(client, 
         "/admin/prime/PRIME-001/passport", headers=auth(admin)
     ).json()["passport"]
     assert after == before
-
-    audit = client.get("/v1/audit?limit=50", headers=auth(admin)).json()["records"]
-    events = [item for item in audit if item.get("event") == "prime_custody_provenance"]
-    assert any(
-        item["payload"]["details"].get("disposition") == "DENIED"
-        for item in events
-    )

--- a/deployments/sara_verified_local_v1/tests/test_prime_sentinel_authorization.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_sentinel_authorization.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from worldshepherd_sara.prime_configuration_custody import PrimeEnvironment
+from worldshepherd_sara.prime_sentinel_authorization import (
+    PrimeSentinelAuthorizationAssertion,
+    PrimeSentinelAuthorizationError,
+    PrimeSentinelVerifier,
+    assert_recorded_authorization_usable,
+    canonical_authorization_message,
+    consumed_authorization_registry_patch,
+    verified_authorization_registry_patch,
+)
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _keys():
+    private = Ed25519PrivateKey.generate()
+    public_b64 = _b64url(private.public_key().public_bytes_raw())
+    verifier = PrimeSentinelVerifier(public_keys_b64url={"PS-K1": public_b64})
+    return private, verifier
+
+
+def _signed_assertion(
+    private: Ed25519PrivateKey,
+    *,
+    now: datetime,
+    authorization_id: str = "AUTH-001",
+    nonce: str = "nonce-0123456789abcdef",
+    prime_id: str = "PRIME-001",
+    target_environment: PrimeEnvironment = PrimeEnvironment.SPACE,
+    issued_at: datetime | None = None,
+    expires_at: datetime | None = None,
+) -> PrimeSentinelAuthorizationAssertion:
+    assertion = PrimeSentinelAuthorizationAssertion(
+        key_id="PS-K1",
+        authorization_id=authorization_id,
+        prime_id=prime_id,
+        target_environment=target_environment,
+        issued_at=issued_at or now,
+        expires_at=expires_at or now + timedelta(minutes=5),
+        nonce=nonce,
+        signature_b64url=_b64url(b"0" * 64),
+    )
+    signature = private.sign(canonical_authorization_message(assertion))
+    return assertion.model_copy(update={"signature_b64url": _b64url(signature)})
+
+
+def test_valid_ed25519_assertion_verifies_with_public_key_only():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    assertion = _signed_assertion(private, now=now)
+    verified = verifier.verify(assertion, now=now)
+    assert verified.authorization_id == "AUTH-001"
+    assert verified.prime_id == "PRIME-001"
+    assert verified.target_environment == PrimeEnvironment.SPACE
+    assert verified.key_id == "PS-K1"
+    assert len(verified.key_fingerprint_sha256) == 64
+
+
+def test_tampered_signed_field_fails_signature_verification():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    assertion = _signed_assertion(private, now=now)
+    tampered = assertion.model_copy(update={"prime_id": "PRIME-OTHER"})
+    with pytest.raises(PrimeSentinelAuthorizationError, match="signature"):
+        verifier.verify(tampered, now=now)
+
+
+def test_unknown_and_revoked_keys_fail_closed():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    assertion = _signed_assertion(private, now=now)
+    unknown = assertion.model_copy(update={"key_id": "PS-UNKNOWN"})
+    with pytest.raises(PrimeSentinelAuthorizationError, match="unknown"):
+        verifier.verify(unknown, now=now)
+
+    revoked = PrimeSentinelVerifier(
+        public_keys_b64url={"PS-K1": _b64url(private.public_key().public_bytes_raw())},
+        revoked_key_ids={"PS-K1"},
+    )
+    with pytest.raises(PrimeSentinelAuthorizationError, match="revoked"):
+        revoked.verify(assertion, now=now)
+
+
+def test_expired_and_future_assertions_fail_closed():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    expired = _signed_assertion(
+        private,
+        now=now,
+        issued_at=now - timedelta(minutes=10),
+        expires_at=now - timedelta(minutes=1),
+    )
+    with pytest.raises(PrimeSentinelAuthorizationError, match="expired"):
+        verifier.verify(expired, now=now)
+
+    future = _signed_assertion(
+        private,
+        now=now,
+        issued_at=now + timedelta(minutes=2),
+        expires_at=now + timedelta(minutes=7),
+    )
+    with pytest.raises(PrimeSentinelAuthorizationError, match="future"):
+        verifier.verify(future, now=now)
+
+
+def test_assertion_lifetime_over_15_minutes_is_rejected_by_schema():
+    private, _ = _keys()
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValueError, match="15 minutes"):
+        _signed_assertion(
+            private,
+            now=now,
+            issued_at=now,
+            expires_at=now + timedelta(minutes=16),
+        )
+
+
+def test_authorization_id_and_nonce_replay_are_rejected():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    first = verifier.verify(_signed_assertion(private, now=now), now=now)
+    registry = verified_authorization_registry_patch({}, first)
+
+    replay_id = verifier.verify(
+        _signed_assertion(
+            private,
+            now=now,
+            authorization_id="AUTH-001",
+            nonce="nonce-different-0123456",
+        ),
+        now=now,
+    )
+    with pytest.raises(PrimeSentinelAuthorizationError, match="authorization_id"):
+        verified_authorization_registry_patch(registry, replay_id)
+
+    replay_nonce = verifier.verify(
+        _signed_assertion(
+            private,
+            now=now,
+            authorization_id="AUTH-002",
+            nonce="nonce-0123456789abcdef",
+        ),
+        now=now,
+    )
+    with pytest.raises(PrimeSentinelAuthorizationError, match="nonce"):
+        verified_authorization_registry_patch(registry, replay_nonce)
+
+
+def test_recorded_authorization_must_match_prime_target_not_be_revoked_and_be_unexpired():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    verified = verifier.verify(_signed_assertion(private, now=now), now=now)
+    registry = verified_authorization_registry_patch({}, verified)
+
+    entry = assert_recorded_authorization_usable(
+        registry,
+        authorization_id="AUTH-001",
+        prime_id="PRIME-001",
+        target_environment=PrimeEnvironment.SPACE,
+        verifier=verifier,
+        now=now,
+    )
+    assert entry["status"] == "VERIFIED"
+
+    with pytest.raises(PrimeSentinelAuthorizationError, match="target environment"):
+        assert_recorded_authorization_usable(
+            registry,
+            authorization_id="AUTH-001",
+            prime_id="PRIME-001",
+            target_environment=PrimeEnvironment.AERO,
+            verifier=verifier,
+            now=now,
+        )
+
+    with pytest.raises(PrimeSentinelAuthorizationError, match="expired"):
+        assert_recorded_authorization_usable(
+            registry,
+            authorization_id="AUTH-001",
+            prime_id="PRIME-001",
+            target_environment=PrimeEnvironment.SPACE,
+            verifier=verifier,
+            now=now + timedelta(minutes=6),
+        )
+
+
+def test_authorization_is_one_time_consumable():
+    private, verifier = _keys()
+    now = datetime.now(timezone.utc)
+    verified = verifier.verify(_signed_assertion(private, now=now), now=now)
+    registry = verified_authorization_registry_patch({}, verified)
+    consumed = consumed_authorization_registry_patch(
+        registry,
+        authorization_id="AUTH-001",
+        transition_id="PRIME-CUSTODY-123",
+        consumed_at=now,
+    )
+    entry = consumed["PRIME_SENTINEL_AUTHORIZATIONS"]["AUTH-001"]
+    assert entry["status"] == "CONSUMED"
+    assert entry["consumed_transition_id"] == "PRIME-CUSTODY-123"
+    with pytest.raises(PrimeSentinelAuthorizationError, match="cannot be consumed"):
+        consumed_authorization_registry_patch(
+            consumed,
+            authorization_id="AUTH-001",
+            transition_id="PRIME-CUSTODY-456",
+            consumed_at=now,
+        )

--- a/deployments/sara_verified_local_v1/tests/test_prime_sentinel_supersession.py
+++ b/deployments/sara_verified_local_v1/tests/test_prime_sentinel_supersession.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timedelta, timezone
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from worldshepherd_sara.prime_configuration_custody import REQUALIFICATION_CHECKS
+from worldshepherd_sara.prime_sentinel_authorization import (
+    PrimeSentinelAuthorizationAssertion,
+    PrimeSentinelVerifier,
+    canonical_authorization_message,
+)
+
+
+def auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _configure_sentinel(client):
+    private = Ed25519PrivateKey.generate()
+    client.app.state.prime_sentinel_verifier = PrimeSentinelVerifier(
+        public_keys_b64url={"PS-K1": _b64url(private.public_key().public_bytes_raw())}
+    )
+    return private
+
+
+def _signed_authorization(private: Ed25519PrivateKey, *, authorization_id: str = "AUTH-SUPERSEDE-001") -> dict[str, object]:
+    now = datetime.now(timezone.utc)
+    assertion = PrimeSentinelAuthorizationAssertion(
+        key_id="PS-K1",
+        authorization_id=authorization_id,
+        prime_id="PRIME-001",
+        target_environment="SPACE",
+        issued_at=now,
+        expires_at=now + timedelta(minutes=5),
+        nonce=f"nonce-{authorization_id}-0123456789abcdef",
+        signature_b64url=_b64url(b"0" * 64),
+    )
+    signature = private.sign(canonical_authorization_message(assertion))
+    return assertion.model_copy(
+        update={"signature_b64url": _b64url(signature)}
+    ).model_dump(mode="json")
+
+
+def _create_quarantined_requalified_passport(client, admin: str):
+    created = client.post(
+        "/admin/prime/PRIME-001/passport",
+        headers=auth(admin),
+        json={"hardware_revision": "HW-A", "software_revision": "SW-A"},
+    )
+    assert created.status_code == 201
+    mission = client.post(
+        "/admin/prime/PRIME-001/mission-complete",
+        headers=auth(admin),
+        json={"environment": "SUBTERRA"},
+    )
+    assert mission.status_code == 200
+    evidence = client.patch(
+        "/admin/prime/PRIME-001/requalification",
+        headers=auth(admin),
+        json={"completed_checks": list(REQUALIFICATION_CHECKS)},
+    )
+    assert evidence.status_code == 200
+
+
+def _qualified_space_pack() -> dict[str, object]:
+    return {
+        "pack": {
+            "pack_id": "SPACE-PACK-001",
+            "target_environment": "SPACE",
+            "authenticated": True,
+            "compatible_with_prime": True,
+            "target_environment_qualification_valid": True,
+        }
+    }
+
+
+def test_requalification_evidence_change_supersedes_pending_authorization_atomically(client, tokens):
+    _, admin = tokens
+    private = _configure_sentinel(client)
+    _create_quarantined_requalified_passport(client, admin)
+
+    authorized = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
+        headers=auth(admin),
+        json=_signed_authorization(private),
+    )
+    assert authorized.status_code == 200
+    assert authorized.json()["passport"]["custody"]["requalification_release_authorization_id"] == "AUTH-SUPERSEDE-001"
+
+    changed = client.patch(
+        "/admin/prime/PRIME-001/requalification",
+        headers=auth(admin),
+        json={
+            "completed_checks": list(REQUALIFICATION_CHECKS),
+            "evidence_refs": ["ECHO:REQUAL:CHANGED:001"],
+        },
+    )
+    assert changed.status_code == 200
+    body = changed.json()
+    assert body["passport"]["custody"]["requalification_release_authorization_id"] is None
+    assert body["provenance"]["details"]["superseded_authorization_id"] == "AUTH-SUPERSEDE-001"
+
+    registry = client.get("/admin/registry", headers=auth(admin)).json()["registry"]
+    record = registry["PRIME_SENTINEL_AUTHORIZATIONS"]["AUTH-SUPERSEDE-001"]
+    assert record["status"] == "SUPERSEDED"
+    assert record["superseded_reason"] == "REQUALIFICATION_EVIDENCE_CHANGED"
+    assert record["superseded_transition_id"] == body["provenance"]["transition_id"]
+
+    blocked = client.post(
+        "/admin/prime/PRIME-001/activate-pack",
+        headers=auth(admin),
+        json=_qualified_space_pack(),
+    )
+    assert blocked.status_code == 409
+    assert blocked.json()["disposition"] == "REQUALIFICATION_REQUIRED"
+
+
+def test_new_mission_supersedes_pending_authorization_and_preserves_quarantine(client, tokens):
+    _, admin = tokens
+    private = _configure_sentinel(client)
+    _create_quarantined_requalified_passport(client, admin)
+
+    authorized = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
+        headers=auth(admin),
+        json=_signed_authorization(private, authorization_id="AUTH-MISSION-001"),
+    )
+    assert authorized.status_code == 200
+
+    mission = client.post(
+        "/admin/prime/PRIME-001/mission-complete",
+        headers=auth(admin),
+        json={"environment": "HADAL", "evidence_refs": ["ECHO:MISSION:HADAL:NEW"]},
+    )
+    assert mission.status_code == 200
+    body = mission.json()
+    custody = body["passport"]["custody"]
+    assert custody["state"] == "QUARANTINED_FOR_REQUALIFICATION"
+    assert custody["requalification_release_authorization_id"] is None
+    assert body["provenance"]["details"]["superseded_authorization_id"] == "AUTH-MISSION-001"
+
+    registry = client.get("/admin/registry", headers=auth(admin)).json()["registry"]
+    record = registry["PRIME_SENTINEL_AUTHORIZATIONS"]["AUTH-MISSION-001"]
+    assert record["status"] == "SUPERSEDED"
+    assert record["superseded_reason"] == "MISSION_COMPLETED"
+    assert record["superseded_transition_id"] == body["provenance"]["transition_id"]
+
+
+def test_removed_signing_key_blocks_activation_of_previously_verified_authorization(client, tokens):
+    _, admin = tokens
+    private = _configure_sentinel(client)
+    _create_quarantined_requalified_passport(client, admin)
+
+    authorized = client.post(
+        "/admin/prime/PRIME-001/requalification/authorize",
+        headers=auth(admin),
+        json=_signed_authorization(private, authorization_id="AUTH-ROTATE-001"),
+    )
+    assert authorized.status_code == 200
+
+    replacement_private = Ed25519PrivateKey.generate()
+    client.app.state.prime_sentinel_verifier = PrimeSentinelVerifier(
+        public_keys_b64url={
+            "PS-K2": _b64url(replacement_private.public_key().public_bytes_raw())
+        }
+    )
+
+    blocked = client.post(
+        "/admin/prime/PRIME-001/activate-pack",
+        headers=auth(admin),
+        json=_qualified_space_pack(),
+    )
+    assert blocked.status_code == 409
+    assert blocked.json()["disposition"] == "REQUALIFICATION_REQUIRED"
+    assert any("no longer configured" in reason for reason in blocked.json()["reasons"])
+
+    passport = client.get(
+        "/admin/prime/PRIME-001/passport", headers=auth(admin)
+    ).json()["passport"]
+    assert passport["custody"]["state"] == "QUARANTINED_FOR_REQUALIFICATION"
+    assert passport["installed_pack"] is None

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/app.py
@@ -15,8 +15,18 @@ from .auth import Role, require_admin, resolve_role, validate_runtime_secrets
 from .hmaa_storage import HMAAEvidenceStore
 from .limits import MAX_REQUEST_BYTES
 from .models import AuditRecord, RegistryPatch, RelayRequest, RelayResponse
+from .prime_passport import PRIME_PASSPORTS_REGISTRY_KEY
 from .prime_passport_api import router as prime_passport_router
+from .prime_sentinel_authorization import (
+    PRIME_SENTINEL_AUTHZ_REGISTRY_KEY,
+    PrimeSentinelVerifier,
+)
 from .storage import DurableStore
+
+
+PROTECTED_REGISTRY_NAMESPACES = frozenset(
+    {PRIME_PASSPORTS_REGISTRY_KEY, PRIME_SENTINEL_AUTHZ_REGISTRY_KEY}
+)
 
 
 class RequestTooLarge(Exception):
@@ -85,11 +95,16 @@ async def lifespan(app: FastAPI):
     validate_runtime_secrets()
     app.state.store = DurableStore()
     app.state.hmaa_store = HMAAEvidenceStore()
+    app.state.prime_sentinel_verifier = PrimeSentinelVerifier.from_environment()
     app.state.store.append_audit(
         AuditRecord.create(
             event="service_started",
             actor="system",
-            payload={"version": __version__, "mode": os.getenv("SARA_MODE", "local")},
+            payload={
+                "version": __version__,
+                "mode": os.getenv("SARA_MODE", "local"),
+                "prime_sentinel_public_keys_configured": app.state.prime_sentinel_verifier.configured,
+            },
         )
     )
     yield
@@ -129,12 +144,13 @@ def hmaa_store(request: Request) -> HMAAEvidenceStore:
 
 
 @app.get("/health")
-def health() -> dict[str, object]:
+def health(request: Request) -> dict[str, object]:
     return {
         "ok": True,
         "service": "Worldshepherd SARA / SSPADAWANZZ Admin Interface",
         "version": __version__,
         "mode": os.getenv("SARA_MODE", "local"),
+        "prime_sentinel_public_keys_configured": request.app.state.prime_sentinel_verifier.configured,
         "endpoints": {
             "ui": "/ui",
             "liveness": "/livez",
@@ -144,6 +160,7 @@ def health() -> dict[str, object]:
             "hmaa_evidence": "/v1/hmaa/evidence?limit=50",
             "registry": "/admin/registry",
             "prime_passport": "/admin/prime/{prime_id}/passport",
+            "prime_requalification_authorize": "/admin/prime/{prime_id}/requalification/authorize",
             "relay": "/v1/relay",
             "selftest": "/admin/selftest",
         },
@@ -176,7 +193,7 @@ code{color:#9ad5ff} .ok{color:#96e6a1}
 <p class="ok">Local administration interface is online.</p>
 <div class="card"><strong>Authority separation</strong><p>CRE1AWS approves high-impact releases. SSPADAWANZZ operates the local service.</p></div>
 <div class="card"><strong>Operational endpoints</strong><p><code>/health</code>, <code>/v1/relay</code>, <code>/v1/audit</code>, <code>/v1/hmaa/status</code>, <code>/v1/hmaa/evidence</code>, <code>/admin/registry</code>, <code>/admin/prime/{prime_id}/passport</code>, <code>/admin/selftest</code></p></div>
-<div class="card"><strong>Security boundary</strong><p>Tokens are never stored in this page. Use Bearer authentication from an approved local client.</p></div>
+<div class="card"><strong>Security boundary</strong><p>Tokens are never stored in this page. PRIME SENTINEL private signing keys are not stored by SARA.</p></div>
 </body></html>"""
 
 
@@ -267,6 +284,19 @@ def registry_patch(
     role: Annotated[Role, Depends(resolve_role)],
 ) -> dict[str, object]:
     require_admin(role)
+    protected = sorted(PROTECTED_REGISTRY_NAMESPACES.intersection(body.values))
+    if protected:
+        store(request).append_audit(
+            AuditRecord.create(
+                event="protected_registry_patch_rejected",
+                actor=role.value,
+                payload={"keys": protected},
+            )
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Protected registry namespaces must use their governed APIs",
+        )
     try:
         updated = store(request).patch_registry(body.values)
     except ValueError as exc:
@@ -307,14 +337,8 @@ def selftest(
         audit_detail = f"audit append failed: {exc}"
     checks: dict[str, dict[str, Any]] = {
         "persistent_storage": {"ok": storage_ok, "detail": storage_detail},
-        "registry_read": {
-            "ok": registry_ok,
-            "detail": registry_detail,
-        },
-        "audit_append": {
-            "ok": audit_ok,
-            "detail": audit_detail,
-        },
+        "registry_read": {"ok": registry_ok, "detail": registry_detail},
+        "audit_append": {"ok": audit_ok, "detail": audit_detail},
     }
     if audit_ok:
         durable_store.append_audit(

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
@@ -46,6 +46,8 @@ class PrimeConfigurationCustodyRecord(BaseModel):
     last_environment: PrimeEnvironment = PrimeEnvironment.GROUND
     completed_requalification_checks: list[str] = Field(default_factory=list)
     requalification_release_authorization_id: str | None = None
+    requalification_release_target_environment: PrimeEnvironment | None = None
+    requalification_release_key_id: str | None = None
 
 
 class PrimeMissionPackEvidence(BaseModel):
@@ -72,6 +74,8 @@ def apply_post_mission_state(
             "state": post_mission_state(environment),
             "completed_requalification_checks": [],
             "requalification_release_authorization_id": None,
+            "requalification_release_target_environment": None,
+            "requalification_release_key_id": None,
         }
     )
 
@@ -107,6 +111,18 @@ def evaluate_pack_activation(
         if not record.requalification_release_authorization_id:
             return PrimeActivationDisposition.REQUALIFICATION_REQUIRED, [
                 "requalification evidence is complete but no release authorization record is present"
+            ]
+        if record.requalification_release_target_environment is None:
+            return PrimeActivationDisposition.DENIED, [
+                "release authorization is not bound to a target environment"
+            ]
+        if record.requalification_release_target_environment != pack.target_environment:
+            return PrimeActivationDisposition.DENIED, [
+                "release authorization target environment does not match mission pack"
+            ]
+        if not record.requalification_release_key_id:
+            return PrimeActivationDisposition.DENIED, [
+                "release authorization is not bound to a PRIME SENTINEL signing key"
             ]
 
     return PrimeActivationDisposition.ACTIVATION_ALLOWED, [

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_configuration_custody.py
@@ -141,5 +141,12 @@ def release_from_quarantine(
     if record.state != PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION:
         return record, disposition, reasons
 
-    released = record.model_copy(update={"state": PrimeCustodyState.READY})
+    released = record.model_copy(
+        update={
+            "state": PrimeCustodyState.READY,
+            "requalification_release_authorization_id": None,
+            "requalification_release_target_environment": None,
+            "requalification_release_key_id": None,
+        }
+    )
     return released, disposition, reasons

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport.py
@@ -3,18 +3,21 @@ from __future__ import annotations
 from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .prime_configuration_custody import (
     REQUALIFICATION_CHECKS,
     PrimeActivationDisposition,
     PrimeConfigurationCustodyRecord,
+    PrimeCustodyState,
     PrimeEnvironment,
     PrimeMissionPackEvidence,
     apply_post_mission_state,
     evaluate_pack_activation,
+    missing_requalification_checks,
     release_from_quarantine,
 )
+from .prime_sentinel_authorization import VerifiedPrimeSentinelAuthorization
 
 
 PRIME_PASSPORTS_REGISTRY_KEY = "PRIME_DIGITAL_PASSPORTS"
@@ -42,20 +45,22 @@ class PrimeDigitalPassport(BaseModel):
 
 
 class PrimePassportCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     hardware_revision: str = Field(min_length=1, max_length=128)
     software_revision: str = Field(min_length=1, max_length=128)
     evidence_refs: list[str] = Field(default_factory=list)
 
 
 class PrimeMissionCompletionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     environment: PrimeEnvironment
     evidence_refs: list[str] = Field(default_factory=list)
 
 
 class PrimeRequalificationEvidenceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     completed_checks: list[str] = Field(default_factory=list)
     evidence_refs: list[str] = Field(default_factory=list)
-    release_authorization_id: str | None = Field(default=None, min_length=1, max_length=128)
 
     @field_validator("completed_checks")
     @classmethod
@@ -69,6 +74,7 @@ class PrimeRequalificationEvidenceRequest(BaseModel):
 
 
 class PrimePackActivationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     pack: PrimeMissionPackEvidence
     evidence_refs: list[str] = Field(default_factory=list)
 
@@ -164,7 +170,9 @@ def update_requalification_evidence(
     updated_custody = passport.custody.model_copy(
         update={
             "completed_requalification_checks": list(request.completed_checks),
-            "requalification_release_authorization_id": request.release_authorization_id,
+            "requalification_release_authorization_id": None,
+            "requalification_release_target_environment": None,
+            "requalification_release_key_id": None,
         }
     )
     updated = passport.model_copy(
@@ -181,8 +189,50 @@ def update_requalification_evidence(
         previous_state=previous_state,
         new_state=updated.custody.state.value,
         evidence_refs=request.evidence_refs,
-        authorization_id=request.release_authorization_id,
         completed_checks=list(request.completed_checks),
+        prior_authorization_cleared=True,
+    )
+    return updated, payload
+
+
+def apply_verified_requalification_authorization(
+    passport: PrimeDigitalPassport,
+    verified: VerifiedPrimeSentinelAuthorization,
+) -> tuple[PrimeDigitalPassport, dict[str, Any]]:
+    if passport.prime_id != verified.prime_id:
+        raise ValueError("PRIME SENTINEL authorization identity does not match passport")
+    if passport.custody.state != PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION:
+        raise ValueError("PRIME is not quarantined for requalification")
+    missing = missing_requalification_checks(passport.custody)
+    if missing:
+        raise ValueError("requalification evidence is incomplete")
+
+    transition_id = new_transition_id()
+    updated_custody = passport.custody.model_copy(
+        update={
+            "requalification_release_authorization_id": verified.authorization_id,
+            "requalification_release_target_environment": verified.target_environment,
+            "requalification_release_key_id": verified.key_id,
+        }
+    )
+    updated = passport.model_copy(
+        update={
+            "custody": updated_custody,
+            "last_transition_id": transition_id,
+        }
+    )
+    payload = custody_provenance_payload(
+        transition_id=transition_id,
+        prime_id=passport.prime_id,
+        action="REQUALIFICATION_AUTHORIZATION_VERIFIED",
+        previous_state=passport.custody.state.value,
+        new_state=updated.custody.state.value,
+        evidence_refs=[],
+        authorization_id=verified.authorization_id,
+        target_environment=verified.target_environment.value,
+        key_id=verified.key_id,
+        key_fingerprint_sha256=verified.key_fingerprint_sha256,
+        expires_at=verified.expires_at.isoformat(),
     )
     return updated, payload
 
@@ -215,6 +265,7 @@ def activate_pack(
         new_state=updated.custody.state.value,
         evidence_refs=request.evidence_refs,
         authorization_id=passport.custody.requalification_release_authorization_id,
+        authorization_key_id=passport.custody.requalification_release_key_id,
         pack_id=request.pack.pack_id,
         target_environment=request.pack.target_environment.value,
         disposition=disposition.value,

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
@@ -30,6 +30,7 @@ from .prime_sentinel_authorization import (
     PrimeSentinelVerifier,
     assert_recorded_authorization_usable,
     consumed_authorization_registry_patch,
+    superseded_authorization_registry_patch,
     verified_authorization_registry_patch,
 )
 from .storage import DurableStore
@@ -103,6 +104,27 @@ def _append_sentinel_rejection(
     )
 
 
+def _passport_with_superseded_authorization_patch(
+    registry: dict[str, Any],
+    *,
+    prior_authorization_id: str | None,
+    updated_passport: PrimeDigitalPassport,
+    transition_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    patch = passport_registry_patch(registry, updated_passport)
+    if prior_authorization_id:
+        patch.update(
+            superseded_authorization_registry_patch(
+                registry,
+                authorization_id=prior_authorization_id,
+                transition_id=transition_id,
+                reason=reason,
+            )
+        )
+    return patch
+
+
 @router.get("/{prime_id}/passport")
 def get_prime_passport(
     prime_id: str,
@@ -161,8 +183,35 @@ def complete_prime_mission(
     require_admin(role)
     durable_store = _store(request)
     passport = _load_or_404(durable_store, prime_id)
+    prior_authorization_id = passport.custody.requalification_release_authorization_id
     updated, payload = complete_mission(passport, body)
-    _persist(durable_store, updated)
+    registry = durable_store.get_registry()
+
+    try:
+        patch = _passport_with_superseded_authorization_patch(
+            registry,
+            prior_authorization_id=prior_authorization_id,
+            updated_passport=updated,
+            transition_id=payload["transition_id"],
+            reason="MISSION_COMPLETED",
+        )
+    except PrimeSentinelAuthorizationError as exc:
+        # Mission completion is safety-tightening. Preserve quarantine even if the
+        # authorization ledger is inconsistent, and surface the integrity defect.
+        durable_store.patch_registry(passport_registry_patch(registry, updated))
+        _append_sentinel_rejection(
+            durable_store,
+            role,
+            prime_id=prime_id,
+            authorization_id=prior_authorization_id,
+            reason=f"mission quarantine preserved; authorization supersession failed: {exc}",
+        )
+        payload["details"]["authorization_supersession"] = "FAILED_SAFE_QUARANTINE"
+    else:
+        durable_store.patch_registry(patch)
+        if prior_authorization_id:
+            payload["details"]["superseded_authorization_id"] = prior_authorization_id
+
     _append_provenance(durable_store, role, payload)
     return {"passport": updated.model_dump(mode="json"), "provenance": payload}
 
@@ -177,8 +226,34 @@ def patch_prime_requalification(
     require_admin(role)
     durable_store = _store(request)
     passport = _load_or_404(durable_store, prime_id)
+    prior_authorization_id = passport.custody.requalification_release_authorization_id
     updated, payload = update_requalification_evidence(passport, body)
-    _persist(durable_store, updated)
+    registry = durable_store.get_registry()
+
+    try:
+        patch = _passport_with_superseded_authorization_patch(
+            registry,
+            prior_authorization_id=prior_authorization_id,
+            updated_passport=updated,
+            transition_id=payload["transition_id"],
+            reason="REQUALIFICATION_EVIDENCE_CHANGED",
+        )
+    except PrimeSentinelAuthorizationError as exc:
+        _append_sentinel_rejection(
+            durable_store,
+            role,
+            prime_id=prime_id,
+            authorization_id=prior_authorization_id,
+            reason=f"requalification update rejected because authorization supersession failed: {exc}",
+        )
+        raise HTTPException(
+            status_code=409,
+            detail="PRIME SENTINEL authorization supersession failed",
+        ) from exc
+
+    durable_store.patch_registry(patch)
+    if prior_authorization_id:
+        payload["details"]["superseded_authorization_id"] = prior_authorization_id
     _append_provenance(durable_store, role, payload)
     return {"passport": updated.model_dump(mode="json"), "provenance": payload}
 

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 
 from .auth import Role, require_admin, resolve_role
 from .models import AuditRecord
-from .prime_configuration_custody import PrimeActivationDisposition
+from .prime_configuration_custody import PrimeActivationDisposition, PrimeCustodyState
 from .prime_passport import (
     PrimeDigitalPassport,
     PrimeMissionCompletionRequest,
@@ -15,6 +15,7 @@ from .prime_passport import (
     PrimePassportCreateRequest,
     PrimeRequalificationEvidenceRequest,
     activate_pack,
+    apply_verified_requalification_authorization,
     complete_mission,
     create_passport,
     custody_provenance_payload,
@@ -22,6 +23,14 @@ from .prime_passport import (
     new_transition_id,
     passport_registry_patch,
     update_requalification_evidence,
+)
+from .prime_sentinel_authorization import (
+    PrimeSentinelAuthorizationAssertion,
+    PrimeSentinelAuthorizationError,
+    PrimeSentinelVerifier,
+    assert_recorded_authorization_usable,
+    consumed_authorization_registry_patch,
+    verified_authorization_registry_patch,
 )
 from .storage import DurableStore
 
@@ -31,6 +40,16 @@ router = APIRouter(prefix="/admin/prime", tags=["prime-custody"])
 
 def _store(request: Request) -> DurableStore:
     return request.app.state.store
+
+
+def _sentinel_verifier(request: Request) -> PrimeSentinelVerifier:
+    verifier = request.app.state.prime_sentinel_verifier
+    if not verifier.configured:
+        raise HTTPException(
+            status_code=503,
+            detail="PRIME SENTINEL public-key verification is not configured",
+        )
+    return verifier
 
 
 def _load_or_404(durable_store: DurableStore, prime_id: str) -> PrimeDigitalPassport:
@@ -58,6 +77,28 @@ def _append_provenance(
             event="prime_custody_provenance",
             actor=role.value,
             payload=payload,
+        )
+    )
+
+
+def _append_sentinel_rejection(
+    durable_store: DurableStore,
+    role: Role,
+    *,
+    prime_id: str,
+    reason: str,
+    authorization_id: str | None = None,
+) -> None:
+    durable_store.append_audit(
+        AuditRecord.create(
+            event="prime_sentinel_authorization_rejected",
+            actor=role.value,
+            payload={
+                "prime_id": prime_id,
+                "authorization_id": authorization_id,
+                "reason": reason,
+                "claims_boundary": "Software authorization decision only; no physical qualification claim.",
+            },
         )
     )
 
@@ -142,6 +183,39 @@ def patch_prime_requalification(
     return {"passport": updated.model_dump(mode="json"), "provenance": payload}
 
 
+@router.post("/{prime_id}/requalification/authorize")
+def authorize_prime_requalification(
+    prime_id: str,
+    body: PrimeSentinelAuthorizationAssertion,
+    request: Request,
+    role: Annotated[Role, Depends(resolve_role)],
+) -> dict[str, Any]:
+    require_admin(role)
+    durable_store = _store(request)
+    verifier = _sentinel_verifier(request)
+    passport = _load_or_404(durable_store, prime_id)
+
+    try:
+        verified = verifier.verify(body)
+        updated, payload = apply_verified_requalification_authorization(passport, verified)
+        registry = durable_store.get_registry()
+        auth_patch = verified_authorization_registry_patch(registry, verified)
+        passport_patch = passport_registry_patch(registry, updated)
+    except (PrimeSentinelAuthorizationError, ValueError) as exc:
+        _append_sentinel_rejection(
+            durable_store,
+            role,
+            prime_id=prime_id,
+            authorization_id=body.authorization_id,
+            reason=str(exc),
+        )
+        raise HTTPException(status_code=403, detail="PRIME SENTINEL authorization rejected") from exc
+
+    durable_store.patch_registry({**passport_patch, **auth_patch})
+    _append_provenance(durable_store, role, payload)
+    return {"passport": updated.model_dump(mode="json"), "provenance": payload}
+
+
 @router.post("/{prime_id}/activate-pack")
 def activate_prime_pack(
     prime_id: str,
@@ -151,7 +225,49 @@ def activate_prime_pack(
 ) -> JSONResponse:
     require_admin(role)
     durable_store = _store(request)
+    verifier = request.app.state.prime_sentinel_verifier
     passport = _load_or_404(durable_store, prime_id)
+    registry = durable_store.get_registry()
+
+    authorization_id = passport.custody.requalification_release_authorization_id
+    if passport.custody.state == PrimeCustodyState.QUARANTINED_FOR_REQUALIFICATION and authorization_id:
+        if not verifier.configured:
+            _append_sentinel_rejection(
+                durable_store,
+                role,
+                prime_id=prime_id,
+                authorization_id=authorization_id,
+                reason="PRIME SENTINEL public-key verification is not configured",
+            )
+            return JSONResponse(
+                {"detail": "PRIME SENTINEL authorization cannot be revalidated"},
+                status_code=503,
+            )
+        try:
+            assert_recorded_authorization_usable(
+                registry,
+                authorization_id=authorization_id,
+                prime_id=prime_id,
+                target_environment=body.pack.target_environment,
+                verifier=verifier,
+            )
+        except PrimeSentinelAuthorizationError as exc:
+            _append_sentinel_rejection(
+                durable_store,
+                role,
+                prime_id=prime_id,
+                authorization_id=authorization_id,
+                reason=str(exc),
+            )
+            return JSONResponse(
+                {
+                    "disposition": PrimeActivationDisposition.REQUALIFICATION_REQUIRED.value,
+                    "reasons": [str(exc)],
+                    "passport": passport.model_dump(mode="json"),
+                },
+                status_code=409,
+            )
+
     updated, disposition, reasons, payload = activate_pack(passport, body)
     _append_provenance(durable_store, role, payload)
 
@@ -163,7 +279,29 @@ def activate_prime_pack(
     }
 
     if disposition == PrimeActivationDisposition.ACTIVATION_ALLOWED:
-        _persist(durable_store, updated)
+        patch = passport_registry_patch(registry, updated)
+        if authorization_id:
+            try:
+                patch.update(
+                    consumed_authorization_registry_patch(
+                        registry,
+                        authorization_id=authorization_id,
+                        transition_id=payload["transition_id"],
+                    )
+                )
+            except PrimeSentinelAuthorizationError as exc:
+                _append_sentinel_rejection(
+                    durable_store,
+                    role,
+                    prime_id=prime_id,
+                    authorization_id=authorization_id,
+                    reason=str(exc),
+                )
+                return JSONResponse(
+                    {"detail": "PRIME SENTINEL authorization consumption failed"},
+                    status_code=409,
+                )
+        durable_store.patch_registry(patch)
         return JSONResponse(response, status_code=200)
     if disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED:
         return JSONResponse(response, status_code=409)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_passport_api.py
@@ -269,8 +269,6 @@ def activate_prime_pack(
             )
 
     updated, disposition, reasons, payload = activate_pack(passport, body)
-    _append_provenance(durable_store, role, payload)
-
     response: dict[str, Any] = {
         "disposition": disposition.value,
         "reasons": reasons,
@@ -302,7 +300,10 @@ def activate_prime_pack(
                     status_code=409,
                 )
         durable_store.patch_registry(patch)
+        _append_provenance(durable_store, role, payload)
         return JSONResponse(response, status_code=200)
+
+    _append_provenance(durable_store, role, payload)
     if disposition == PrimeActivationDisposition.REQUALIFICATION_REQUIRED:
         return JSONResponse(response, status_code=409)
     return JSONResponse(response, status_code=403)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_sentinel_authorization.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_sentinel_authorization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import json
 import os
@@ -83,9 +84,10 @@ def canonical_authorization_message(assertion: PrimeSentinelAuthorizationAsserti
 
 def _decode_b64url(value: str, *, expected_length: int, label: str) -> bytes:
     try:
-        padded = value + "=" * (-len(value) % 4)
-        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
-    except (ValueError, UnicodeEncodeError) as exc:
+        encoded = value.encode("ascii")
+        padded = encoded + b"=" * (-len(encoded) % 4)
+        decoded = base64.b64decode(padded, altchars=b"-_", validate=True)
+    except (ValueError, UnicodeEncodeError, binascii.Error) as exc:
         raise PrimeSentinelAuthorizationError(f"invalid {label} encoding") from exc
     if len(decoded) != expected_length:
         raise PrimeSentinelAuthorizationError(
@@ -114,6 +116,12 @@ class PrimeSentinelVerifier:
     def configured(self) -> bool:
         return bool(self._public_keys)
 
+    def key_is_configured(self, key_id: str) -> bool:
+        return key_id in self._public_keys
+
+    def key_is_revoked(self, key_id: str) -> bool:
+        return key_id in self.revoked_key_ids
+
     @classmethod
     def from_environment(cls) -> "PrimeSentinelVerifier":
         raw_keys = os.getenv("PRIME_SENTINEL_PUBLIC_KEYS_JSON", "{}").strip() or "{}"
@@ -134,9 +142,6 @@ class PrimeSentinelVerifier:
             return cls(public_keys_b64url=parsed, revoked_key_ids=revoked)
         except (ValueError, PrimeSentinelAuthorizationError) as exc:
             raise RuntimeError(f"invalid PRIME SENTINEL key configuration: {exc}") from exc
-
-    def key_is_revoked(self, key_id: str) -> bool:
-        return key_id in self.revoked_key_ids
 
     def verify(
         self,
@@ -237,8 +242,10 @@ def assert_recorded_authorization_usable(
     if entry.get("target_environment") != target_environment.value:
         raise PrimeSentinelAuthorizationError("authorization target environment mismatch")
     key_id = entry.get("key_id")
-    if not isinstance(key_id, str) or verifier.key_is_revoked(key_id):
-        raise PrimeSentinelAuthorizationError("authorization signing key is revoked or invalid")
+    if not isinstance(key_id, str) or not verifier.key_is_configured(key_id):
+        raise PrimeSentinelAuthorizationError("authorization signing key is no longer configured")
+    if verifier.key_is_revoked(key_id):
+        raise PrimeSentinelAuthorizationError("authorization signing key is revoked")
     try:
         expires = datetime.fromisoformat(str(entry["expires_at"]).replace("Z", "+00:00"))
     except (KeyError, ValueError) as exc:

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_sentinel_authorization.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_sentinel_authorization.py
@@ -277,3 +277,28 @@ def consumed_authorization_registry_patch(
     )
     records[authorization_id] = updated
     return {PRIME_SENTINEL_AUTHZ_REGISTRY_KEY: records}
+
+
+def superseded_authorization_registry_patch(
+    registry: dict[str, Any],
+    *,
+    authorization_id: str,
+    transition_id: str,
+    reason: str,
+    superseded_at: datetime | None = None,
+) -> dict[str, Any]:
+    records = _authorization_map(registry)
+    entry = records.get(authorization_id)
+    if not isinstance(entry, dict) or entry.get("status") != "VERIFIED":
+        raise PrimeSentinelAuthorizationError("authorization cannot be superseded")
+    updated = dict(entry)
+    updated.update(
+        {
+            "status": "SUPERSEDED",
+            "superseded_transition_id": transition_id,
+            "superseded_reason": reason,
+            "superseded_at": _utc_iso(superseded_at or datetime.now(timezone.utc)),
+        }
+    )
+    records[authorization_id] = updated
+    return {PRIME_SENTINEL_AUTHZ_REGISTRY_KEY: records}

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/prime_sentinel_authorization.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/prime_sentinel_authorization.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .prime_configuration_custody import PrimeEnvironment
+
+
+PRIME_SENTINEL_AUTHZ_SCHEMA = "WS-PRIME-SENTINEL-AUTHZ-V1"
+PRIME_SENTINEL_AUTHZ_REGISTRY_KEY = "PRIME_SENTINEL_AUTHORIZATIONS"
+MAX_ASSERTION_LIFETIME = timedelta(minutes=15)
+MAX_FUTURE_SKEW = timedelta(seconds=60)
+
+
+class PrimeSentinelAuthorizationError(ValueError):
+    pass
+
+
+class PrimeSentinelAuthorizationAssertion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal[PRIME_SENTINEL_AUTHZ_SCHEMA] = PRIME_SENTINEL_AUTHZ_SCHEMA
+    issuer: Literal["PRIME_SENTINEL"] = "PRIME_SENTINEL"
+    key_id: str = Field(min_length=1, max_length=128)
+    authorization_id: str = Field(min_length=1, max_length=128)
+    prime_id: str = Field(min_length=1, max_length=128)
+    action: Literal["REQUALIFICATION_RELEASE"] = "REQUALIFICATION_RELEASE"
+    target_environment: PrimeEnvironment
+    issued_at: datetime
+    expires_at: datetime
+    nonce: str = Field(min_length=16, max_length=128)
+    signature_b64url: str = Field(min_length=1, max_length=256)
+
+    @model_validator(mode="after")
+    def validate_window(self) -> "PrimeSentinelAuthorizationAssertion":
+        if self.issued_at.tzinfo is None or self.expires_at.tzinfo is None:
+            raise ValueError("issued_at and expires_at must be timezone-aware")
+        if self.expires_at <= self.issued_at:
+            raise ValueError("expires_at must be after issued_at")
+        if self.expires_at - self.issued_at > MAX_ASSERTION_LIFETIME:
+            raise ValueError("authorization lifetime exceeds 15 minutes")
+        return self
+
+
+class VerifiedPrimeSentinelAuthorization(BaseModel):
+    authorization_id: str
+    prime_id: str
+    target_environment: PrimeEnvironment
+    key_id: str
+    key_fingerprint_sha256: str
+    nonce: str
+    issued_at: datetime
+    expires_at: datetime
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def canonical_authorization_message(assertion: PrimeSentinelAuthorizationAssertion) -> bytes:
+    payload = {
+        "schema": assertion.schema,
+        "issuer": assertion.issuer,
+        "key_id": assertion.key_id,
+        "authorization_id": assertion.authorization_id,
+        "prime_id": assertion.prime_id,
+        "action": assertion.action,
+        "target_environment": assertion.target_environment.value,
+        "issued_at": _utc_iso(assertion.issued_at),
+        "expires_at": _utc_iso(assertion.expires_at),
+        "nonce": assertion.nonce,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _decode_b64url(value: str, *, expected_length: int, label: str) -> bytes:
+    try:
+        padded = value + "=" * (-len(value) % 4)
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+    except (ValueError, UnicodeEncodeError) as exc:
+        raise PrimeSentinelAuthorizationError(f"invalid {label} encoding") from exc
+    if len(decoded) != expected_length:
+        raise PrimeSentinelAuthorizationError(
+            f"{label} must decode to {expected_length} bytes"
+        )
+    return decoded
+
+
+class PrimeSentinelVerifier:
+    def __init__(
+        self,
+        *,
+        public_keys_b64url: dict[str, str],
+        revoked_key_ids: set[str] | None = None,
+    ) -> None:
+        self._public_keys: dict[str, bytes] = {}
+        for key_id, encoded in public_keys_b64url.items():
+            if not key_id:
+                raise ValueError("PRIME SENTINEL key id cannot be empty")
+            self._public_keys[key_id] = _decode_b64url(
+                encoded, expected_length=32, label=f"public key {key_id}"
+            )
+        self.revoked_key_ids = frozenset(revoked_key_ids or set())
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._public_keys)
+
+    @classmethod
+    def from_environment(cls) -> "PrimeSentinelVerifier":
+        raw_keys = os.getenv("PRIME_SENTINEL_PUBLIC_KEYS_JSON", "{}").strip() or "{}"
+        try:
+            parsed = json.loads(raw_keys)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("PRIME_SENTINEL_PUBLIC_KEYS_JSON is invalid JSON") from exc
+        if not isinstance(parsed, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+        ):
+            raise RuntimeError("PRIME_SENTINEL_PUBLIC_KEYS_JSON must be a string-to-string object")
+        revoked = {
+            item.strip()
+            for item in os.getenv("PRIME_SENTINEL_REVOKED_KEY_IDS", "").split(",")
+            if item.strip()
+        }
+        try:
+            return cls(public_keys_b64url=parsed, revoked_key_ids=revoked)
+        except (ValueError, PrimeSentinelAuthorizationError) as exc:
+            raise RuntimeError(f"invalid PRIME SENTINEL key configuration: {exc}") from exc
+
+    def key_is_revoked(self, key_id: str) -> bool:
+        return key_id in self.revoked_key_ids
+
+    def verify(
+        self,
+        assertion: PrimeSentinelAuthorizationAssertion,
+        *,
+        now: datetime | None = None,
+    ) -> VerifiedPrimeSentinelAuthorization:
+        if not self.configured:
+            raise PrimeSentinelAuthorizationError("no PRIME SENTINEL public keys are configured")
+        if assertion.key_id in self.revoked_key_ids:
+            raise PrimeSentinelAuthorizationError("PRIME SENTINEL signing key is revoked")
+        key_bytes = self._public_keys.get(assertion.key_id)
+        if key_bytes is None:
+            raise PrimeSentinelAuthorizationError("unknown PRIME SENTINEL signing key")
+
+        current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        issued = assertion.issued_at.astimezone(timezone.utc)
+        expires = assertion.expires_at.astimezone(timezone.utc)
+        if issued > current + MAX_FUTURE_SKEW:
+            raise PrimeSentinelAuthorizationError("authorization assertion is issued too far in the future")
+        if current >= expires:
+            raise PrimeSentinelAuthorizationError("authorization assertion is expired")
+
+        signature = _decode_b64url(
+            assertion.signature_b64url,
+            expected_length=64,
+            label="Ed25519 signature",
+        )
+        try:
+            Ed25519PublicKey.from_public_bytes(key_bytes).verify(
+                signature,
+                canonical_authorization_message(assertion),
+            )
+        except (InvalidSignature, ValueError) as exc:
+            raise PrimeSentinelAuthorizationError("invalid PRIME SENTINEL Ed25519 signature") from exc
+
+        return VerifiedPrimeSentinelAuthorization(
+            authorization_id=assertion.authorization_id,
+            prime_id=assertion.prime_id,
+            target_environment=assertion.target_environment,
+            key_id=assertion.key_id,
+            key_fingerprint_sha256=hashlib.sha256(key_bytes).hexdigest(),
+            nonce=assertion.nonce,
+            issued_at=issued,
+            expires_at=expires,
+        )
+
+
+def _authorization_map(registry: dict[str, Any]) -> dict[str, Any]:
+    raw = registry.get(PRIME_SENTINEL_AUTHZ_REGISTRY_KEY, {})
+    if not isinstance(raw, dict):
+        raise PrimeSentinelAuthorizationError(
+            f"{PRIME_SENTINEL_AUTHZ_REGISTRY_KEY} must be a JSON object"
+        )
+    return dict(raw)
+
+
+def verified_authorization_registry_patch(
+    registry: dict[str, Any],
+    verified: VerifiedPrimeSentinelAuthorization,
+) -> dict[str, Any]:
+    records = _authorization_map(registry)
+    if verified.authorization_id in records:
+        raise PrimeSentinelAuthorizationError("authorization_id has already been recorded")
+    for entry in records.values():
+        if isinstance(entry, dict) and entry.get("nonce") == verified.nonce:
+            raise PrimeSentinelAuthorizationError("authorization nonce has already been recorded")
+    records[verified.authorization_id] = {
+        "status": "VERIFIED",
+        "prime_id": verified.prime_id,
+        "target_environment": verified.target_environment.value,
+        "key_id": verified.key_id,
+        "key_fingerprint_sha256": verified.key_fingerprint_sha256,
+        "nonce": verified.nonce,
+        "issued_at": _utc_iso(verified.issued_at),
+        "expires_at": _utc_iso(verified.expires_at),
+    }
+    return {PRIME_SENTINEL_AUTHZ_REGISTRY_KEY: records}
+
+
+def assert_recorded_authorization_usable(
+    registry: dict[str, Any],
+    *,
+    authorization_id: str,
+    prime_id: str,
+    target_environment: PrimeEnvironment,
+    verifier: PrimeSentinelVerifier,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    records = _authorization_map(registry)
+    entry = records.get(authorization_id)
+    if not isinstance(entry, dict):
+        raise PrimeSentinelAuthorizationError("authorization is not recorded")
+    if entry.get("status") != "VERIFIED":
+        raise PrimeSentinelAuthorizationError("authorization is not in VERIFIED state")
+    if entry.get("prime_id") != prime_id:
+        raise PrimeSentinelAuthorizationError("authorization PRIME identity mismatch")
+    if entry.get("target_environment") != target_environment.value:
+        raise PrimeSentinelAuthorizationError("authorization target environment mismatch")
+    key_id = entry.get("key_id")
+    if not isinstance(key_id, str) or verifier.key_is_revoked(key_id):
+        raise PrimeSentinelAuthorizationError("authorization signing key is revoked or invalid")
+    try:
+        expires = datetime.fromisoformat(str(entry["expires_at"]).replace("Z", "+00:00"))
+    except (KeyError, ValueError) as exc:
+        raise PrimeSentinelAuthorizationError("authorization expiry is invalid") from exc
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if current >= expires.astimezone(timezone.utc):
+        raise PrimeSentinelAuthorizationError("authorization is expired")
+    return entry
+
+
+def consumed_authorization_registry_patch(
+    registry: dict[str, Any],
+    *,
+    authorization_id: str,
+    transition_id: str,
+    consumed_at: datetime | None = None,
+) -> dict[str, Any]:
+    records = _authorization_map(registry)
+    entry = records.get(authorization_id)
+    if not isinstance(entry, dict) or entry.get("status") != "VERIFIED":
+        raise PrimeSentinelAuthorizationError("authorization cannot be consumed")
+    updated = dict(entry)
+    updated.update(
+        {
+            "status": "CONSUMED",
+            "consumed_transition_id": transition_id,
+            "consumed_at": _utc_iso(consumed_at or datetime.now(timezone.utc)),
+        }
+    )
+    records[authorization_id] = updated
+    return {PRIME_SENTINEL_AUTHZ_REGISTRY_KEY: records}


### PR DESCRIPTION
Hardens PRIME requalification release from an auditable-but-unverified authorization ID to an asymmetric PRIME SENTINEL assertion contract. Adds cryptography 50.0.1 to the pinned runtime; Ed25519 public-key verification; stable key IDs/fingerprints; a maximum 15-minute assertion lifetime; future-clock bounds; PRIME/action/target-environment binding; authorization-ID and nonce replay rejection; activation-time expiry, key-removal, and revocation checks; one-time consumption; and audit records for rejected assertions. SARA stores only public verification keys; private signing keys are intentionally external. Generic admin registry patching is blocked for PRIME_DIGITAL_PASSPORTS and PRIME_SENTINEL_AUTHORIZATIONS so those namespaces must use governed APIs. Requalification evidence changes and new mission-completion transitions supersede any still-pending VERIFIED authorization; normal supersession and passport clearing are committed in the same registry write, while mission completion preserves fail-safe quarantine if the authorization ledger is inconsistent. Successful activation is audited only after the passport update and one-time authorization consumption are durably committed. The branch has been reconciled with current main so the already-merged PRIME physics engine remains present; fresh protected CI is required on the combined head. Physical mine/deep-sea/flight/launch/space qualification is not established by this change.