### PR TITLE
V10: add frozen core external-evaluation package

### DIFF
--- a/docs/v10/README.md
+++ b/docs/v10/README.md
@@ -1,0 +1,21 @@
+# V10 Evaluator Bundle Index
+
+This directory supports Worldshepherd's V10 valuation-evidence program. It does not establish a valuation by itself.
+
+## Core SARA evaluator lane
+
+- `WS-SARA-EVAL-v1_SCOPE_AND_PROTOCOL.md`
+- `WS-SARA-EVAL-v1_SCORECARD.md`
+- `WS-SARA-EVAL-v1_RELEASE_NOTE.md`
+
+**Frozen source-code baseline:** `1c7be6c51ffd475f124e951f6c8c76208460b895`
+
+The evaluator documents may be added after the frozen source baseline. The source baseline remains the exact SHA above unless a successor release is explicitly created and reviewed.
+
+## Separate external-evaluation lane
+
+W-RMABM G4 preparation remains separate from the core SARA evaluator lane. Its protocol and scorecard live under the Golden Dome documentation on the `golden-dome-rmabm-g4prep` lineage. Evidence from one lane must not be silently attributed to the other.
+
+## V10 closure principle
+
+V10 requires evidence conversion, not document count. A protocol, scorecard, frozen branch, CI run, outreach thread, or internal test is preparation until the required external or documentary gate is actually closed.

--- a/docs/v10/WS-SARA-EVAL-v1_EVIDENCE_MANIFEST_TEMPLATE.md
+++ b/docs/v10/WS-SARA-EVAL-v1_EVIDENCE_MANIFEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+# WS-SARA-EVAL-v1 — Evidence Manifest Template
+
+This template is completed by the evaluator for the received bundle and produced evidence. Do not pre-populate hashes that have not been independently computed in the evaluator environment.
+
+## Identity
+
+- source baseline SHA: `1c7be6c51ffd475f124e951f6c8c76208460b895`
+- evaluator documentation bundle commit: `<record exact commit received>`
+- evaluator organization/reference: `<value>`
+- evaluation date: `<value>`
+
+## Received bundle
+
+| Artifact/path | SHA-256 | Notes |
+|---|---|---|
+| source archive / checkout record | | |
+| evaluator protocol | | |
+| evaluator scorecard | | |
+| release note | | |
+| installation/deployment instructions used | | |
+| dependency/environment lock used | | |
+
+## Produced evidence
+
+| Run | Artifact/path | SHA-256 | Result |
+|---|---|---|---|
+| C1 | | | PASS / FAIL |
+| C2 | | | PASS / FAIL |
+| C3 | | | PASS / FAIL |
+| C4 | | | PASS / FAIL |
+| C5 | | | PASS / FAIL |
+| C6 | | | PASS / FAIL |
+
+## Discrepancy preservation
+
+Every failed or unexpected run receives a unique discrepancy ID and an independently retained original artifact. A corrected retest must be stored as a new record and linked to the failure; the original failure must not be deleted or replaced.
+
+## Attestation boundary
+
+Completing this manifest does not by itself establish independence. Independence requires that the evaluator actually be outside the Worldshepherd development process and control its own execution environment and original evidence record.

