### PR TITLE
Record ECHO remote-provider retrieval pilot evidence

### DIFF
--- a/deployments/sara_verified_local_v1/docs/ECHO_PROVIDER_RETRIEVAL_PILOT_V1_9.md
+++ b/deployments/sara_verified_local_v1/docs/ECHO_PROVIDER_RETRIEVAL_PILOT_V1_9.md
@@ -1,0 +1,90 @@
+# ECHO SENTINEL LINK provider-retrieval pilot v1.9
+
+## Purpose
+
+This record advances the v1.8 external-anchor program by exercising a real authorized remote-provider publication and retrieval path with a deliberately non-sensitive synthetic transport object before any production ECHO checkpoint is published.
+
+It does **not** replace or weaken `ECHO_CHECKPOINT_V1_8_EXTERNAL_ANCHOR_DESIGN.md`. The v1.8 verifier remains authoritative for deterministic checkpoint-anchor requests, evidence artifacts, receipts, and `READ_BACK_CONTENT_MATCH`.
+
+## Pilot object
+
+Provider: GitHub repository content service.
+
+Repository: `Bdavis1390/Sara_pro`.
+
+Published object:
+
+`external_anchor_pilots/github/2026-09-11/provider-retrieval-pilot-v1.json`
+
+Publication commit:
+
+`6e87e711b82d6e7349af09b8ef05002d42a04556`
+
+GitHub provider blob SHA:
+
+`89c9a74c3fe53cb0ee38cd49c9901c4079b34203`
+
+Local byte-content SHA-256 before publication:
+
+`cecd3c4f029d4d90971d8e99b99c32f722286d957f734159e7662ab9bca0b003`
+
+Canonical pilot-payload SHA-256:
+
+`12ae1597e4443132c83222ab3d54efd88c6bb6eda7910a9a3b2d154eb755a1f1`
+
+## Retrieval evidence
+
+The published object was subsequently retrieved through two provider surfaces:
+
+1. the GitHub Contents API on branch `echo-provider-retrieval-pilot-v1-9`; and
+2. a raw GitHub URL pinned to publication commit `6e87e711b82d6e7349af09b8ef05002d42a04556`.
+
+Both returned the published JSON content. The Contents API reported provider blob SHA `89c9a74c3fe53cb0ee38cd49c9901c4079b34203`.
+
+The bounded evidence record is stored at:
+
+`external_anchor_pilots/github/2026-09-11/provider-retrieval-evidence-v1.json`
+
+Its canonical evidence digest is:
+
+`ef15b0149cf6d3b25535a6cdd4ffe430fcd3301db483fef7a3e82c4e31a77770`
+
+## Bounded result
+
+`PROVEN INTERNALLY — a non-sensitive synthetic Worldshepherd provider-path pilot object was published to GitHub and retrieved through both the GitHub Contents API and a commit-pinned raw GitHub path with matching content.`
+
+This result proves only the remote provider transport/retrieval substrate used by the pilot.
+
+The pilot object is explicitly **not** a `WS-ECHO-CHECKPOINT-ANCHOR-REQUEST-V1` object. Therefore this result does **not** establish that a signed ECHO checkpoint has been externally anchored.
+
+## Claims boundary
+
+This pilot does not establish:
+
+- independent third-party attestation;
+- immutable or WORM retention;
+- trusted timestamp or transparency-log guarantees;
+- privileged rollback resistance;
+- legal chain-of-custody status;
+- production HSM/KMS custody;
+- exactly-once transport;
+- certification or government authorization;
+- customer acceptance; or
+- physical-system qualification.
+
+GitHub is an external service, but the repository/account is under Worldshepherd user control. Provider retrieval is therefore evidence of remote observability and content retrieval, not independent attestation.
+
+## Relationship to v1.8
+
+The next gate is intentionally stricter than this pilot:
+
+1. generate a real `WS-ECHO-CHECKPOINT-ANCHOR-REQUEST-V1` from a verified signed ECHO checkpoint using the v1.8 implementation;
+2. publish that exact deterministic request through an authorized remote provider path;
+3. retrieve it through a separately evidenced provider read path;
+4. retain provider locator, provider response metadata, retrieved document, evidence artifact, and receipt;
+5. require the v1.8 verifier to return `READ_BACK_CONTENT_MATCH` on the retrieved provider document; and
+6. preserve the provider-retrieval evidence separately so local content verification cannot grant itself remote provenance.
+
+Only after that sequence may Worldshepherd make the bounded v1.8 statement that the identified checkpoint anchor request was observed through the separately evidenced provider retrieval and its content matched the local deterministic anchor request.
+
+Even then, independent attestation, WORM/immutability, trusted timestamping, privileged rollback resistance, HSM/KMS custody, exactly-once transport, certification, and physical qualification remain separate gates.

