### PR TITLE
Preserve outbox replay after partial audit tail

### DIFF
--- a/deployments/sara_verified_local_v1/tests/test_event_outbox.py
+++ b/deployments/sara_verified_local_v1/tests/test_event_outbox.py
@@ -276,4 +276,4 @@ def test_replay_after_partial_audit_tail_preserves_a_valid_event(tmp_path):
     assert len(delivered) == 1
     assert delivered[0]["payload"]["_outbox_event_id"] == event_id
     assert outbox_status(store.get_registry())["pending"] == 0
-    assert store.audit_path.read_bytes().endswith(b"\\n")
+    assert store.audit_path.read_bytes().endswith(b"\n")

--- a/deployments/sara_verified_local_v1/tests/test_event_outbox.py
+++ b/deployments/sara_verified_local_v1/tests/test_event_outbox.py
@@ -277,3 +277,29 @@ def test_replay_after_partial_audit_tail_preserves_a_valid_event(tmp_path):
     assert delivered[0]["payload"]["_outbox_event_id"] == event_id
     assert outbox_status(store.get_registry())["pending"] == 0
     assert store.audit_path.read_bytes().endswith(b"\n")
+
+
+
+def test_failed_tail_separator_write_keeps_outbox_pending(tmp_path, monkeypatch):
+    from worldshepherd_sara import storage as storage_module
+
+    store = DurableStore(tmp_path / "data")
+    event_id = queue_fixed_event(store, "SARA-EVENT-SEPARATOR-001")
+    store.audit_path.write_bytes(b'{"event":"interrupted"')
+    original_write = storage_module.os.write
+
+    def fail_separator(descriptor, data):
+        if data == b"\\n":
+            return 0
+        return original_write(descriptor, data)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(storage_module.os, "write", fail_separator)
+        with pytest.raises(OSError, match="separator write made no progress"):
+            drain_event_outbox(store, limit=1)
+
+    assert pending_event_ids(store.get_registry()) == [event_id]
+    assert not any(
+        record.get("event") == "test_provenance"
+        for record in store.read_audit(50)
+    )

--- a/deployments/sara_verified_local_v1/tests/test_event_outbox.py
+++ b/deployments/sara_verified_local_v1/tests/test_event_outbox.py
@@ -289,7 +289,7 @@ def test_failed_tail_separator_write_keeps_outbox_pending(tmp_path, monkeypatch)
     original_write = storage_module.os.write
 
     def fail_separator(descriptor, data):
-        if data == b"\\n":
+        if data == b"\n":
             return 0
         return original_write(descriptor, data)
 

--- a/deployments/sara_verified_local_v1/tests/test_event_outbox.py
+++ b/deployments/sara_verified_local_v1/tests/test_event_outbox.py
@@ -262,3 +262,18 @@ def test_mission_completion_quarantines_even_when_outbox_is_saturated(client, to
     assert persisted.json()["passport"]["custody"]["state"] == (
         "QUARANTINED_FOR_REQUALIFICATION"
     )
+
+
+
+def test_replay_after_partial_audit_tail_preserves_a_valid_event(tmp_path):
+    store = DurableStore(tmp_path / "data")
+    event_id = queue_fixed_event(store, "SARA-EVENT-PARTIAL-001")
+    store.audit_path.write_bytes(b'{"event":"interrupted"')
+    assert drain_event_outbox(store, limit=1) == 1
+    records = store.read_audit(50)
+    assert records[0] == {"event": "audit_corruption_detected", "reason": "invalid_line"}
+    delivered = [item for item in records if item.get("event") == "test_provenance"]
+    assert len(delivered) == 1
+    assert delivered[0]["payload"]["_outbox_event_id"] == event_id
+    assert outbox_status(store.get_registry())["pending"] == 0
+    assert store.audit_path.read_bytes().endswith(b"\\n")

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
@@ -174,7 +174,7 @@ class DurableStore:
         with self._lock:
             descriptor = os.open(
                 self.audit_path,
-                os.O_WRONLY
+                os.O_RDWR
                 | os.O_CREAT
                 | os.O_APPEND
                 | getattr(os, "O_NOFOLLOW", 0),
@@ -182,13 +182,23 @@ class DurableStore:
             )
             try:
                 self._secure_descriptor(descriptor, 0o600, "audit file")
-            except Exception:
+                size = os.fstat(descriptor).st_size
+                if size:
+                    os.lseek(descriptor, -1, os.SEEK_END)
+                    if os.read(descriptor, 1) != b"\n":
+                        # Preserve an interrupted tail as visible corruption,
+                        # then frame the replayed event as its own JSONL record.
+                        # A crash before the new record keeps the outbox pending.
+                        os.write(descriptor, b"\n")
+                payload = (line + "\n").encode("utf-8")
+                while payload:
+                    written = os.write(descriptor, payload)
+                    if written == 0:
+                        raise OSError("audit append made no progress")
+                    payload = payload[written:]
+                os.fsync(descriptor)
+            finally:
                 os.close(descriptor)
-                raise
-            with os.fdopen(descriptor, "a", encoding="utf-8") as handle:
-                handle.write(line + "\n")
-                handle.flush()
-                os.fsync(handle.fileno())
             self._secure_mode(self.audit_path, 0o600, "audit file")
 
     def read_audit(self, limit: int) -> list[dict[str, Any]]:

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/storage.py
@@ -189,7 +189,8 @@ class DurableStore:
                         # Preserve an interrupted tail as visible corruption,
                         # then frame the replayed event as its own JSONL record.
                         # A crash before the new record keeps the outbox pending.
-                        os.write(descriptor, b"\n")
+                        if os.write(descriptor, b"\n") != 1:
+                            raise OSError("audit tail separator write made no progress")
                 payload = (line + "\n").encode("utf-8")
                 while payload:
                     written = os.write(descriptor, payload)


### PR DESCRIPTION
## Superseded

This stale-base PR is superseded by current-main safe-port PR #275. A compare from this PR's base through current `main` confirmed neither changed file was modified in the intervening commits, so #275 reuses the exact reviewed blobs on top of current main.

This PR is retained closed for provenance only. Do not merge or use it as a readiness claim.