--- a/docs/v10/WS-SARA-EVAL-v1_INSTALLATION_CHECKLIST.md
+++ b/docs/v10/WS-SARA-EVAL-v1_INSTALLATION_CHECKLIST.md
@@ -1,0 +1,57 @@
+# WS-SARA-EVAL-v1 — Installation Checklist
+
+Use only with the frozen source baseline `1c7be6c51ffd475f124e951f6c8c76208460b895`.
+
+This checklist is an evaluator aid, not evidence of external reproduction until an external evaluator completes it in an evaluator-controlled environment.
+
+## Preflight
+
+- [ ] record exact source SHA
+- [ ] record OS / architecture
+- [ ] record Python version
+- [ ] record Docker / Compose versions if used
+- [ ] record dependency installation method
+- [ ] confirm no production/customer/CUI/classified data are present
+- [ ] confirm localhost-only publication unless the evaluator deliberately changes the network boundary and records that deviation
+
+## Python local path
+
+The frozen README documents the following local setup sequence:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[test]'
+cp .env.example .env
+# Replace both tokens with different random values.
+./scripts/start_interface.sh
+```
+
+Evaluator must use its own credentials/tokens and retain no Worldshepherd production secrets.
+
+## Documented local surfaces
+
+Default local UI: `http://127.0.0.1:9530/ui`
+
+Documented surfaces at the frozen baseline include:
+
+- `/health`
+- `/livez`
+- `/readyz`
+- `/v1/relay`
+- `/v1/audit?limit=50`
+- `/admin/registry`
+- `/admin/selftest`
+
+## Acceptance record
+
+For each step record:
+
+- command or action;
+- exit/result status;
+- relevant output hash or artifact reference;
+- discrepancy ID if behavior differs from the reviewed instructions.
+
+## Claims boundary
+
+A successful installation proves only that the reviewed frozen software can be installed in the recorded environment. It does not by itself establish independent functional reproduction, production readiness, customer acceptance, regulatory conformity, or physical capability.

--- a/docs/v10/WS-SARA-EVAL-v1_RELEASE_NOTE.md
+++ b/docs/v10/WS-SARA-EVAL-v1_RELEASE_NOTE.md
@@ -1,0 +1,36 @@
+# WS-SARA-EVAL-v1 — Evaluator Release Note
+
+## Source baseline
+
+The software source baseline under evaluation is fixed at:
+
+`1c7be6c51ffd475f124e951f6c8c76208460b895`
+
+The `ws-sara-eval-v1-freeze` branch may contain evaluator documentation added after that source baseline. Those documentation commits do **not** change the declared source baseline. Evaluators must record both the source baseline SHA and the evaluator-document bundle identity they received.
+
+## Included software claim
+
+This package supports evaluation of the bounded SARA / PRIME SENTINEL software behavior present at the source baseline, including the merged PRIME SENTINEL durable issuance ledger v1.5 and the verified-local deployment material present there.
+
+## Explicit exclusions
+
+This package does not silently include or validate:
+
+- ECHO v1.6 / PR #153;
+- W-RMABM G4 prep / PR #116;
+- XTEND Certified candidate work;
+- Sentinel infrastructure candidate branches;
+- physical drone, humanoid, companion, materials, RF, propulsion, energy, quantum, or other hardware performance;
+- customer/government acceptance;
+- production certification;
+- CMMC/NIST/DFARS conformity;
+- classified suitability;
+- HSM/KMS or immutable/WORM custody.
+
+## Existing installation reference
+
+The frozen deployment package documents a localhost-only interface, a Python virtual-environment quick start, Docker-based acceptance material, health/liveness/readiness surfaces, relay, audit, registry and self-test endpoints, and PRE evidence compilation. The evaluator should use only reviewed instructions and record any deviation.
+
+## Evidence rule
+
+A reproducible installation or green test run performed by Worldshepherd is still internal evidence. External-reproduction status requires an evaluator outside the development process to execute the agreed protocol in an evaluator-controlled environment and retain its original evidence.