--- a/external_anchor_pilots/github/2026-09-11/provider-retrieval-evidence-v1.json
+++ b/external_anchor_pilots/github/2026-09-11/provider-retrieval-evidence-v1.json
@@ -1,0 +1,41 @@
+{
+  "bounded_claim": "PROVEN INTERNALLY — a non-sensitive synthetic Worldshepherd provider-path pilot object was published to GitHub and retrieved through both the GitHub Contents API and a commit-pinned raw GitHub path with matching content.",
+  "evidence_class": "PROVEN_INTERNALLY_SYNTHETIC_PROVIDER_PATH",
+  "evidence_sha256": "ef15b0149cf6d3b25535a6cdd4ffe430fcd3301db483fef7a3e82c4e31a77770",
+  "not_claimed": [
+    "external anchoring of a signed ECHO checkpoint",
+    "independent third-party attestation",
+    "immutable or WORM retention",
+    "trusted timestamp or transparency-log guarantee",
+    "privileged rollback resistance",
+    "legal chain of custody",
+    "production HSM/KMS custody",
+    "exactly-once transport",
+    "certification or government authorization",
+    "physical-system qualification"
+  ],
+  "provider": "GITHUB",
+  "provider_blob_sha": "89c9a74c3fe53cb0ee38cd49c9901c4079b34203",
+  "provider_reported_modified_utc": "2026-09-11T02:30:40Z",
+  "publication_commit_sha": "6e87e711b82d6e7349af09b8ef05002d42a04556",
+  "published_content_sha256": "cecd3c4f029d4d90971d8e99b99c32f722286d957f734159e7662ab9bca0b003",
+  "published_object_path": "external_anchor_pilots/github/2026-09-11/provider-retrieval-pilot-v1.json",
+  "published_payload_sha256": "12ae1597e4443132c83222ab3d54efd88c6bb6eda7910a9a3b2d154eb755a1f1",
+  "repository": "Bdavis1390/Sara_pro",
+  "result": "PASS",
+  "retrieval_observed_utc": "2026-09-11T02:31:15Z",
+  "retrieval_paths": [
+    {
+      "kind": "GITHUB_CONTENTS_API",
+      "provider_blob_sha": "89c9a74c3fe53cb0ee38cd49c9901c4079b34203",
+      "ref": "echo-provider-retrieval-pilot-v1-9",
+      "result": "CONTENT_MATCH"
+    },
+    {
+      "kind": "RAW_COMMIT_URL",
+      "ref": "6e87e711b82d6e7349af09b8ef05002d42a04556",
+      "result": "CONTENT_MATCH"
+    }
+  ],
+  "schema": "WS-ECHO-PROVIDER-RETRIEVAL-EVIDENCE-V1"
+}

--- a/external_anchor_pilots/github/2026-09-11/provider-retrieval-pilot-v1.json
+++ b/external_anchor_pilots/github/2026-09-11/provider-retrieval-pilot-v1.json
@@ -1,0 +1,27 @@
+{
+  "claims_boundary": [
+    "This is not a WS-ECHO-CHECKPOINT-ANCHOR-REQUEST-V1 object.",
+    "This does not establish external anchoring of a signed ECHO checkpoint.",
+    "A successful GitHub read-back proves only provider-path observability and exact content retrieval for this pilot object.",
+    "It does not establish independent third-party attestation, immutable/WORM retention, trusted timestamping, privileged rollback resistance, legal chain of custody, production HSM/KMS custody, exactly-once transport, certification, or physical-system qualification."
+  ],
+  "evidence_class": "SYNTHETIC_TRANSPORT_PILOT",
+  "pilot_payload_sha256": "12ae1597e4443132c83222ab3d54efd88c6bb6eda7910a9a3b2d154eb755a1f1",
+  "protected_ci_run_id": 34553568881,
+  "protected_pytest": {
+    "duration_seconds": 134.21,
+    "passed": 651,
+    "warnings": 10
+  },
+  "provider": "GITHUB_CONTENTS_API",
+  "purpose": "Exercise an authorized real remote-provider write/read path with non-sensitive synthetic evidence before anchoring a production ECHO checkpoint.",
+  "release_evidence_index_artifact": {
+    "artifact_id": 10181771063,
+    "sha256": "82f73ffea02ce0d447ac760781f4dbb54074fe21ed1bea990d60a5b34ef229c9"
+  },
+  "repository": "Bdavis1390/Sara_pro",
+  "schema": "WS-ECHO-PROVIDER-RETRIEVAL-PILOT-V1",
+  "v1_8_landed_tree": "136cae3e713fc4bcdeb92c586b512de5b3d776f2",
+  "v1_8_merge_commit": "c525305b6865f3814169158e961aab81e26dcdb0",
+  "v1_8_tested_branch_head": "d7a2891ee659348ef1ef690c4d6d912f22d89719"
+}


### PR DESCRIPTION
## Purpose
Preserve the first bounded real GitHub provider-path publication/read-back pilot for ECHO anchoring work.

## Evidence
- Synthetic/non-sensitive pilot object published on GitHub at commit `6e87e711b82d6e7349af09b8ef05002d42a04556`.
- Read back through GitHub Contents API; provider blob SHA `89c9a74c3fe53cb0ee38cd49c9901c4079b34203`.
- Read back independently through a commit-pinned raw GitHub path with matching content.
- Retrieval evidence record persisted on the branch and read back from GitHub.

## Claims boundary
This proves only the real remote-provider transport/retrieval path for a synthetic pilot object. It is **not** a `WS-ECHO-CHECKPOINT-ANCHOR-REQUEST-V1` and does not establish external anchoring of a signed ECHO checkpoint, independent third-party attestation, immutable/WORM retention, trusted timestamping, privileged rollback resistance, HSM/KMS custody, exactly-once transport, certification, or physical qualification.

The next gate remains publication and separately evidenced retrieval of an actual deterministic v1.8 anchor request derived from a verified signed ECHO checkpoint.