--- a/docs/v10/WS-SARA-EVAL-v1_SCOPE_AND_PROTOCOL.md
+++ b/docs/v10/WS-SARA-EVAL-v1_SCOPE_AND_PROTOCOL.md
@@ -1,0 +1,114 @@
+# WS-SARA-EVAL-v1 — Core Evaluator Scope and Protocol
+
+**V10 gate:** V10-2 / V10-3 support
+
+**Source-code baseline:** `1c7be6c51ffd475f124e951f6c8c76208460b895`
+
+**Release posture:** UNCLASSIFIED / NON-CONFIDENTIAL / REVIEW REQUIRED BEFORE EXTERNAL RELEASE
+
+## Purpose
+
+Define a bounded independent reproduction target for the Worldshepherd core SARA / PRIME SENTINEL software baseline without promoting unmerged candidate work or physical capability claims.
+
+This evaluator package is distinct from the W-RMABM G4 package. W-RMABM external evaluation is tracked separately and may be used as independent evidence for its tested synthetic mission-assurance scope. This document governs the reusable core-platform lane.
+
+## Included baseline
+
+The frozen source baseline is the exact main commit above. It includes the merged PRIME SENTINEL durable issuance ledger v1.5 and the SARA verified-local deployment material present at that commit.
+
+## Excluded from this baseline
+
+- unmerged ECHO v1.6 candidate work / PR #153;
+- unmerged W-RMABM G4 preparation / PR #116;
+- unmerged XTEND, Sentinel, physics, vehicle, materials, RF, propulsion, or other candidate branches;
+- any customer, partner, government, certification, compliance, classified-readiness, or physical-performance claim not separately established.
+
+## Existing local deployment boundary
+
+The frozen deployment documentation exposes a localhost-only SARA interface by default at `127.0.0.1:9530`, with documented health, liveness, readiness, relay, audit, registry, and self-test surfaces. External scanning, arbitrary command execution, third-party activation, self-expanding network behavior, and broadcast behavior are outside the verified local boundary.
+
+The application audit is operational evidence, not immutable or independently verified storage.
+
+## Evaluator control principle
+
+The evaluator must control the test environment and retain its own original evidence. Worldshepherd may provide installation instructions, the frozen source identity, and bounded challenge categories, but must not choose the evaluator's final challenge values or rewrite failed evidence after execution.
+
+## Minimum evaluator environment record
+
+Record before execution:
+
+- repository and exact source baseline SHA;
+- evaluator-controlled checkout or supplied reviewed bundle identity;
+- OS and architecture;
+- Python/runtime version;
+- Docker/Compose version if used;
+- dependency-lock or installed-package fingerprint;
+- execution date/time;
+- evaluator identifier or organization-controlled reference;
+- network boundary used for the test;
+- SHA-256 manifest for the evaluator's received bundle and produced evidence.
+
+## Required core runs
+
+### C1 — Clean deployment and health/readiness
+
+Acceptance:
+- installation/deployment completes from the reviewed instructions;
+- localhost publication remains bounded as documented;
+- health/liveness/readiness surfaces behave consistently with the frozen baseline;
+- no external activation is required.
+
+### C2 — Authorization separation
+
+Acceptance:
+- administrative operations require the documented administrative authorization path;
+- a non-administrative/operator context cannot silently obtain administrative audit or registry authority;
+- denial is retained as evidence where the frozen implementation records it.
+
+### C3 — Registry and audit traceability
+
+Acceptance:
+- a bounded authorized registry mutation can be traced to the expected retained evidence;
+- resulting audit/evidence records can be retrieved through the documented interface;
+- evaluator records hashes of relevant output artifacts.
+
+### C4 — PRIME issuance durability / idempotency
+
+Acceptance is limited to behavior actually implemented by the frozen v1.5 source. Evaluator must test documented same-request retry behavior, restart persistence, conflict rejection, and reconciliation/integrity surfaces without inferring exactly-once transport, HSM/KMS custody, WORM storage, or external attestation.
+
+### C5 — Negative / malformed / unauthorized cases
+
+Evaluator selects bounded malformed or unauthorized cases from the documented API/input contracts.
+
+Acceptance:
+- malformed or unauthorized input is not silently promoted into a successful governed action;
+- observed behavior and error class are retained;
+- any discrepancy is recorded rather than discarded.
+
+### C6 — Restart / recovery
+
+Where supported by the frozen deployment package, evaluator restarts the relevant local service(s) and records whether documented persisted state, readiness, and recovery behavior match the frozen implementation.
+
+## Evidence retention
+
+For every run retain:
+
+1. source baseline SHA;
+2. evaluator environment fingerprint;
+3. command/run identity or equivalent procedural record;
+4. input/challenge identity;
+5. output hashes;
+6. pass/fail result for each assertion;
+7. evaluator-authored discrepancy notes;
+8. original failed evidence if a run fails;
+9. any retest as a new linked record, never as a replacement for the failure.
+
+## Pass rule
+
+This core evaluator lane may be labeled **INDEPENDENTLY REPRODUCED — BOUNDED SOFTWARE BEHAVIOR ONLY** only after an evaluator outside the Worldshepherd development process executes the reviewed protocol in an evaluator-controlled environment and records all mandatory assertions for the agreed scope as passing.
+
+Internal CI, a Worldshepherd-controlled machine, a founder-authored scorecard without external execution, or the existence of this protocol cannot satisfy V10-3.
+
+## Claims boundary
+
+A pass does not establish production certification, customer/government acceptance, CMMC/NIST/DFARS conformity, classified suitability, immutable audit storage, HSM/KMS custody, operational effectiveness, physical platform capability, or any broader untested Worldshepherd technology claim.

--- a/docs/v10/WS-SARA-EVAL-v1_SCORECARD.md
+++ b/docs/v10/WS-SARA-EVAL-v1_SCORECARD.md
@@ -1,0 +1,96 @@
+# WS-SARA-EVAL-v1 — Independent Evaluation Scorecard
+
+Use with `WS-SARA-EVAL-v1_SCOPE_AND_PROTOCOL.md`.
+
+**Source-code baseline:** `1c7be6c51ffd475f124e951f6c8c76208460b895`
+
+## Evaluation record
+
+| Field | Evaluator entry |
+|---|---|
+| Evaluating organization / lab | |
+| Evaluator name or controlled identifier | |
+| Evaluation date | |
+| Source repository | `Bdavis1390/Sara_pro` |
+| Frozen source baseline SHA | `1c7be6c51ffd475f124e951f6c8c76208460b895` |
+| Received bundle SHA-256 | |
+| Operating system / architecture | |
+| Python/runtime version | |
+| Docker / Compose version if used | |
+| Dependency / environment fingerprint | |
+| Network boundary | |
+| Overall result | PASS / PARTIAL / FAIL |
+
+Do not place passwords, tokens, private keys, CUI, classified data, export-controlled third-party data, or proprietary customer information in this scorecard.
+
+## Required runs
+
+| Run | Expected control | Result | Evidence / hash | Notes |
+|---|---|---|---|---|
+| C1 clean deployment + health/readiness | reviewed local baseline reproduces | | | |
+| C2 authorization separation | unauthorized/admin boundary fails closed | | | |
+| C3 registry + audit traceability | authorized bounded change is traceable | | | |
+| C4 PRIME issuance durability/idempotency | frozen v1.5 documented behavior reproduces | | | |
+| C5 malformed/unauthorized cases | no silent promotion to success | | | |
+| C6 restart/recovery | documented persisted/recovery behavior reproduces | | | |
+
+## Control assertions
+
+Mark each `PASS`, `FAIL`, or `NOT OBSERVED`.
+
+| Assertion | Result | Notes |
+|---|---|---|
+| Exact frozen source identity was used | | |
+| Evaluator controlled the execution environment | | |
+| Localhost/network boundary matched reviewed instructions | | |
+| Administrative and operator authority remained separated | | |
+| Unauthorized administrative operation did not silently succeed | | |
+| Bounded authorized registry operation was traceable | | |
+| Relevant audit/evidence output was retained | | |
+| PRIME same-request retry behavior matched frozen v1.5 contract | | |
+| PRIME conflicting request reuse was rejected as documented | | |
+| Relevant restart persistence behavior matched frozen v1.5 scope | | |
+| Malformed/unauthorized input was not silently accepted | | |
+| Failed runs, if any, were retained | | |
+| Retests, if any, were recorded as new linked evidence | | |
+| No unmerged ECHO v1.6 behavior was attributed to this baseline | | |
+| No W-RMABM behavior was attributed to this core baseline unless separately evaluated | | |
+| No physical, certification, government/customer acceptance, or classified-readiness claim was inferred | | |
+
+## Evidence inventory
+
+| Artifact | SHA-256 / value | Custodian |
+|---|---|---|
+| Received evaluator bundle | | |
+| Environment record | | |
+| C1 evidence | | |
+| C2 evidence | | |
+| C3 evidence | | |
+| C4 evidence | | |
+| C5 evidence | | |
+| C6 evidence | | |
+| Evaluator result record | | |
+
+## Discrepancy register
+
+For each discrepancy retain:
+
+- discrepancy ID;
+- affected run;
+- observed behavior;
+- expected behavior;
+- reproducibility information;
+- safety/claims impact;
+- disposition: `OPEN`, `CORRECTED_AND_RETESTED`, or `ACCEPTED_LIMITATION`;
+- link/reference to the original evidence;
+- link/reference to any later retest.
+
+Do not delete or overwrite a failed evaluation record after correction.
+
+## Determination
+
+A successful result may be described only as:
+
+**INDEPENDENTLY REPRODUCED — BOUNDED SOFTWARE BEHAVIOR ONLY**
+
+unless broader evidence has been separately established and reviewed.

--- a/docs/v10/WS-SARA-EVAL-v1_VERSION_POLICY.md
+++ b/docs/v10/WS-SARA-EVAL-v1_VERSION_POLICY.md
@@ -1,0 +1,23 @@
+# WS-SARA-EVAL-v1 — Version Freeze Policy
+
+`WS-SARA-EVAL-v1` remains pinned to source baseline:
+
+`1c7be6c51ffd475f124e951f6c8c76208460b895`
+
+Subsequent merges to `main`, including ECHO v1.6, do not retroactively change this evaluator target.
+
+## Why
+
+Independent reproducibility requires a stable target. Moving the source baseline after an evaluator has begun screening would contaminate the evidence chain and make results difficult to compare.
+
+## Successor rule
+
+A successor such as `WS-SARA-EVAL-v1.1` or `WS-SARA-EVAL-v2` may be created only by:
+
+1. naming a new exact source SHA;
+2. recording the delta from the prior baseline;
+3. reviewing installation/dependency changes;
+4. updating the protocol only where the new scope requires it;
+5. preserving the original v1 evaluation record intact.
+
+A pass on v1 must not be silently attributed to a successor release; changed behavior must be re-evaluated to the extent material to the claimed scope.


### PR DESCRIPTION
## Purpose
Prepare the V10 core-software independent-reproduction package without moving the tested source target or claiming external validation.

## Frozen source target
`WS-SARA-EVAL-v1` evaluates source baseline:
`1c7be6c51ffd475f124e951f6c8c76208460b895`

The evaluator-document commits on this branch do not change that declared source target. Current main has since advanced to merged ECHO v1.6; that later software is intentionally not retroactively inserted into the v1 evaluator target.

## Added
- core evaluator scope/protocol
- evaluator scorecard
- release note
- evidence-manifest template
- version-freeze policy
- installation checklist
- V10 evaluator bundle index

## Separate lane
The active Aerospace inquiry concerns the W-RMABM G4 evaluation package. That is a separate evaluator lane. A W-RMABM external result must not be silently represented as reproduction of the core SARA/PRIME baseline, and vice versa.

## Claims boundary
Documentation and CI are preparation only. V10-3 closes only when an evaluator outside the Worldshepherd development process runs an agreed frozen package in an evaluator-controlled environment and retains the original evidence.

No production certification, customer/government acceptance, CMMC/NIST/DFARS conformity, classified suitability, immutable/WORM storage, HSM/KMS custody, operational effectiveness, or physical capability is claimed.

**DRAFT / REVIEW ONLY. Do not merge solely because CI is green.**