### PR TITLE
Add simulator-only fusion control demonstrator

### DIFF
--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -14,6 +14,7 @@ on:
       - 'worldshepherd_sara/fusion_replay.py'
       - 'worldshepherd_sara/fusion_audit_bridge.py'
       - 'worldshepherd_sara/fusion_faults.py'
+      - 'worldshepherd_sara/fusion_consensus.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fair_mast_manifest.py'
@@ -21,6 +22,7 @@ on:
       - 'tests/test_fusion_replay.py'
       - 'tests/test_fusion_audit_bridge.py'
       - 'tests/test_fusion_faults.py'
+      - 'tests/test_fusion_consensus.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
@@ -52,6 +54,7 @@ jobs:
           worldshepherd_sara/fusion_replay.py
           worldshepherd_sara/fusion_audit_bridge.py
           worldshepherd_sara/fusion_faults.py
+          worldshepherd_sara/fusion_consensus.py
           scripts/probe_fair_mast_data.py
       - name: Run fusion-control test suite
         run: >-
@@ -63,6 +66,7 @@ jobs:
           tests/test_fusion_replay.py
           tests/test_fusion_audit_bridge.py
           tests/test_fusion_faults.py
+          tests/test_fusion_consensus.py
 
   fair-mast-source-probe:
     if: >-

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -11,9 +11,11 @@ on:
       - 'worldshepherd_sara/fusion_control.py'
       - 'worldshepherd_sara/fair_mast_adapter.py'
       - 'worldshepherd_sara/fusion_replay.py'
+      - 'worldshepherd_sara/fusion_audit_bridge.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fusion_replay.py'
+      - 'tests/test_fusion_audit_bridge.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
@@ -40,9 +42,11 @@ jobs:
           worldshepherd_sara/fusion_control.py
           worldshepherd_sara/fair_mast_adapter.py
           worldshepherd_sara/fusion_replay.py
-      - name: Run fusion-control, FAIR-MAST, and replay tests
+          worldshepherd_sara/fusion_audit_bridge.py
+      - name: Run fusion-control test suite
         run: >-
           python -m pytest -q
           tests/test_fusion_control.py
           tests/test_fair_mast_adapter.py
           tests/test_fusion_replay.py
+          tests/test_fusion_audit_bridge.py

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -22,6 +22,7 @@ on:
       - 'tests/test_fusion_audit_bridge.py'
       - 'tests/test_fusion_faults.py'
       - 'scripts/run_fusion_control_demo.py'
+      - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
@@ -51,6 +52,7 @@ jobs:
           worldshepherd_sara/fusion_replay.py
           worldshepherd_sara/fusion_audit_bridge.py
           worldshepherd_sara/fusion_faults.py
+          scripts/probe_fair_mast_data.py
       - name: Run fusion-control test suite
         run: >-
           python -m pytest -q
@@ -96,4 +98,43 @@ jobs:
               print(signal + '_shape=' + repr(zarray.get('shape')))
               print(signal + '_dtype=' + repr(zarray.get('dtype')))
               print(signal + '_units=' + repr(zattrs.get('units')))
+          PY
+
+  fair-mast-data-probe:
+    if: >-
+      github.event_name == 'push' &&
+      contains(github.event.head_commit.message, '[probe-fair-mast-data]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - name: Install pinned decoder dependencies
+        run: >-
+          python -m pip install --disable-pip-version-check
+          numpy==1.26.4 numcodecs==0.12.1
+      - name: Fetch and validate pinned FAIR-MAST time/current chunks
+        run: >-
+          python scripts/probe_fair_mast_data.py
+          --manifest data/fair_mast/shot_30420_amc_manifest.json
+          --output /tmp/fair-mast-shot-30420-amc-data-probe.json
+      - name: Verify data-probe claims boundary
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('/tmp/fair-mast-shot-30420-amc-data-probe.json').read_text())
+          assert report['raw_values_persisted'] is False
+          assert report['machine_control_authority'] is False
+          assert report['control_evidence_eligible'] is False
+          assert report['time']['count'] == report['plasma_current']['count'] == 30000
+          print('data_probe_report_sha256=' + report['report_sha256'])
+          print('time_chunk_sha256=' + report['time']['compressed_sha256'])
+          print('plasma_current_chunk_sha256=' + report['plasma_current']['compressed_sha256'])
+          print('paired_window_sha256=' + str(report['paired_window_0_to_0_35_s']['paired_values_sha256']))
+          print('paired_window_count=' + str(report['paired_window_0_to_0_35_s']['finite_sample_count']))
           PY

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -18,6 +18,7 @@ on:
       - 'worldshepherd_sara/archive_readiness.py'
       - 'worldshepherd_sara/external_observer.py'
       - 'worldshepherd_sara/control_admission.py'
+      - 'worldshepherd_sara/observer_authority.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fair_mast_manifest.py'
@@ -29,6 +30,7 @@ on:
       - 'tests/test_archive_readiness.py'
       - 'tests/test_external_observer.py'
       - 'tests/test_control_admission.py'
+      - 'tests/test_observer_authority.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
@@ -65,6 +67,7 @@ jobs:
           worldshepherd_sara/archive_readiness.py
           worldshepherd_sara/external_observer.py
           worldshepherd_sara/control_admission.py
+          worldshepherd_sara/observer_authority.py
           scripts/probe_fair_mast_data.py
       - name: Run fusion-control test suite
         run: >-
@@ -80,6 +83,7 @@ jobs:
           tests/test_archive_readiness.py
           tests/test_external_observer.py
           tests/test_control_admission.py
+          tests/test_observer_authority.py
 
   fair-mast-source-probe:
     if: >-

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -9,7 +9,9 @@ on:
       - worldshepherd-sspadawanzz-admin
     paths:
       - 'worldshepherd_sara/fusion_control.py'
+      - 'worldshepherd_sara/fair_mast_adapter.py'
       - 'tests/test_fusion_control.py'
+      - 'tests/test_fair_mast_adapter.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
@@ -30,7 +32,13 @@ jobs:
           python-version: '3.11'
       - name: Install test dependency
         run: python -m pip install --disable-pip-version-check pytest
-      - name: Compile fusion control module
-        run: python -m py_compile worldshepherd_sara/fusion_control.py
-      - name: Run fusion-control tests
-        run: python -m pytest -q tests/test_fusion_control.py
+      - name: Compile fusion modules
+        run: >-
+          python -m py_compile
+          worldshepherd_sara/fusion_control.py
+          worldshepherd_sara/fair_mast_adapter.py
+      - name: Run fusion-control and FAIR-MAST adapter tests
+        run: >-
+          python -m pytest -q
+          tests/test_fusion_control.py
+          tests/test_fair_mast_adapter.py

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -1,0 +1,36 @@
+name: Fusion Control Simulator CI
+
+on:
+  push:
+    branches:
+      - worldshepherd/fusion-control-sim-v0-1-20260912
+  pull_request:
+    branches:
+      - worldshepherd-sspadawanzz-admin
+    paths:
+      - 'worldshepherd_sara/fusion_control.py'
+      - 'tests/test_fusion_control.py'
+      - 'scripts/run_fusion_control_demo.py'
+      - 'docs/WS_FUSION_CTRL_001.md'
+      - '.github/workflows/fusion-control-sim.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  fusion-control-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install test dependency
+        run: python -m pip install --disable-pip-version-check pytest
+      - name: Compile fusion control module
+        run: python -m py_compile worldshepherd_sara/fusion_control.py
+      - name: Run fusion-control tests
+        run: python -m pytest -q tests/test_fusion_control.py

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -29,13 +29,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - name: Install test dependency
-        run: python -m pip install --disable-pip-version-check pytest
+      - name: Install pinned test dependency
+        run: python -m pip install --disable-pip-version-check pytest==9.1.1
       - name: Compile fusion modules
         run: >-
           python -m py_compile

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -10,12 +10,14 @@ on:
     paths:
       - 'worldshepherd_sara/fusion_control.py'
       - 'worldshepherd_sara/fair_mast_adapter.py'
+      - 'worldshepherd_sara/fair_mast_probe.py'
       - 'worldshepherd_sara/fusion_replay.py'
       - 'worldshepherd_sara/fusion_audit_bridge.py'
       - 'worldshepherd_sara/fusion_faults.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fair_mast_manifest.py'
+      - 'tests/test_fair_mast_probe.py'
       - 'tests/test_fusion_replay.py'
       - 'tests/test_fusion_audit_bridge.py'
       - 'tests/test_fusion_faults.py'
@@ -45,6 +47,7 @@ jobs:
           python -m py_compile
           worldshepherd_sara/fusion_control.py
           worldshepherd_sara/fair_mast_adapter.py
+          worldshepherd_sara/fair_mast_probe.py
           worldshepherd_sara/fusion_replay.py
           worldshepherd_sara/fusion_audit_bridge.py
           worldshepherd_sara/fusion_faults.py
@@ -54,6 +57,43 @@ jobs:
           tests/test_fusion_control.py
           tests/test_fair_mast_adapter.py
           tests/test_fair_mast_manifest.py
+          tests/test_fair_mast_probe.py
           tests/test_fusion_replay.py
           tests/test_fusion_audit_bridge.py
           tests/test_fusion_faults.py
+
+  fair-mast-source-probe:
+    if: >-
+      github.event_name == 'push' &&
+      contains(github.event.head_commit.message, '[probe-fair-mast]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - name: Probe pinned FAIR-MAST Zarr metadata only
+        run: >-
+          python -m worldshepherd_sara.fair_mast_probe
+          --manifest data/fair_mast/shot_30420_amc_manifest.json
+          --output /tmp/fair-mast-shot-30420-amc-probe.json
+      - name: Verify probe safety flags
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('/tmp/fair-mast-shot-30420-amc-probe.json').read_text())
+          assert report['array_chunks_fetched'] is False
+          assert report['machine_control_authority'] is False
+          assert set(report['signals']) == {'time', 'plasma_current'}
+          print('probe_report_sha256=' + report['report_sha256'])
+          for signal in ('time', 'plasma_current'):
+              zarray = report['signals'][signal]['.zarray']['metadata']
+              zattrs = report['signals'][signal]['.zattrs']['metadata']
+              print(signal + '_shape=' + repr(zarray.get('shape')))
+              print(signal + '_dtype=' + repr(zarray.get('dtype')))
+              print(signal + '_units=' + repr(zattrs.get('units')))
+          PY

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -16,6 +16,7 @@ on:
       - 'worldshepherd_sara/fusion_faults.py'
       - 'worldshepherd_sara/fusion_consensus.py'
       - 'worldshepherd_sara/archive_readiness.py'
+      - 'worldshepherd_sara/external_observer.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fair_mast_manifest.py'
@@ -25,6 +26,7 @@ on:
       - 'tests/test_fusion_faults.py'
       - 'tests/test_fusion_consensus.py'
       - 'tests/test_archive_readiness.py'
+      - 'tests/test_external_observer.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
@@ -59,6 +61,7 @@ jobs:
           worldshepherd_sara/fusion_faults.py
           worldshepherd_sara/fusion_consensus.py
           worldshepherd_sara/archive_readiness.py
+          worldshepherd_sara/external_observer.py
           scripts/probe_fair_mast_data.py
       - name: Run fusion-control test suite
         run: >-
@@ -72,6 +75,7 @@ jobs:
           tests/test_fusion_faults.py
           tests/test_fusion_consensus.py
           tests/test_archive_readiness.py
+          tests/test_external_observer.py
 
   fair-mast-source-probe:
     if: >-

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -10,8 +10,10 @@ on:
     paths:
       - 'worldshepherd_sara/fusion_control.py'
       - 'worldshepherd_sara/fair_mast_adapter.py'
+      - 'worldshepherd_sara/fusion_replay.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
+      - 'tests/test_fusion_replay.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
@@ -37,8 +39,10 @@ jobs:
           python -m py_compile
           worldshepherd_sara/fusion_control.py
           worldshepherd_sara/fair_mast_adapter.py
-      - name: Run fusion-control and FAIR-MAST adapter tests
+          worldshepherd_sara/fusion_replay.py
+      - name: Run fusion-control, FAIR-MAST, and replay tests
         run: >-
           python -m pytest -q
           tests/test_fusion_control.py
           tests/test_fair_mast_adapter.py
+          tests/test_fusion_replay.py

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -34,7 +34,9 @@ on:
       - 'scripts/run_fusion_control_demo.py'
       - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
+      - 'evidence/fair_mast/shot_30420_amc_metadata_probe_20260912.json'
       - 'evidence/fair_mast/shot_30420_amc_data_probe_20260912.json'
+      - 'evidence/fair_mast/observer_authority_gap_20260912.json'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
 

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -15,6 +15,7 @@ on:
       - 'worldshepherd_sara/fusion_audit_bridge.py'
       - 'worldshepherd_sara/fusion_faults.py'
       - 'worldshepherd_sara/fusion_consensus.py'
+      - 'worldshepherd_sara/archive_readiness.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fair_mast_manifest.py'
@@ -23,9 +24,11 @@ on:
       - 'tests/test_fusion_audit_bridge.py'
       - 'tests/test_fusion_faults.py'
       - 'tests/test_fusion_consensus.py'
+      - 'tests/test_archive_readiness.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
+      - 'evidence/fair_mast/shot_30420_amc_data_probe_20260912.json'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
 
@@ -55,6 +58,7 @@ jobs:
           worldshepherd_sara/fusion_audit_bridge.py
           worldshepherd_sara/fusion_faults.py
           worldshepherd_sara/fusion_consensus.py
+          worldshepherd_sara/archive_readiness.py
           scripts/probe_fair_mast_data.py
       - name: Run fusion-control test suite
         run: >-
@@ -67,6 +71,7 @@ jobs:
           tests/test_fusion_audit_bridge.py
           tests/test_fusion_faults.py
           tests/test_fusion_consensus.py
+          tests/test_archive_readiness.py
 
   fair-mast-source-probe:
     if: >-

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -12,11 +12,15 @@ on:
       - 'worldshepherd_sara/fair_mast_adapter.py'
       - 'worldshepherd_sara/fusion_replay.py'
       - 'worldshepherd_sara/fusion_audit_bridge.py'
+      - 'worldshepherd_sara/fusion_faults.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
+      - 'tests/test_fair_mast_manifest.py'
       - 'tests/test_fusion_replay.py'
       - 'tests/test_fusion_audit_bridge.py'
+      - 'tests/test_fusion_faults.py'
       - 'scripts/run_fusion_control_demo.py'
+      - 'data/fair_mast/shot_30420_amc_manifest.json'
       - 'docs/WS_FUSION_CTRL_001.md'
       - '.github/workflows/fusion-control-sim.yml'
 
@@ -43,10 +47,13 @@ jobs:
           worldshepherd_sara/fair_mast_adapter.py
           worldshepherd_sara/fusion_replay.py
           worldshepherd_sara/fusion_audit_bridge.py
+          worldshepherd_sara/fusion_faults.py
       - name: Run fusion-control test suite
         run: >-
           python -m pytest -q
           tests/test_fusion_control.py
           tests/test_fair_mast_adapter.py
+          tests/test_fair_mast_manifest.py
           tests/test_fusion_replay.py
           tests/test_fusion_audit_bridge.py
+          tests/test_fusion_faults.py

--- a/.github/workflows/fusion-control-sim.yml
+++ b/.github/workflows/fusion-control-sim.yml
@@ -17,6 +17,7 @@ on:
       - 'worldshepherd_sara/fusion_consensus.py'
       - 'worldshepherd_sara/archive_readiness.py'
       - 'worldshepherd_sara/external_observer.py'
+      - 'worldshepherd_sara/control_admission.py'
       - 'tests/test_fusion_control.py'
       - 'tests/test_fair_mast_adapter.py'
       - 'tests/test_fair_mast_manifest.py'
@@ -27,6 +28,7 @@ on:
       - 'tests/test_fusion_consensus.py'
       - 'tests/test_archive_readiness.py'
       - 'tests/test_external_observer.py'
+      - 'tests/test_control_admission.py'
       - 'scripts/run_fusion_control_demo.py'
       - 'scripts/probe_fair_mast_data.py'
       - 'data/fair_mast/shot_30420_amc_manifest.json'
@@ -62,6 +64,7 @@ jobs:
           worldshepherd_sara/fusion_consensus.py
           worldshepherd_sara/archive_readiness.py
           worldshepherd_sara/external_observer.py
+          worldshepherd_sara/control_admission.py
           scripts/probe_fair_mast_data.py
       - name: Run fusion-control test suite
         run: >-
@@ -76,6 +79,7 @@ jobs:
           tests/test_fusion_consensus.py
           tests/test_archive_readiness.py
           tests/test_external_observer.py
+          tests/test_control_admission.py
 
   fair-mast-source-probe:
     if: >-

--- a/data/fair_mast/shot_30420_amc_manifest.json
+++ b/data/fair_mast/shot_30420_amc_manifest.json
@@ -1,0 +1,35 @@
+{
+  "schema": "worldshepherd.fair_mast.source_manifest.v1",
+  "status": "SOURCE_MANIFEST_ONLY_NO_ARCHIVED_VALUES_EMBEDDED",
+  "archive": "FAIR-MAST",
+  "shot_id": 30420,
+  "data_level": "level1",
+  "diagnostic_group": "amc",
+  "signals": [
+    "time",
+    "plasma_current"
+  ],
+  "zarr_uri": "s3://mast/level1/shots/30420.zarr/amc",
+  "s3_endpoint": "https://s3.echo.stfc.ac.uk",
+  "metadata_api_base": "https://mastapp.site/json",
+  "source_evidence": [
+    {
+      "type": "upstream_repository",
+      "organization": "UK Atomic Energy Authority",
+      "repository": "ukaea/fair-mast",
+      "reference": "https://github.com/ukaea/fair-mast"
+    },
+    {
+      "type": "upstream_usage_example",
+      "organization": "UK Atomic Energy Authority FAIR-MAST",
+      "reference": "https://github.com/ukaea/fair-mast/issues/107",
+      "supports": "shot 30420 level1 AMC Zarr path and plasma_current signal"
+    }
+  ],
+  "claims_boundary": {
+    "real_archive_values_in_repository": false,
+    "live_machine_data": false,
+    "machine_control_authority": false,
+    "purpose": "Pin a reproducible public archive target before downloading or replaying real diagnostic arrays."
+  }
+}

--- a/docs/WS_FUSION_CTRL_001.md
+++ b/docs/WS_FUSION_CTRL_001.md
@@ -13,11 +13,12 @@ The branch now exercises:
 5. SHA-256 hash-chained audit and deterministic replay;
 6. strict read-only FAIR-MAST source/data validation;
 7. non-mutating mapping into the existing SARA audit shape;
-8. offline diagnostic fault injection;
+8. expanded offline diagnostic fault injection;
 9. estimator-consensus/disagreement handling;
 10. provenance-gated external observer intake;
-11. archive evidence readiness classification;
-12. an explicit archive-to-control admission gate.
+11. external-observer authority completeness checks;
+12. archive evidence readiness classification;
+13. an explicit archive-to-control admission gate.
 
 ## Hard safety boundary
 
@@ -44,6 +45,8 @@ provenance + validity checks
 state estimator(s)
         |
         +---- external observer adapter (source validated only)
+        |             |
+        |             +---- observer authority completeness gate
         |
         v
 estimator consensus / disagreement gate
@@ -72,7 +75,7 @@ FAIR-MAST evidence -> archive readiness -> control admission
 
 ## Core contracts
 
-Every `SensorSample` carries timestamp, shot identity, diagnostic identity, value/unit, uncertainty, validity, quality, and provenance.
+Every `SensorSample` carries timestamp, shot identity, diagnostic identity, value/unit, uncertainty, validity, quality, and provenance. Blank unit, quality, diagnostic identity, or provenance now fails validation.
 
 Every `PlasmaStateEstimate` carries timestamp, shot identity, displacement estimate, confidence, estimator identity, and source diagnostics.
 
@@ -97,6 +100,8 @@ Rejected proposals receive `applied_value = null`.
 
 `DifferentialOpticalEstimator` uses a normalized difference between upper/lower synthetic optical-emission channels. It exists to exercise the data/control architecture and is **not** a validated plasma-position estimator.
 
+The estimator now also rejects paired inputs that claim the same diagnostic identity, preventing contradictory metadata from being treated as two independent optical channels.
+
 `ProportionalVirtualActuatorController` produces an abstract correction from the demonstration displacement. It has no physical actuator semantics.
 
 ## Estimator consensus and external observers
@@ -113,6 +118,24 @@ Rejected proposals receive `applied_value = null`.
 The tolerance is a software policy parameter, **not** a validated plasma-physics threshold.
 
 `ExternalObserverAdapter` does not implement magnetic or equilibrium reconstruction. It only admits an externally produced estimate when method, diagnostics, provenance, quality, confidence, estimator identity, and source validation are explicit. This creates a partner/laboratory integration point without fabricating a second physics model.
+
+### Observer authority completeness
+
+`observer_authority.py` adds a separate fail-closed completeness check for external equilibrium/state observers. A packet must carry provenance for:
+
+- diagnostic geometry and calibration;
+- passive-structure model;
+- response matrices or their generation method;
+- reconstruction settings;
+- coordinate conventions.
+
+Profile/kinetic constraints are tracked as optional because they are method-dependent.
+
+The validator also requires explicit `validated_by` and `validation_reference` fields. This proves packet completeness only; it does **not** certify that a source is scientifically authoritative.
+
+A public FAIR-MAST issue (#231, opened 2026-07-24) independently requests these same categories for reproducible MAST equilibrium reconstruction work. Worldshepherd records that as supporting evidence only—not as proof that UKAEA lacks or possesses the requested materials. The claims-controlled record is:
+
+`evidence/fair_mast/observer_authority_gap_20260912.json`
 
 ## Audit, replay, and SARA bridge
 
@@ -197,14 +220,22 @@ Current control blockers include:
 
 ## Offline diagnostic fault campaign
 
-The standard campaign verifies safe failure for:
+The standard campaign now verifies safe failure for twelve cases:
 
 - dropped paired sample;
 - excessive timestamp skew;
 - shot mismatch;
 - missing provenance;
 - non-finite value;
-- explicit invalid-sensor flag.
+- explicit invalid-sensor flag;
+- duplicated pair;
+- delayed lower stream;
+- reordered pair;
+- contradictory/colliding diagnostic identity;
+- missing unit metadata;
+- missing quality metadata.
+
+Duplicated and reordered pairs are rejected by the strictly increasing replay-time invariant. One-sided delay is rejected by the pair-time-skew invariant. Metadata corruption and diagnostic identity collision fail before a valid state estimate can be produced.
 
 These are data-integrity invariants, not plasma-physics anomaly thresholds.
 
@@ -219,13 +250,13 @@ Branch-scoped GitHub Actions uses:
 - `contents: read` permissions;
 - explicit Python compile gate.
 
-At commit `a5d8f3825dc28af06d43f7c4ec3f8cfd2962b270`, the complete targeted suite reported:
+At commit `b7d0cf4de45cc5a0e7568293032203ae67813830`, the complete targeted suite reported:
 
 ```text
-50 passed in 0.14s
+57 passed in 0.15s
 ```
 
-The suite covers simulator control, FAIR-MAST adapter/manifest/probe, deterministic replay, SARA audit mapping, fault injection, estimator consensus, archive readiness, external-observer admission, and archive-to-control admission.
+The suite covers simulator control, FAIR-MAST adapter/manifest/probe, deterministic replay, SARA audit mapping, twelve-case fault injection, estimator consensus, archive readiness, external-observer admission, observer-authority completeness, and archive-to-control admission.
 
 ## Claims state
 
@@ -239,9 +270,10 @@ The suite covers simulator control, FAIR-MAST adapter/manifest/probe, determinis
 - read-only FAIR-MAST adapters/probes;
 - deterministic replay/fingerprinting;
 - non-mutating SARA audit bridge;
-- six-case diagnostic fault campaign;
+- twelve-case diagnostic fault campaign;
 - estimator-consensus gate;
 - external-observer adapter;
+- observer-authority completeness gate;
 - archive readiness classifier;
 - archive-to-control admission gate.
 
@@ -252,11 +284,17 @@ The suite covers simulator control, FAIR-MAST adapter/manifest/probe, determinis
 - archive content hashes and statistics persisted without raw sample persistence;
 - time and plasma-current arrays each contain 30,000 finite samples in this probe.
 
+### SUPPORTED BY EXTERNAL SOURCE EVIDENCE
+
+- FAIR-MAST issue #231 independently identifies diagnostic geometry/calibration, passive-structure authority, response matrices, reconstruction settings, coordinate conventions, and optional profile/kinetic constraints as relevant authorities for reproducible MAST equilibrium reconstruction work.
+- This issue is a community request hosted in the FAIR-MAST tracker; it is not treated as an official statement that UKAEA lacks or possesses those authorities.
+
 ### REQUIRES FURTHER DATA/PARTNER VALIDATION
 
 - calibration/quality interpretation beyond the archive's `Not Checked` label;
 - a defensible uncertainty model supplied by source metadata, calibration evidence, or validated methodology;
 - a genuine independent state estimator/observer supplied by a qualified external method or implemented and validated separately;
+- an authority-complete observer packet backed by genuinely authoritative sources;
 - comparison against authoritative plasma-state/equilibrium reconstruction;
 - real state-estimation accuracy and latency validation.
 
@@ -274,8 +312,8 @@ Any claim that Worldshepherd estimates or controls real plasma position, improve
 
 ## Next gates
 
-1. Obtain authoritative calibration/uncertainty/quality information for selected FAIR-MAST diagnostics instead of inventing uncertainty.
-2. Attach a genuinely independent equilibrium/state observer through `ExternalObserverAdapter` and exercise disagreement handling against the demonstration estimator.
-3. Extend fault injection to duplicated, delayed, contradictory, reordered, and metadata-corrupted streams.
+1. Resolve authoritative calibration/uncertainty/quality information for selected FAIR-MAST diagnostics instead of inventing uncertainty.
+2. Resolve the required observer-authority categories against primary UKAEA/lab documentation or a qualified partner package.
+3. Attach a genuinely independent equilibrium/state observer through `ExternalObserverAdapter` and exercise disagreement handling against the demonstration estimator.
 4. Build analysis-only replay for selected real public signals where the physics mapping is justified; keep control admission closed until validation requirements are actually met.
 5. Only after these gates pass, evaluate a **non-actuating, read-only EPICS-compatible telemetry adapter**.

--- a/docs/WS_FUSION_CTRL_001.md
+++ b/docs/WS_FUSION_CTRL_001.md
@@ -1,22 +1,25 @@
-# WS-FUSION-CTRL-001 — Simulator-Only Fusion Control Demonstrator
+# WS-FUSION-CTRL-001 — Simulator-Only Fusion Control Assurance Demonstrator
 
 ## Purpose
 
-Establish an auditable Worldshepherd control pattern for fusion research without creating any live hardware command path.
+Establish an auditable Worldshepherd control-assurance pattern for fusion research without creating any live hardware command path.
 
-The demonstrator now exercises:
+The branch now exercises:
 
-1. diagnostic sample validation and provenance;
-2. state estimation from paired demonstration optical signals;
-3. a model-generated virtual-actuator proposal;
+1. provenance-bearing diagnostic validation;
+2. a demonstration optical state estimator;
+3. abstract virtual-actuator proposals;
 4. an independent deterministic PRIME-style safety gate;
-5. append-only hash-chained audit/replay evidence;
-6. strict read-only FAIR-MAST source identity and metadata access;
-7. deterministic replay with evidence fingerprints;
-8. non-mutating mapping into the existing SARA audit event shape;
-9. offline diagnostic fault injection and safe-failure verification.
+5. SHA-256 hash-chained audit and deterministic replay;
+6. strict read-only FAIR-MAST source/data validation;
+7. non-mutating mapping into the existing SARA audit shape;
+8. offline diagnostic fault injection;
+9. estimator-consensus/disagreement handling;
+10. provenance-gated external observer intake;
+11. archive evidence readiness classification;
+12. an explicit archive-to-control admission gate.
 
-## Safety boundary
+## Hard safety boundary
 
 This branch intentionally contains **no**:
 
@@ -27,157 +30,235 @@ This branch intentionally contains **no**:
 - neutral-beam or RF-heating command interface;
 - plasma-facing hardware actuator transport.
 
-The only actuator enabled by the default demo is `virtual_vertical_balance`, measured in arbitrary simulator units.
+The default actuator remains `virtual_vertical_balance` in arbitrary simulator units.
 
-The FAIR-MAST client is GET-only, HTTPS-only, host-allowlisted, and provides no arbitrary-URL fetch method. Zarr array reading is deliberately kept outside the control core so archive access cannot be mistaken for actuator authority.
+## Control architecture
 
-## Core data contract
+```text
+measurement / archive source
+        |
+        v
+provenance + validity checks
+        |
+        v
+state estimator(s)
+        |
+        +---- external observer adapter (source validated only)
+        |
+        v
+estimator consensus / disagreement gate
+        |
+        v
+model-generated virtual proposal
+        |
+        v
+independent PRIME-style deterministic safety gate
+        |
+        v
+virtual actuator only
+        |
+        v
+hash-chained audit + deterministic replay
+```
 
-Every `SensorSample` carries:
+Archive data has a separate claims gate:
 
-- timestamp;
-- shot identifier;
-- diagnostic identifier;
-- value and unit;
-- uncertainty;
-- validity flag;
-- quality label;
-- provenance identifier.
+```text
+FAIR-MAST evidence -> archive readiness -> control admission
+                                      |
+                                      +-> analysis allowed when justified
+                                      +-> control denied unless all control evidence requirements pass
+```
 
-Every state estimate carries estimator identity, confidence, and source diagnostics.
-Every control proposal carries model identity, confidence, rationale, target virtual actuator, and requested value.
+## Core contracts
+
+Every `SensorSample` carries timestamp, shot identity, diagnostic identity, value/unit, uncertainty, validity, quality, and provenance.
+
+Every `PlasmaStateEstimate` carries timestamp, shot identity, displacement estimate, confidence, estimator identity, and source diagnostics.
+
+Every `ControlProposal` carries timestamp, shot identity, virtual actuator, requested value/unit, model identity, confidence, and rationale.
 
 ## PRIME-style safety gate
 
-The deterministic gate operates independently from the proposal generator and rejects proposals when any of the following holds:
+The deterministic gate is independent of the proposal generator and rejects:
 
-- actuator is not allowlisted;
-- units do not match the configured envelope;
-- model identity is missing;
-- value or confidence is invalid;
-- confidence is below threshold;
-- command is outside min/max bounds;
-- command timing is non-monotonic;
-- slew rate exceeds the configured limit.
+- non-allowlisted actuators;
+- unit mismatches;
+- missing model identity;
+- non-finite values or invalid confidence;
+- confidence below threshold;
+- values outside configured bounds;
+- non-monotonic command timing;
+- excessive slew.
 
 Rejected proposals receive `applied_value = null`.
 
-## Demonstration estimator
+## Demonstration estimator and controller
 
-`DifferentialOpticalEstimator` uses a normalized difference between upper and lower synthetic optical-emission channels. It exists only to exercise the control/data architecture. It is **not** represented as a validated plasma-position estimator.
+`DifferentialOpticalEstimator` uses a normalized difference between upper/lower synthetic optical-emission channels. It exists to exercise the data/control architecture and is **not** a validated plasma-position estimator.
 
-## Virtual controller
+`ProportionalVirtualActuatorController` produces an abstract correction from the demonstration displacement. It has no physical actuator semantics.
 
-`ProportionalVirtualActuatorController` generates an abstract correction from the simulated vertical displacement. It has no hardware semantics.
+## Estimator consensus and external observers
+
+`StateConsensusGate` requires multiple distinct estimator identities and rejects:
+
+- insufficient estimators;
+- duplicate estimator identity presented as independence;
+- cross-shot estimates;
+- low-confidence estimates;
+- excessive estimator time skew;
+- disagreement outside a configured tolerance.
+
+The tolerance is a software policy parameter, **not** a validated plasma-physics threshold.
+
+`ExternalObserverAdapter` does not implement magnetic or equilibrium reconstruction. It only admits an externally produced estimate when method, diagnostics, provenance, quality, confidence, estimator identity, and source validation are explicit. This creates a partner/laboratory integration point without fabricating a second physics model.
 
 ## Audit, replay, and SARA bridge
 
-`FusionAuditLedger` creates a sequence-numbered SHA-256 hash chain over sensor, state, proposal, and gate-decision events. The goal is deterministic replay evidence, not cryptographic non-repudiation.
+`FusionAuditLedger` creates a sequence-numbered SHA-256 hash chain over control-pipeline events.
 
-`FusionReplayRunner` requires paired series, matching shot identity, bounded pair-time skew, and strictly increasing replay time. A canonical SHA-256 fingerprint changes when replay input changes and remains stable for identical input/configuration.
+`FusionReplayRunner` requires paired series, matching shot identity, bounded pair-time skew, and strictly increasing time. Identical inputs/configuration produce a stable evidence fingerprint; changed inputs change that fingerprint.
 
-`fusion_audit_bridge.py` maps fusion audit records into the existing SARA `ts/event/actor/payload` structure without writing the SARA audit file or invoking an admin endpoint. It refuses to impersonate `admin`, `operator`, or `SSPADAWANZZ_ADMIN`.
+`fusion_audit_bridge.py` maps fusion records into SARA's existing `ts/event/actor/payload` event shape without writing the SARA audit file or invoking privileged endpoints. It rejects impersonation of `admin`, `operator`, and `SSPADAWANZZ_ADMIN`.
 
-## FAIR-MAST source lane
+## FAIR-MAST source and data evidence
 
-`fair_mast_adapter.py` provides:
-
-- a strict source identity (`FairMastSource`);
-- stable source provenance for each sample index;
-- GET-only host-allowlisted shot metadata access;
-- conversion of already-read archive series into `SensorSample` objects;
-- Level-1/Level-2 quality labels;
-- a conservative quality rule that blocks derivative-sensitive Level-2 magnetics by default because upstream FAIR-MAST issue #211 documented severe quantization for at least one Level-2 magnetics case and recommended Level-1 raw data for derivative-sensitive work.
-
-The repository pins a reproducible public source target at:
+The pinned source manifest is:
 
 `data/fair_mast/shot_30420_amc_manifest.json`
 
-That manifest identifies FAIR-MAST shot `30420`, Level-1 source `amc`, signals `time` and `plasma_current`, and the public Zarr location `s3://mast/level1/shots/30420.zarr/amc`.
+It identifies historical MAST shot `30420`, Level-1 group `amc`, signals `time` and `plasma_current`, and:
 
-**Important:** the manifest is source identity only. It explicitly states that no archived diagnostic values are embedded in this repository. Therefore this branch does not yet claim a completed replay of real FAIR-MAST signal arrays.
+`s3://mast/level1/shots/30420.zarr/amc`
 
-## Fault campaign
+### Metadata-only live probe
 
-`fusion_faults.py` injects faults only into offline `SensorSample` fixtures and checks for safe failure. The standard campaign covers:
+The bounded live metadata probe confirmed directly from the STFC public archive:
 
-- dropped lower-channel sample;
-- excessive pair timestamp skew;
-- shot-identity mismatch;
+- Zarr format 2;
+- `time`: shape `[30000]`, dtype `<f4`, units `s`;
+- `plasma_current`: shape `[30000]`, dtype `<f4`, units `kA`;
+- source description: `Plasma Current and PF/TF Coil Currents`;
+- upstream quality label: `Not Checked`;
+- no uncertainty field observed in the probed signal attributes.
+
+Metadata evidence is persisted at:
+
+`evidence/fair_mast/shot_30420_amc_metadata_probe_20260912.json`
+
+Metadata probe report SHA-256:
+
+`ffddced3a27e0b479298e5a09203ad59bba1460dd58ef43954d0e248eb416c0b`
+
+### Bounded real-value integrity probe
+
+A one-shot GitHub Actions job fetched only the pinned `time/0` and `plasma_current/0` compressed chunks, decoded them according to the declared Zarr metadata, calculated hashes/statistics, and discarded the raw arrays. Raw values were **not** committed.
+
+Evidence is persisted at:
+
+`evidence/fair_mast/shot_30420_amc_data_probe_20260912.json`
+
+Validated results:
+
+- 30,000 finite time samples;
+- time range approximately `-2.00000024 s` to `3.99979949 s`;
+- strictly increasing time base;
+- median sample interval approximately `0.000200033 s` (~5 kHz);
+- 30,000 finite plasma-current samples;
+- plasma-current units `kA`;
+- time compressed-chunk SHA-256: `3d1f90c80e334a581dc2185e0718c4a0c26e0dddf00d1bb8898fdca46c0f8aae`;
+- current compressed-chunk SHA-256: `6766652b81e6af1586222aa9f5496f61f5dcf813d810fe1e2a7f2e55025a7a64`;
+- bounded paired `0–0.35 s` window: 1,750 finite pairs;
+- paired-window SHA-256: `636d6da6e4f74e112789d239e45c177bc78bfc4feffe169ab1e244f49f1b5f75`;
+- probe report SHA-256: `4d7823c39cca64353a35aa848542fc12b6e783377242a7f4b46dca427e552489`.
+
+This establishes real archive reachability, decoding, time-base integrity, finite-value coverage, and reproducible content fingerprints. It does **not** establish plasma-position estimation or safe control.
+
+## FAIR-MAST quality guard
+
+FAIR-MAST issue #211 documented severe quantization in at least one Level-2 MAST magnetics dataset and derivative artifacts, while Level-1 raw data avoided that specific issue. `FairMastQualityPolicy` therefore blocks derivative-sensitive Level-2 magnetic-looking signals by default. This is a conservative workaround for the documented case, not a claim that every Level-2 signal is defective.
+
+## Archive readiness and control admission
+
+`archive_readiness.py` classifies the real shot-30420 evidence as:
+
+- **analysis evidence eligible:** yes;
+- **control evidence eligible:** no.
+
+Current control blockers include:
+
+- upstream quality is `Not Checked`;
+- no uncertainty metadata was observed;
+- real plasma-state estimation has not been validated;
+- real machine control has not been validated.
+
+`control_admission.py` enforces this distinction. Supplying an ad-hoc uncertainty or manually flipping a `control_evidence_eligible` flag is insufficient to admit the source. The additional validation blockers must also be resolved explicitly.
+
+## Offline diagnostic fault campaign
+
+The standard campaign verifies safe failure for:
+
+- dropped paired sample;
+- excessive timestamp skew;
+- shot mismatch;
 - missing provenance;
-- non-finite diagnostic value;
+- non-finite value;
 - explicit invalid-sensor flag.
 
-These checks enforce data-integrity invariants. They are not substitutes for validated plasma-physics anomaly thresholds.
+These are data-integrity invariants, not plasma-physics anomaly thresholds.
 
 ## CI validation
 
-Branch-scoped GitHub Actions CI uses:
+Branch-scoped GitHub Actions uses:
 
 - `actions/checkout@v7`;
 - `actions/setup-python@v7`;
 - CPython 3.11;
 - pinned `pytest==9.1.1`;
-- `contents: read` workflow permissions;
-- an explicit Python compile gate before tests.
+- `contents: read` permissions;
+- explicit Python compile gate.
 
-At commit `bf33f96d367668b1d0ada3bc07e03a887581310d`, the complete targeted suite reported:
+At commit `a5d8f3825dc28af06d43f7c4ec3f8cfd2962b270`, the complete targeted suite reported:
 
 ```text
-29 passed in 0.09s
+50 passed in 0.14s
 ```
 
-The successful suite covers simulator control, FAIR-MAST adapter/source manifest, deterministic replay, SARA audit mapping, and the diagnostic fault campaign.
-
-## Run the simulator
-
-From the repository root on this branch:
-
-```bash
-PYTHONPATH=. python scripts/run_fusion_control_demo.py
-```
-
-Expected result: one accepted or rejected virtual-actuator decision plus `ledger_ok: true` when the chain is intact.
-
-## Run the targeted tests
-
-```bash
-python -m pytest -q \
-  tests/test_fusion_control.py \
-  tests/test_fair_mast_adapter.py \
-  tests/test_fair_mast_manifest.py \
-  tests/test_fusion_replay.py \
-  tests/test_fusion_audit_bridge.py \
-  tests/test_fusion_faults.py
-```
+The suite covers simulator control, FAIR-MAST adapter/manifest/probe, deterministic replay, SARA audit mapping, fault injection, estimator consensus, archive readiness, external-observer admission, and archive-to-control admission.
 
 ## Claims state
 
 ### IMPLEMENTED IN SOFTWARE + CI VALIDATED
 
 - provenance-bearing simulator data contract;
-- demonstration differential estimator;
+- demonstration optical estimator;
 - virtual controller;
-- independent deterministic PRIME-style gate;
+- independent PRIME-style gate;
 - hash-chained audit ledger;
-- strict read-only FAIR-MAST source adapter;
-- FAIR-MAST source manifest and quality guard;
-- deterministic replay/fingerprint engine;
+- read-only FAIR-MAST adapters/probes;
+- deterministic replay/fingerprinting;
 - non-mutating SARA audit bridge;
-- six-case diagnostic fault campaign.
+- six-case diagnostic fault campaign;
+- estimator-consensus gate;
+- external-observer adapter;
+- archive readiness classifier;
+- archive-to-control admission gate.
 
-### SUPPORTED BY EXTERNAL SOURCE EVIDENCE
+### EXTERNALLY VERIFIED ARCHIVE EVIDENCE
 
-- FAIR-MAST exposes historical MAST metadata/data for research;
-- upstream examples identify the shot-30420 Level-1 AMC path and `plasma_current` signal;
-- upstream issue #211 documents Level-2 magnetics quantization risk relevant to derivative-sensitive analysis.
+- real FAIR-MAST shot-30420 Level-1 AMC metadata retrieved and hashed;
+- real time/plasma-current chunks retrieved and decoded transiently;
+- archive content hashes and statistics persisted without raw sample persistence;
+- time and plasma-current arrays each contain 30,000 finite samples in this probe.
 
-### REQUIRES DATA VALIDATION
+### REQUIRES FURTHER DATA/PARTNER VALIDATION
 
-- retrieval and checksum/provenance capture of actual FAIR-MAST arrays;
-- replay against those retrieved arrays;
-- verification of units, calibration, signal quality, time bases, missing values, and diagnostic-specific metadata;
-- comparison against an independent state-estimation method.
+- calibration/quality interpretation beyond the archive's `Not Checked` label;
+- a defensible uncertainty model supplied by source metadata, calibration evidence, or validated methodology;
+- a genuine independent state estimator/observer supplied by a qualified external method or implemented and validated separately;
+- comparison against authoritative plasma-state/equilibrium reconstruction;
+- real state-estimation accuracy and latency validation.
 
 ### REQUIRES LAB/PARTNER VALIDATION
 
@@ -188,14 +269,13 @@ Any claim that Worldshepherd estimates or controls real plasma position, improve
 - control of a real tokamak;
 - improved fusion performance;
 - net fusion power;
-- propulsion from these control effects;
-- plasma shielding or other unsupported macroscopic protective effects.
+- propulsion from these effects;
+- plasma shielding or unsupported macroscopic protective effects.
 
 ## Next gates
 
-1. Acquire a bounded real FAIR-MAST diagnostic slice with exact archive provenance and content hash; keep it read-only.
-2. Validate units, time base, calibration/quality metadata, and missing-value behavior before replay.
-3. Replay that recorded public slice through the evidence pipeline and capture a deterministic report.
-4. Add an independent second estimator/observer and explicit disagreement handling.
-5. Expand fault injection to delayed, duplicated, contradictory, and metadata-corrupted streams using justified invariants.
-6. Only after those gates pass, evaluate a **non-actuating** EPICS-compatible telemetry adapter.
+1. Obtain authoritative calibration/uncertainty/quality information for selected FAIR-MAST diagnostics instead of inventing uncertainty.
+2. Attach a genuinely independent equilibrium/state observer through `ExternalObserverAdapter` and exercise disagreement handling against the demonstration estimator.
+3. Extend fault injection to duplicated, delayed, contradictory, reordered, and metadata-corrupted streams.
+4. Build analysis-only replay for selected real public signals where the physics mapping is justified; keep control admission closed until validation requirements are actually met.
+5. Only after these gates pass, evaluate a **non-actuating, read-only EPICS-compatible telemetry adapter**.

--- a/docs/WS_FUSION_CTRL_001.md
+++ b/docs/WS_FUSION_CTRL_001.md
@@ -4,30 +4,36 @@
 
 Establish an auditable Worldshepherd control pattern for fusion research without creating any live hardware command path.
 
-The demonstrator exercises:
+The demonstrator now exercises:
 
 1. diagnostic sample validation and provenance;
-2. state estimation from paired optical signals;
+2. state estimation from paired demonstration optical signals;
 3. a model-generated virtual-actuator proposal;
-4. an independent deterministic safety gate;
-5. append-only hash-chained audit/replay evidence.
+4. an independent deterministic PRIME-style safety gate;
+5. append-only hash-chained audit/replay evidence;
+6. strict read-only FAIR-MAST source identity and metadata access;
+7. deterministic replay with evidence fingerprints;
+8. non-mutating mapping into the existing SARA audit event shape;
+9. offline diagnostic fault injection and safe-failure verification.
 
 ## Safety boundary
 
 This branch intentionally contains **no**:
 
-- EPICS client;
+- EPICS machine-control client;
 - CODAC/RTF machine-control integration;
 - magnet power-supply driver;
 - gas injection command interface;
 - neutral-beam or RF-heating command interface;
 - plasma-facing hardware actuator transport.
 
-The only actuator name enabled by the default demo is `virtual_vertical_balance`, measured in arbitrary simulator units.
+The only actuator enabled by the default demo is `virtual_vertical_balance`, measured in arbitrary simulator units.
 
-## Data contract
+The FAIR-MAST client is GET-only, HTTPS-only, host-allowlisted, and provides no arbitrary-URL fetch method. Zarr array reading is deliberately kept outside the control core so archive access cannot be mistaken for actuator authority.
 
-Every sensor sample carries:
+## Core data contract
+
+Every `SensorSample` carries:
 
 - timestamp;
 - shot identifier;
@@ -38,8 +44,8 @@ Every sensor sample carries:
 - quality label;
 - provenance identifier.
 
-Every state estimate carries the estimator identity, confidence, and source diagnostics.
-Every control proposal carries its model identity, confidence, rationale, target virtual actuator, and requested value.
+Every state estimate carries estimator identity, confidence, and source diagnostics.
+Every control proposal carries model identity, confidence, rationale, target virtual actuator, and requested value.
 
 ## PRIME-style safety gate
 
@@ -56,19 +62,74 @@ The deterministic gate operates independently from the proposal generator and re
 
 Rejected proposals receive `applied_value = null`.
 
-## Current estimator
+## Demonstration estimator
 
 `DifferentialOpticalEstimator` uses a normalized difference between upper and lower synthetic optical-emission channels. It exists only to exercise the control/data architecture. It is **not** represented as a validated plasma-position estimator.
 
-## Current controller
+## Virtual controller
 
-`ProportionalVirtualActuatorController` generates a bounded virtual correction from the simulated vertical displacement. It has no hardware semantics.
+`ProportionalVirtualActuatorController` generates an abstract correction from the simulated vertical displacement. It has no hardware semantics.
 
-## Audit and replay
+## Audit, replay, and SARA bridge
 
-`FusionAuditLedger` creates a sequence-numbered SHA-256 hash chain over sensor, state, proposal, and gate-decision events. The v0.1 goal is deterministic replay evidence, not cryptographic non-repudiation.
+`FusionAuditLedger` creates a sequence-numbered SHA-256 hash chain over sensor, state, proposal, and gate-decision events. The goal is deterministic replay evidence, not cryptographic non-repudiation.
 
-## Run
+`FusionReplayRunner` requires paired series, matching shot identity, bounded pair-time skew, and strictly increasing replay time. A canonical SHA-256 fingerprint changes when replay input changes and remains stable for identical input/configuration.
+
+`fusion_audit_bridge.py` maps fusion audit records into the existing SARA `ts/event/actor/payload` structure without writing the SARA audit file or invoking an admin endpoint. It refuses to impersonate `admin`, `operator`, or `SSPADAWANZZ_ADMIN`.
+
+## FAIR-MAST source lane
+
+`fair_mast_adapter.py` provides:
+
+- a strict source identity (`FairMastSource`);
+- stable source provenance for each sample index;
+- GET-only host-allowlisted shot metadata access;
+- conversion of already-read archive series into `SensorSample` objects;
+- Level-1/Level-2 quality labels;
+- a conservative quality rule that blocks derivative-sensitive Level-2 magnetics by default because upstream FAIR-MAST issue #211 documented severe quantization for at least one Level-2 magnetics case and recommended Level-1 raw data for derivative-sensitive work.
+
+The repository pins a reproducible public source target at:
+
+`data/fair_mast/shot_30420_amc_manifest.json`
+
+That manifest identifies FAIR-MAST shot `30420`, Level-1 source `amc`, signals `time` and `plasma_current`, and the public Zarr location `s3://mast/level1/shots/30420.zarr/amc`.
+
+**Important:** the manifest is source identity only. It explicitly states that no archived diagnostic values are embedded in this repository. Therefore this branch does not yet claim a completed replay of real FAIR-MAST signal arrays.
+
+## Fault campaign
+
+`fusion_faults.py` injects faults only into offline `SensorSample` fixtures and checks for safe failure. The standard campaign covers:
+
+- dropped lower-channel sample;
+- excessive pair timestamp skew;
+- shot-identity mismatch;
+- missing provenance;
+- non-finite diagnostic value;
+- explicit invalid-sensor flag.
+
+These checks enforce data-integrity invariants. They are not substitutes for validated plasma-physics anomaly thresholds.
+
+## CI validation
+
+Branch-scoped GitHub Actions CI uses:
+
+- `actions/checkout@v7`;
+- `actions/setup-python@v7`;
+- CPython 3.11;
+- pinned `pytest==9.1.1`;
+- `contents: read` workflow permissions;
+- an explicit Python compile gate before tests.
+
+At commit `bf33f96d367668b1d0ada3bc07e03a887581310d`, the complete targeted suite reported:
+
+```text
+29 passed in 0.09s
+```
+
+The successful suite covers simulator control, FAIR-MAST adapter/source manifest, deterministic replay, SARA audit mapping, and the diagnostic fault campaign.
+
+## Run the simulator
 
 From the repository root on this branch:
 
@@ -78,37 +139,63 @@ PYTHONPATH=. python scripts/run_fusion_control_demo.py
 
 Expected result: one accepted or rejected virtual-actuator decision plus `ledger_ok: true` when the chain is intact.
 
-## Test
+## Run the targeted tests
 
 ```bash
-PYTHONPATH=. pytest -q tests/test_fusion_control.py
+python -m pytest -q \
+  tests/test_fusion_control.py \
+  tests/test_fair_mast_adapter.py \
+  tests/test_fair_mast_manifest.py \
+  tests/test_fusion_replay.py \
+  tests/test_fusion_audit_bridge.py \
+  tests/test_fusion_faults.py
 ```
-
-The tests cover:
-
-- valid bounded command acceptance;
-- invalid-sensor rejection;
-- out-of-bounds command rejection;
-- low-confidence rejection;
-- unknown-actuator rejection;
-- audit-chain tamper detection.
-
-## External interoperability target
-
-The next data-side adapter should ingest public FAIR-MAST metadata and diagnostic arrays into the same `SensorSample` contract while preserving source, quality, and uncertainty metadata. Public FAIR-MAST currently exposes historical MAST campaigns through a JSON API and Zarr/S3 diagnostic storage; MAST-U live-machine control is outside this demonstrator.
 
 ## Claims state
 
-- **IMPLEMENTED IN SOFTWARE:** simulator data contract, differential demonstration estimator, virtual controller, deterministic safety gate, hash-chained audit ledger, unit tests.
-- **REQUIRES EXECUTION VALIDATION:** test results on this new branch until CI/local execution is confirmed.
-- **SUPPORTED BY LITERATURE / EXTERNAL DEMONSTRATION:** machine-learning-assisted plasma control, diagnostics, and real-time control patterns used as architectural references.
-- **REQUIRES LAB VALIDATION:** any Worldshepherd plasma-control claim involving actual fusion hardware.
-- **NOT CURRENTLY CLAIMED:** improved confinement, ELM suppression, net fusion power, propulsion, shielding, or safe control of a real tokamak.
+### IMPLEMENTED IN SOFTWARE + CI VALIDATED
+
+- provenance-bearing simulator data contract;
+- demonstration differential estimator;
+- virtual controller;
+- independent deterministic PRIME-style gate;
+- hash-chained audit ledger;
+- strict read-only FAIR-MAST source adapter;
+- FAIR-MAST source manifest and quality guard;
+- deterministic replay/fingerprint engine;
+- non-mutating SARA audit bridge;
+- six-case diagnostic fault campaign.
+
+### SUPPORTED BY EXTERNAL SOURCE EVIDENCE
+
+- FAIR-MAST exposes historical MAST metadata/data for research;
+- upstream examples identify the shot-30420 Level-1 AMC path and `plasma_current` signal;
+- upstream issue #211 documents Level-2 magnetics quantization risk relevant to derivative-sensitive analysis.
+
+### REQUIRES DATA VALIDATION
+
+- retrieval and checksum/provenance capture of actual FAIR-MAST arrays;
+- replay against those retrieved arrays;
+- verification of units, calibration, signal quality, time bases, missing values, and diagnostic-specific metadata;
+- comparison against an independent state-estimation method.
+
+### REQUIRES LAB/PARTNER VALIDATION
+
+Any claim that Worldshepherd estimates or controls real plasma position, improves stability/confinement, suppresses ELMs, reduces heat loads, or safely commands a fusion machine.
+
+### NOT CURRENTLY CLAIMED
+
+- control of a real tokamak;
+- improved fusion performance;
+- net fusion power;
+- propulsion from these control effects;
+- plasma shielding or other unsupported macroscopic protective effects.
 
 ## Next gates
 
-1. Execute tests and capture results.
-2. Add FAIR-MAST read-only ingestion adapter and data-quality checks.
-3. Add deterministic replay from recorded public data.
-4. Integrate audit events with the existing SARA audit schema without weakening the existing admin/operator separation.
-5. Only after those gates pass, evaluate a non-actuating EPICS-compatible telemetry adapter.
+1. Acquire a bounded real FAIR-MAST diagnostic slice with exact archive provenance and content hash; keep it read-only.
+2. Validate units, time base, calibration/quality metadata, and missing-value behavior before replay.
+3. Replay that recorded public slice through the evidence pipeline and capture a deterministic report.
+4. Add an independent second estimator/observer and explicit disagreement handling.
+5. Expand fault injection to delayed, duplicated, contradictory, and metadata-corrupted streams using justified invariants.
+6. Only after those gates pass, evaluate a **non-actuating** EPICS-compatible telemetry adapter.

--- a/docs/WS_FUSION_CTRL_001.md
+++ b/docs/WS_FUSION_CTRL_001.md
@@ -1,0 +1,114 @@
+# WS-FUSION-CTRL-001 — Simulator-Only Fusion Control Demonstrator
+
+## Purpose
+
+Establish an auditable Worldshepherd control pattern for fusion research without creating any live hardware command path.
+
+The demonstrator exercises:
+
+1. diagnostic sample validation and provenance;
+2. state estimation from paired optical signals;
+3. a model-generated virtual-actuator proposal;
+4. an independent deterministic safety gate;
+5. append-only hash-chained audit/replay evidence.
+
+## Safety boundary
+
+This branch intentionally contains **no**:
+
+- EPICS client;
+- CODAC/RTF machine-control integration;
+- magnet power-supply driver;
+- gas injection command interface;
+- neutral-beam or RF-heating command interface;
+- plasma-facing hardware actuator transport.
+
+The only actuator name enabled by the default demo is `virtual_vertical_balance`, measured in arbitrary simulator units.
+
+## Data contract
+
+Every sensor sample carries:
+
+- timestamp;
+- shot identifier;
+- diagnostic identifier;
+- value and unit;
+- uncertainty;
+- validity flag;
+- quality label;
+- provenance identifier.
+
+Every state estimate carries the estimator identity, confidence, and source diagnostics.
+Every control proposal carries its model identity, confidence, rationale, target virtual actuator, and requested value.
+
+## PRIME-style safety gate
+
+The deterministic gate operates independently from the proposal generator and rejects proposals when any of the following holds:
+
+- actuator is not allowlisted;
+- units do not match the configured envelope;
+- model identity is missing;
+- value or confidence is invalid;
+- confidence is below threshold;
+- command is outside min/max bounds;
+- command timing is non-monotonic;
+- slew rate exceeds the configured limit.
+
+Rejected proposals receive `applied_value = null`.
+
+## Current estimator
+
+`DifferentialOpticalEstimator` uses a normalized difference between upper and lower synthetic optical-emission channels. It exists only to exercise the control/data architecture. It is **not** represented as a validated plasma-position estimator.
+
+## Current controller
+
+`ProportionalVirtualActuatorController` generates a bounded virtual correction from the simulated vertical displacement. It has no hardware semantics.
+
+## Audit and replay
+
+`FusionAuditLedger` creates a sequence-numbered SHA-256 hash chain over sensor, state, proposal, and gate-decision events. The v0.1 goal is deterministic replay evidence, not cryptographic non-repudiation.
+
+## Run
+
+From the repository root on this branch:
+
+```bash
+PYTHONPATH=. python scripts/run_fusion_control_demo.py
+```
+
+Expected result: one accepted or rejected virtual-actuator decision plus `ledger_ok: true` when the chain is intact.
+
+## Test
+
+```bash
+PYTHONPATH=. pytest -q tests/test_fusion_control.py
+```
+
+The tests cover:
+
+- valid bounded command acceptance;
+- invalid-sensor rejection;
+- out-of-bounds command rejection;
+- low-confidence rejection;
+- unknown-actuator rejection;
+- audit-chain tamper detection.
+
+## External interoperability target
+
+The next data-side adapter should ingest public FAIR-MAST metadata and diagnostic arrays into the same `SensorSample` contract while preserving source, quality, and uncertainty metadata. Public FAIR-MAST currently exposes historical MAST campaigns through a JSON API and Zarr/S3 diagnostic storage; MAST-U live-machine control is outside this demonstrator.
+
+## Claims state
+
+- **IMPLEMENTED IN SOFTWARE:** simulator data contract, differential demonstration estimator, virtual controller, deterministic safety gate, hash-chained audit ledger, unit tests.
+- **REQUIRES EXECUTION VALIDATION:** test results on this new branch until CI/local execution is confirmed.
+- **SUPPORTED BY LITERATURE / EXTERNAL DEMONSTRATION:** machine-learning-assisted plasma control, diagnostics, and real-time control patterns used as architectural references.
+- **REQUIRES LAB VALIDATION:** any Worldshepherd plasma-control claim involving actual fusion hardware.
+- **NOT CURRENTLY CLAIMED:** improved confinement, ELM suppression, net fusion power, propulsion, shielding, or safe control of a real tokamak.
+
+## Next gates
+
+1. Execute tests and capture results.
+2. Add FAIR-MAST read-only ingestion adapter and data-quality checks.
+3. Add deterministic replay from recorded public data.
+4. Integrate audit events with the existing SARA audit schema without weakening the existing admin/operator separation.
+5. Only after those gates pass, evaluate a non-actuating EPICS-compatible telemetry adapter.

--- a/evidence/fair_mast/observer_authority_gap_20260912.json
+++ b/evidence/fair_mast/observer_authority_gap_20260912.json
@@ -1,0 +1,39 @@
+{
+  "schema": "worldshepherd.fusion.observer_authority_gap.v1",
+  "recorded_date": "2026-09-12",
+  "claims_state": "SUPPORTED BY EXTERNAL SOURCE EVIDENCE",
+  "scope": "MAST equilibrium/state-observer authority requirements",
+  "source": {
+    "repository": "ukaea/fair-mast",
+    "issue_number": 231,
+    "title": "Community tool: FAIR-MAST → FreeGSNKE shot-only pipeline; request for equilibrium reconstruction authorities",
+    "url": "https://github.com/ukaea/fair-mast/issues/231",
+    "opened": "2026-07-24",
+    "source_role": "community request hosted in the UKAEA FAIR-MAST issue tracker"
+  },
+  "observed_requests": [
+    "probe and flux-loop geometry and calibration",
+    "passive structure model",
+    "Green's tables or response matrices, or documentation of their generation",
+    "EFIT++ run settings or namelists",
+    "coordinate conventions including flux convention and COCOS",
+    "optional profile or kinetic constraints"
+  ],
+  "worldshepherd_required_authorities": [
+    "diagnostic_geometry_and_calibration",
+    "passive_structure_model",
+    "response_matrices_or_generation_method",
+    "reconstruction_settings",
+    "coordinate_conventions"
+  ],
+  "worldshepherd_optional_authorities": [
+    "profile_or_kinetic_constraints"
+  ],
+  "interpretation": {
+    "supports": "These categories are independently recognized as necessary inputs/authorities for reproducible MAST equilibrium reconstruction work.",
+    "does_not_support": "The issue does not prove that UKAEA lacks these materials, that the listed materials are complete for every reconstruction method, or that any Worldshepherd observer is scientifically validated.",
+    "policy": "Missing authority remains a hard fail for promotion of an external observer beyond analysis-only integration."
+  },
+  "machine_control_authority": false,
+  "control_evidence_eligible": false
+}

--- a/evidence/fair_mast/shot_30420_amc_data_probe_20260912.json
+++ b/evidence/fair_mast/shot_30420_amc_data_probe_20260912.json
@@ -1,0 +1,92 @@
+{
+  "schema": "worldshepherd.fair_mast.data_evidence.v1",
+  "captured_utc": "2026-09-12T17:49:38Z",
+  "source": {
+    "archive": "FAIR-MAST",
+    "organization": "UK Atomic Energy Authority",
+    "storage_provider": "STFC Echo",
+    "shot_id": 30420,
+    "data_level": "level1",
+    "diagnostic_group": "amc",
+    "zarr_uri": "s3://mast/level1/shots/30420.zarr/amc"
+  },
+  "capture": {
+    "repository": "Bdavis1390/Sara_pro",
+    "branch": "worldshepherd/fusion-control-sim-v0-1-20260912",
+    "commit": "d6e24054cc42cc25ea3938547a934c8297ab31d8",
+    "github_actions_run_id": 34709281836,
+    "job": "fair-mast-data-probe",
+    "report_sha256": "4d7823c39cca64353a35aa848542fc12b6e783377242a7f4b46dca427e552489",
+    "raw_values_persisted": false,
+    "machine_control_authority": false
+  },
+  "time": {
+    "chunk_url": "https://s3.echo.stfc.ac.uk/mast/level1/shots/30420.zarr/amc/time/0",
+    "compressed_bytes": 23258,
+    "compressed_sha256": "3d1f90c80e334a581dc2185e0718c4a0c26e0dddf00d1bb8898fdca46c0f8aae",
+    "decoded_bytes": 120000,
+    "decoded_sha256": "5d1079d3f7c9125fbcea01dccf461d5df9784efd7f883959fb3af883a250bfb2",
+    "count": 30000,
+    "dtype": "float32",
+    "units": "s",
+    "finite_count": 30000,
+    "finite_fraction": 1.0,
+    "min": -2.000000238418579,
+    "max": 3.9997994899749756,
+    "monotonic_non_decreasing": true,
+    "strictly_increasing": true,
+    "dt_min": 0.00019979476928710938,
+    "dt_median": 0.00020003318786621094,
+    "dt_max": 0.0002002716064453125
+  },
+  "plasma_current": {
+    "chunk_url": "https://s3.echo.stfc.ac.uk/mast/level1/shots/30420.zarr/amc/plasma_current/0",
+    "compressed_bytes": 107553,
+    "compressed_sha256": "6766652b81e6af1586222aa9f5496f61f5dcf813d810fe1e2a7f2e55025a7a64",
+    "decoded_bytes": 120000,
+    "decoded_sha256": "a546c1d0bd2775bbe61aac99c3cbf3331d27290ff882bb2d3773515bb5fafaef",
+    "count": 30000,
+    "dtype": "float32",
+    "units": "kA",
+    "finite_count": 30000,
+    "finite_fraction": 1.0,
+    "min": -24.034608840942383,
+    "max": 864.7200927734375,
+    "mean": 26.950964319972858,
+    "std": 127.59275483305682,
+    "upstream_quality": "Not Checked"
+  },
+  "paired_window_0_to_0_35_s": {
+    "finite_sample_count": 1750,
+    "first_index": 10001,
+    "last_index": 11750,
+    "paired_values_sha256": "636d6da6e4f74e112789d239e45c177bc78bfc4feffe169ab1e244f49f1b5f75",
+    "raw_values_in_evidence_record": false
+  },
+  "readiness": {
+    "archive_reachability_confirmed": true,
+    "chunk_integrity_hashed": true,
+    "decoded_shape_confirmed": true,
+    "all_values_finite": true,
+    "time_strictly_increasing": true,
+    "bounded_analysis_window_fingerprinted": true,
+    "uncertainty_metadata_available": false,
+    "upstream_quality": "Not Checked",
+    "analysis_evidence_eligible": true,
+    "control_evidence_eligible": false
+  },
+  "control_blockers": [
+    "Upstream signal quality is Not Checked.",
+    "No uncertainty metadata was present in the probed attributes.",
+    "Plasma current is a measured signal, not a validated Worldshepherd plasma-position estimator.",
+    "This evidence establishes archive-data integrity/statistics only, not safe real-time control performance."
+  ],
+  "claims_boundary": {
+    "real_archive_values_fetched_transiently": true,
+    "real_archive_values_persisted": false,
+    "real_archive_statistics_and_hashes_persisted": true,
+    "real_data_replayed_through_control_estimator": false,
+    "real_plasma_state_estimation_validated": false,
+    "real_machine_control_validated": false
+  }
+}

--- a/evidence/fair_mast/shot_30420_amc_metadata_probe_20260912.json
+++ b/evidence/fair_mast/shot_30420_amc_metadata_probe_20260912.json
@@ -1,0 +1,107 @@
+{
+  "schema": "worldshepherd.fair_mast.metadata_evidence.v1",
+  "captured_utc": "2026-09-12T17:45:24Z",
+  "source": {
+    "archive": "FAIR-MAST",
+    "organization": "UK Atomic Energy Authority",
+    "storage_provider": "STFC Echo",
+    "shot_id": 30420,
+    "data_level": "level1",
+    "diagnostic_group": "amc",
+    "zarr_uri": "s3://mast/level1/shots/30420.zarr/amc",
+    "http_base": "https://s3.echo.stfc.ac.uk/mast/level1/shots/30420.zarr/amc",
+    "source_license": "CC BY-SA 4.0 except where otherwise noted by the archive",
+    "source_license_reference": "https://mastapp.site/"
+  },
+  "capture": {
+    "repository": "Bdavis1390/Sara_pro",
+    "branch": "worldshepherd/fusion-control-sim-v0-1-20260912",
+    "commit": "f6ea2ed004524fd29204d73221668ec2bf91663a",
+    "github_actions_run_id": 34709145877,
+    "probe_job": "fair-mast-source-probe",
+    "report_sha256": "ffddced3a27e0b479298e5a09203ad59bba1460dd58ef43954d0e248eb416c0b",
+    "array_chunks_fetched": false,
+    "machine_control_authority": false
+  },
+  "root_metadata": {
+    "zarr_format": 2,
+    "zgroup_sha256": "2383746e67b4bcc2762b3f100f06c3fa2d5f149ab5a8e5da5d33521464a01959",
+    "zattrs_sha256": "43895f7222fa640bb25a8cef60be08e44601a1409a3474a4bf4c025274b846fd",
+    "description": "Plasma Current and PF/TF Coil Currents",
+    "file_name": "amc0304.20",
+    "format": "IDA3",
+    "quality": "Not Checked",
+    "signal_type": "Analysed",
+    "source": "amc",
+    "uda_name": "AMC",
+    "uuid": "01aad0c4-2a84-59e2-8b1b-168b4bd66aa3",
+    "version": 0
+  },
+  "signals": {
+    "time": {
+      "shape": [30000],
+      "chunks": [30000],
+      "dtype": "<f4",
+      "fill_value": "NaN",
+      "order": "C",
+      "compressor": {
+        "id": "blosc",
+        "cname": "lz4",
+        "clevel": 5,
+        "shuffle": 1,
+        "blocksize": 0
+      },
+      "units": "s",
+      "zarray_sha256": "d641ce0bc6f1e17cb4d0faad3967db557185c235203f8089a7b6ad6695a17036",
+      "zattrs_sha256": "0a5ec58451e5ebf607605328c92866060e306e608429e4da3e36f3d1b66edba8"
+    },
+    "plasma_current": {
+      "shape": [30000],
+      "chunks": [30000],
+      "dtype": "<f4",
+      "fill_value": "NaN",
+      "order": "C",
+      "compressor": {
+        "id": "blosc",
+        "cname": "lz4",
+        "clevel": 5,
+        "shuffle": 1,
+        "blocksize": 0
+      },
+      "units": "kA",
+      "description": "Plasma Current",
+      "quality": "Not Checked",
+      "rank": 1,
+      "signal_type": "Analysed",
+      "source": "amc",
+      "time_index": 0,
+      "uda_name": "AMC_PLASMA CURRENT",
+      "uuid": "6327e756-e587-5c74-8aed-4e595d3546cf",
+      "version": 0,
+      "zarray_sha256": "d641ce0bc6f1e17cb4d0faad3967db557185c235203f8089a7b6ad6695a17036",
+      "zattrs_sha256": "df5c1ed3dcd9a0fd447c57a131269bbabd8d7abc6718d61ea9469059e32aefdd"
+    }
+  },
+  "readiness_assessment": {
+    "source_identity_confirmed": true,
+    "metadata_object_integrity_hashed": true,
+    "time_and_signal_shapes_match": true,
+    "units_identified": true,
+    "upstream_quality_label": "Not Checked",
+    "uncertainty_metadata_observed": false,
+    "real_signal_values_fetched": false,
+    "real_signal_replay_completed": false,
+    "control_evidence_eligible": false,
+    "reason_control_evidence_blocked": [
+      "No signal array chunks were fetched in this metadata-only gate.",
+      "The upstream archive labels the source/signal quality as Not Checked.",
+      "No uncertainty field was observed in the probed time or plasma_current attributes."
+    ]
+  },
+  "claims_boundary": {
+    "proven_external_archive_structure": true,
+    "proven_real_values_ingested": false,
+    "proven_real_plasma_state_estimation": false,
+    "proven_real_machine_control": false
+  }
+}

--- a/scripts/probe_fair_mast_data.py
+++ b/scripts/probe_fair_mast_data.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Fetch and validate two pinned FAIR-MAST Zarr chunks without persisting values.
+
+This script is an offline evidence-generation utility, not a control component.
+It fetches only the `time/0` and `plasma_current/0` chunks identified by the
+metadata gate, decodes them with their declared Zarr compressor/dtype, computes
+integrity and quality statistics, and emits hashes/statistics only.  Raw signal
+values are never written to the output report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Tuple
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+import numpy as np
+from numcodecs import get_codec
+
+
+ALLOWED_HOST = "s3.echo.stfc.ac.uk"
+MAX_CHUNK_BYTES = 10_000_000
+
+
+def fetch_bytes(url: str, *, max_bytes: int = MAX_CHUNK_BYTES, timeout_s: float = 30.0) -> bytes:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname != ALLOWED_HOST:
+        raise ValueError("data_probe_url_not_allowlisted")
+    request = Request(url, method="GET", headers={"User-Agent": "Worldshepherd-FAIR-MAST-data-probe/0.1"})
+    with urlopen(request, timeout=timeout_s) as response:  # nosec B310: host allowlisted above
+        status = getattr(response, "status", 200)
+        if status != 200:
+            raise RuntimeError(f"chunk_http_status:{status}:{url}")
+        raw = response.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ValueError(f"chunk_exceeds_bound:{url}")
+    return raw
+
+
+def fetch_json(url: str) -> Dict[str, Any]:
+    raw = fetch_bytes(url, max_bytes=2_000_000)
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("metadata_not_object")
+    return payload
+
+
+def decode_single_chunk(base: str, signal: str) -> Tuple[np.ndarray, Dict[str, Any]]:
+    zarray = fetch_json(f"{base}/{signal}/.zarray")
+    shape = zarray.get("shape")
+    chunks = zarray.get("chunks")
+    if not isinstance(shape, list) or len(shape) != 1:
+        raise ValueError(f"unsupported_rank:{signal}")
+    if not isinstance(chunks, list) or chunks != shape:
+        raise ValueError(f"expected_single_full_length_chunk:{signal}")
+
+    chunk_url = f"{base}/{signal}/0"
+    compressed = fetch_bytes(chunk_url)
+    compressed_sha = hashlib.sha256(compressed).hexdigest()
+
+    compressor = zarray.get("compressor")
+    if compressor is None:
+        decoded = compressed
+    else:
+        decoded = get_codec(compressor).decode(compressed)
+        if isinstance(decoded, np.ndarray):
+            decoded = decoded.tobytes(order="C")
+        else:
+            decoded = bytes(decoded)
+
+    dtype = np.dtype(str(zarray["dtype"]))
+    values = np.frombuffer(decoded, dtype=dtype)
+    expected_count = int(shape[0])
+    if values.size != expected_count:
+        raise ValueError(f"decoded_length_mismatch:{signal}:{values.size}:{expected_count}")
+
+    decoded_sha = hashlib.sha256(values.tobytes(order="C")).hexdigest()
+    evidence = {
+        "chunk_url": chunk_url,
+        "compressed_bytes": len(compressed),
+        "compressed_sha256": compressed_sha,
+        "decoded_bytes": int(values.nbytes),
+        "decoded_sha256": decoded_sha,
+        "count": int(values.size),
+        "dtype": str(values.dtype),
+    }
+    return values, evidence
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default="data/fair_mast/shot_30420_amc_manifest.json")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    endpoint = str(manifest["s3_endpoint"]).rstrip("/")
+    zarr_uri = str(manifest["zarr_uri"])
+    parsed = urlparse(zarr_uri)
+    if parsed.scheme != "s3" or parsed.netloc != "mast":
+        raise ValueError("manifest_zarr_uri_not_allowlisted")
+    base = f"{endpoint}/{parsed.netloc}{parsed.path.rstrip('/')}"
+
+    time_values, time_evidence = decode_single_chunk(base, "time")
+    current_values, current_evidence = decode_single_chunk(base, "plasma_current")
+    if time_values.shape != current_values.shape:
+        raise ValueError("time_current_shape_mismatch")
+
+    time_finite = np.isfinite(time_values)
+    current_finite = np.isfinite(current_values)
+    paired_finite = time_finite & current_finite
+    finite_time_values = time_values[time_finite].astype(np.float64)
+    finite_current_values = current_values[current_finite].astype(np.float64)
+    if finite_time_values.size < 2:
+        raise ValueError("insufficient_finite_time_values")
+
+    time_diffs = np.diff(finite_time_values)
+    monotonic_non_decreasing = bool(np.all(time_diffs >= 0))
+    strictly_increasing = bool(np.all(time_diffs > 0))
+
+    analysis_mask = paired_finite & (time_values >= 0.0) & (time_values <= 0.35)
+    analysis_indices = np.nonzero(analysis_mask)[0]
+    if analysis_indices.size:
+        paired_bytes = (
+            time_values[analysis_mask].astype("<f4", copy=False).tobytes(order="C")
+            + current_values[analysis_mask].astype("<f4", copy=False).tobytes(order="C")
+        )
+        window_sha = hashlib.sha256(paired_bytes).hexdigest()
+        first_index = int(analysis_indices[0])
+        last_index = int(analysis_indices[-1])
+    else:
+        window_sha = None
+        first_index = None
+        last_index = None
+
+    report = {
+        "schema": "worldshepherd.fair_mast.data_probe.v1",
+        "archive": "FAIR-MAST",
+        "shot_id": int(manifest["shot_id"]),
+        "data_level": str(manifest["data_level"]),
+        "diagnostic_group": str(manifest["diagnostic_group"]),
+        "zarr_uri": zarr_uri,
+        "raw_values_persisted": False,
+        "machine_control_authority": False,
+        "uncertainty_metadata_available": False,
+        "control_evidence_eligible": False,
+        "time": {
+            **time_evidence,
+            "units": "s",
+            "finite_count": int(time_finite.sum()),
+            "finite_fraction": float(time_finite.mean()),
+            "min": float(finite_time_values.min()),
+            "max": float(finite_time_values.max()),
+            "monotonic_non_decreasing": monotonic_non_decreasing,
+            "strictly_increasing": strictly_increasing,
+            "dt_min": float(time_diffs.min()),
+            "dt_median": float(np.median(time_diffs)),
+            "dt_max": float(time_diffs.max()),
+        },
+        "plasma_current": {
+            **current_evidence,
+            "units": "kA",
+            "upstream_quality": "Not Checked",
+            "finite_count": int(current_finite.sum()),
+            "finite_fraction": float(current_finite.mean()),
+            "min": float(finite_current_values.min()),
+            "max": float(finite_current_values.max()),
+            "mean": float(finite_current_values.mean()),
+            "std": float(finite_current_values.std()),
+        },
+        "paired_window_0_to_0_35_s": {
+            "finite_sample_count": int(analysis_mask.sum()),
+            "first_index": first_index,
+            "last_index": last_index,
+            "paired_values_sha256": window_sha,
+            "raw_values_in_report": False,
+        },
+        "control_blockers": [
+            "Upstream signal quality is Not Checked.",
+            "No uncertainty metadata is available in the probed signal attributes.",
+            "This probe validates archive data integrity/statistics only; it is not a plasma-state estimator."
+        ]
+    }
+
+    canonical = json.dumps(report, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    report["report_sha256"] = hashlib.sha256(canonical).hexdigest()
+    rendered = json.dumps(report, indent=2, sort_keys=True, allow_nan=False)
+    Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_fusion_control_demo.py
+++ b/scripts/run_fusion_control_demo.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Run one simulator-only Worldshepherd fusion-control cycle."""
+
+import json
+from dataclasses import asdict
+
+from worldshepherd_sara.fusion_control import SensorSample, run_simulated_control_cycle
+
+
+if __name__ == "__main__":
+    upper = SensorSample(
+        timestamp=1_000.000,
+        shot_id="demo-001",
+        diagnostic="upper_divertor_visible_emission",
+        value=112.0,
+        unit="arb",
+        uncertainty=1.0,
+        valid=True,
+        quality="demo",
+        provenance="synthetic:demo-001:upper",
+    )
+    lower = SensorSample(
+        timestamp=1_000.000,
+        shot_id="demo-001",
+        diagnostic="lower_divertor_visible_emission",
+        value=88.0,
+        unit="arb",
+        uncertainty=1.0,
+        valid=True,
+        quality="demo",
+        provenance="synthetic:demo-001:lower",
+    )
+
+    result = run_simulated_control_cycle(upper, lower)
+    print(json.dumps({
+        "state": asdict(result.state),
+        "proposal": asdict(result.proposal),
+        "decision": asdict(result.decision),
+        "ledger_ok": result.ledger_ok,
+        "ledger_reason": result.ledger_reason,
+        "hardware_interface": "disabled",
+    }, indent=2, sort_keys=True))

--- a/tests/test_archive_readiness.py
+++ b/tests/test_archive_readiness.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from worldshepherd_sara.archive_readiness import evaluate_archive_evidence
+
+
+EVIDENCE = Path("evidence/fair_mast/shot_30420_amc_data_probe_20260912.json")
+
+
+def load_evidence():
+    return json.loads(EVIDENCE.read_text(encoding="utf-8"))
+
+
+def test_real_fair_mast_probe_is_analysis_eligible_but_control_ineligible():
+    decision = evaluate_archive_evidence(load_evidence())
+    assert decision.analysis_eligible is True
+    assert decision.control_evidence_eligible is False
+    assert "uncertainty_metadata_unavailable" in decision.reasons
+    assert "upstream_quality_not_control_qualified" in decision.reasons
+    assert "real_plasma_state_estimation_not_validated" in decision.reasons
+    assert "real_machine_control_not_validated" in decision.reasons
+    assert "source_record_declares_control_ineligible" in decision.reasons
+
+
+def test_missing_integrity_blocks_even_analysis_eligibility():
+    evidence = load_evidence()
+    evidence["readiness"]["chunk_integrity_hashed"] = False
+    decision = evaluate_archive_evidence(evidence)
+    assert decision.analysis_eligible is False
+    assert decision.control_evidence_eligible is False
+    assert "chunk_integrity_not_hashed" in decision.reasons
+
+
+def test_missing_readiness_section_fails_closed():
+    decision = evaluate_archive_evidence({"schema": "test"})
+    assert decision.analysis_eligible is False
+    assert decision.control_evidence_eligible is False
+    assert decision.reasons == ("readiness_section_missing",)
+
+
+def test_control_eligibility_cannot_be_created_by_only_flipping_declared_flag():
+    evidence = load_evidence()
+    evidence["readiness"]["control_evidence_eligible"] = True
+    decision = evaluate_archive_evidence(evidence)
+    assert decision.control_evidence_eligible is False
+    assert "uncertainty_metadata_unavailable" in decision.reasons
+    assert "upstream_quality_not_control_qualified" in decision.reasons

--- a/tests/test_control_admission.py
+++ b/tests/test_control_admission.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from worldshepherd_sara.control_admission import ArchiveControlAdmissionGate
+
+
+EVIDENCE = Path("evidence/fair_mast/shot_30420_amc_data_probe_20260912.json")
+
+
+def load_evidence():
+    return json.loads(EVIDENCE.read_text(encoding="utf-8"))
+
+
+def test_real_fair_mast_probe_is_denied_control_admission():
+    decision = ArchiveControlAdmissionGate().evaluate(load_evidence())
+    assert decision.admitted is False
+    assert decision.reason == "archive_not_control_evidence_eligible"
+    assert "uncertainty_metadata_unavailable" in decision.blockers
+    assert "upstream_quality_not_control_qualified" in decision.blockers
+
+
+def test_require_fails_closed_with_machine_readable_blockers():
+    with pytest.raises(ValueError, match="archive_not_control_evidence_eligible") as exc:
+        ArchiveControlAdmissionGate().require(load_evidence())
+    assert "real_plasma_state_estimation_not_validated" in str(exc.value)
+
+
+def test_admission_cannot_be_forced_by_supplying_only_uncertainty_and_quality_flags():
+    evidence = load_evidence()
+    evidence["readiness"]["uncertainty_metadata_available"] = True
+    evidence["readiness"]["upstream_quality"] = "Checked"
+    evidence["readiness"]["control_evidence_eligible"] = True
+    decision = ArchiveControlAdmissionGate().evaluate(evidence)
+    assert decision.admitted is False
+    assert "real_plasma_state_estimation_not_validated" in decision.blockers
+    assert "real_machine_control_not_validated" in decision.blockers
+
+
+def test_fully_explicit_validated_fixture_can_be_admitted():
+    evidence = load_evidence()
+    evidence["readiness"]["uncertainty_metadata_available"] = True
+    evidence["readiness"]["upstream_quality"] = "Checked"
+    evidence["readiness"]["control_evidence_eligible"] = True
+    evidence["claims_boundary"]["real_plasma_state_estimation_validated"] = True
+    evidence["claims_boundary"]["real_machine_control_validated"] = True
+    decision = ArchiveControlAdmissionGate().evaluate(evidence)
+    assert decision.admitted is True
+    assert decision.blockers == ()

--- a/tests/test_external_observer.py
+++ b/tests/test_external_observer.py
@@ -1,0 +1,67 @@
+import pytest
+
+from worldshepherd_sara.external_observer import ExternalObserverAdapter, ExternalObserverRecord
+from worldshepherd_sara.fusion_consensus import StateConsensusGate, StateConsensusPolicy
+from worldshepherd_sara.fusion_control import PlasmaStateEstimate
+
+
+def record(**overrides):
+    values = dict(
+        timestamp=1.0,
+        shot_id="observer-shot",
+        vertical_displacement_m=0.011,
+        confidence=0.92,
+        estimator_id="partner-equilibrium-observer-v1",
+        method="external_equilibrium_reconstruction",
+        source_diagnostics=("magnetic_flux_loop_set",),
+        provenance="partner-record:observer-shot:1.0",
+        quality="source-validated",
+        validated_by_source=True,
+    )
+    values.update(overrides)
+    return ExternalObserverRecord(**values)
+
+
+def test_valid_external_record_adapts_to_common_state_contract():
+    estimate = ExternalObserverAdapter().adapt(record())
+    assert isinstance(estimate, PlasmaStateEstimate)
+    assert estimate.estimator_id == "partner-equilibrium-observer-v1"
+    assert estimate.vertical_displacement_m == 0.011
+
+
+def test_unvalidated_external_record_fails_closed():
+    with pytest.raises(ValueError, match="external_estimate_not_source_validated"):
+        ExternalObserverAdapter().adapt(record(validated_by_source=False))
+
+
+def test_missing_provenance_fails_closed():
+    with pytest.raises(ValueError, match="provenance_missing"):
+        ExternalObserverAdapter().adapt(record(provenance=""))
+
+
+def test_low_confidence_external_record_is_rejected():
+    with pytest.raises(ValueError, match="confidence_below_policy"):
+        ExternalObserverAdapter(minimum_confidence=0.85).adapt(record(confidence=0.84))
+
+
+def test_external_observer_can_participate_in_consensus_without_being_implemented_here():
+    external = ExternalObserverAdapter().adapt(record())
+    local_demo = PlasmaStateEstimate(
+        timestamp=1.001,
+        shot_id="observer-shot",
+        vertical_displacement_m=0.010,
+        confidence=0.95,
+        estimator_id="optical-demo-estimator",
+        source_diagnostics=("upper_demo", "lower_demo"),
+    )
+    gate = StateConsensusGate(
+        StateConsensusPolicy(
+            minimum_estimators=2,
+            minimum_confidence=0.80,
+            maximum_time_skew_s=0.01,
+            maximum_abs_disagreement_m=0.005,
+        )
+    )
+    decision = gate.evaluate([local_demo, external])
+    assert decision.accepted is True
+    assert set(decision.estimator_ids) == {"optical-demo-estimator", "partner-equilibrium-observer-v1"}

--- a/tests/test_fair_mast_adapter.py
+++ b/tests/test_fair_mast_adapter.py
@@ -1,0 +1,119 @@
+import pytest
+
+from worldshepherd_sara.fair_mast_adapter import (
+    FairMastQualityPolicy,
+    FairMastReadOnlyMetadataClient,
+    FairMastSource,
+    series_to_sensor_samples,
+)
+
+
+def test_level1_source_builds_stable_zarr_provenance():
+    source = FairMastSource(
+        shot_id=30420,
+        diagnostic_group="amc",
+        signal="plasma_current",
+        level="level1",
+    )
+    assert source.zarr_uri == "s3://mast/level1/shots/30420.zarr/amc"
+    assert source.diagnostic_name == "amc/plasma_current"
+    provenance = source.provenance_for_index(7)
+    assert "https://s3.echo.stfc.ac.uk" in provenance
+    assert "s3://mast/level1/shots/30420.zarr/amc" in provenance
+    assert "signal=plasma_current" in provenance
+    assert "index=7" in provenance
+
+
+def test_metadata_client_is_get_only_and_host_allowlisted():
+    client = FairMastReadOnlyMetadataClient()
+    assert client.shot_url(30420) == "https://mastapp.site/json/shots/30420"
+
+    with pytest.raises(ValueError, match="host not allowlisted"):
+        FairMastReadOnlyMetadataClient("https://example.com/json")
+
+    with pytest.raises(ValueError, match="must use https"):
+        FairMastReadOnlyMetadataClient("http://mastapp.site/json")
+
+
+def test_series_conversion_attaches_provenance_and_level_quality():
+    source = FairMastSource(30420, "amc", "plasma_current", "level1")
+    samples = series_to_sensor_samples(
+        source,
+        timestamps=[0.0, 0.001, 0.002],
+        values=[0.0, 100.0, 200.0],
+        unit="A",
+        uncertainty=0.5,
+        quality="curated",
+    )
+    assert len(samples) == 3
+    assert all(sample.shot_id == "30420" for sample in samples)
+    assert all(sample.diagnostic == "amc/plasma_current" for sample in samples)
+    assert all("fair-mast-level1" in sample.quality for sample in samples)
+    assert samples[2].provenance.endswith("|index=2|level=level1")
+
+
+def test_nonfinite_archive_value_is_retained_as_invalid_not_control_valid():
+    source = FairMastSource(30420, "amc", "plasma_current", "level1")
+    samples = series_to_sensor_samples(
+        source,
+        timestamps=[0.0, 0.001],
+        values=[100.0, float("nan")],
+        unit="A",
+        uncertainty=0.5,
+    )
+    assert samples[0].valid is True
+    assert samples[1].valid is False
+
+
+def test_level2_magnetics_are_blocked_for_derivative_sensitive_analysis():
+    source = FairMastSource(
+        29980,
+        "magnetics",
+        "b_field_pol_probe_cc_field",
+        "level2",
+    )
+    ok, reason = FairMastQualityPolicy.evaluate(source, derivative_sensitive=True)
+    assert ok is False
+    assert reason == "level2_magnetics_derivative_quality_risk"
+
+    with pytest.raises(ValueError, match="level2_magnetics_derivative_quality_risk"):
+        series_to_sensor_samples(
+            source,
+            timestamps=[0.0, 0.001],
+            values=[0.1, 0.2],
+            unit="T",
+            uncertainty=1e-6,
+            derivative_sensitive=True,
+        )
+
+
+def test_level2_magnetics_remain_available_for_non_derivative_replay_with_provenance():
+    source = FairMastSource(
+        29980,
+        "magnetics",
+        "b_field_pol_probe_cc_field",
+        "level2",
+    )
+    samples = series_to_sensor_samples(
+        source,
+        timestamps=[0.0],
+        values=[0.1],
+        unit="T",
+        uncertainty=1e-6,
+        derivative_sensitive=False,
+    )
+    assert len(samples) == 1
+    assert samples[0].valid is True
+    assert "level=level2" in samples[0].provenance
+
+
+def test_timestamp_regression_is_rejected():
+    source = FairMastSource(30420, "amc", "plasma_current", "level1")
+    with pytest.raises(ValueError, match="timestamp_not_monotonic"):
+        series_to_sensor_samples(
+            source,
+            timestamps=[0.002, 0.001],
+            values=[100.0, 101.0],
+            unit="A",
+            uncertainty=0.5,
+        )

--- a/tests/test_fair_mast_manifest.py
+++ b/tests/test_fair_mast_manifest.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from worldshepherd_sara.fair_mast_adapter import FairMastSource
+
+
+MANIFEST = Path("data/fair_mast/shot_30420_amc_manifest.json")
+
+
+def load_manifest():
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def test_manifest_is_source_only_and_does_not_claim_embedded_archive_values():
+    manifest = load_manifest()
+    assert manifest["status"] == "SOURCE_MANIFEST_ONLY_NO_ARCHIVED_VALUES_EMBEDDED"
+    assert manifest["claims_boundary"]["real_archive_values_in_repository"] is False
+    assert manifest["claims_boundary"]["live_machine_data"] is False
+    assert manifest["claims_boundary"]["machine_control_authority"] is False
+
+
+def test_manifest_matches_adapter_generated_archive_identity():
+    manifest = load_manifest()
+    source = FairMastSource(
+        shot_id=manifest["shot_id"],
+        diagnostic_group=manifest["diagnostic_group"],
+        signal="plasma_current",
+        level=manifest["data_level"],
+    )
+    assert source.zarr_uri == manifest["zarr_uri"]
+    assert manifest["s3_endpoint"] == "https://s3.echo.stfc.ac.uk"
+    assert "time" in manifest["signals"]
+    assert source.signal in manifest["signals"]
+
+
+def test_manifest_contains_upstream_evidence_references():
+    manifest = load_manifest()
+    refs = {entry["reference"] for entry in manifest["source_evidence"]}
+    assert "https://github.com/ukaea/fair-mast" in refs
+    assert "https://github.com/ukaea/fair-mast/issues/107" in refs

--- a/tests/test_fair_mast_probe.py
+++ b/tests/test_fair_mast_probe.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+
+from worldshepherd_sara.fair_mast_probe import probe_source_manifest, zarr_http_base
+
+
+def manifest():
+    return {
+        "status": "SOURCE_MANIFEST_ONLY_NO_ARCHIVED_VALUES_EMBEDDED",
+        "archive": "FAIR-MAST",
+        "shot_id": 30420,
+        "data_level": "level1",
+        "diagnostic_group": "amc",
+        "signals": ["time", "plasma_current"],
+        "zarr_uri": "s3://mast/level1/shots/30420.zarr/amc",
+        "s3_endpoint": "https://s3.echo.stfc.ac.uk",
+    }
+
+
+def fake_fetcher(url: str):
+    if url.endswith("/.zgroup"):
+        payload = {"zarr_format": 2}
+    elif url.endswith("/time/.zarray"):
+        payload = {"shape": [3], "chunks": [3], "dtype": "<f8"}
+    elif url.endswith("/plasma_current/.zarray"):
+        payload = {"shape": [3], "chunks": [3], "dtype": "<f4"}
+    elif url.endswith("/time/.zattrs"):
+        payload = {"units": "s"}
+    elif url.endswith("/plasma_current/.zattrs"):
+        payload = {"units": "kA"}
+    elif url.endswith("/.zattrs"):
+        payload = {"shot_id": 30420}
+    else:
+        raise AssertionError(f"unexpected URL {url}")
+    raw = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return payload, raw
+
+
+def test_http_base_is_exact_allowlisted_archive_path():
+    assert zarr_http_base(
+        "https://s3.echo.stfc.ac.uk",
+        "s3://mast/level1/shots/30420.zarr/amc",
+    ) == "https://s3.echo.stfc.ac.uk/mast/level1/shots/30420.zarr/amc"
+
+    with pytest.raises(ValueError, match="endpoint_host_not_allowlisted"):
+        zarr_http_base("https://example.com", "s3://mast/level1/shots/30420.zarr/amc")
+
+    with pytest.raises(ValueError, match="zarr_bucket_not_allowlisted"):
+        zarr_http_base("https://s3.echo.stfc.ac.uk", "s3://other/level1/shots/30420.zarr/amc")
+
+
+def test_probe_reads_only_metadata_objects_and_is_hash_stable():
+    first = probe_source_manifest(manifest(), fetcher=fake_fetcher)
+    second = probe_source_manifest(manifest(), fetcher=fake_fetcher)
+
+    assert first["array_chunks_fetched"] is False
+    assert first["machine_control_authority"] is False
+    assert set(first["signals"]) == {"time", "plasma_current"}
+    assert first["signals"]["time"][".zattrs"]["metadata"]["units"] == "s"
+    assert first["signals"]["plasma_current"][".zattrs"]["metadata"]["units"] == "kA"
+    assert first["report_sha256"] == second["report_sha256"]

--- a/tests/test_fusion_audit_bridge.py
+++ b/tests/test_fusion_audit_bridge.py
@@ -1,0 +1,44 @@
+import pytest
+
+from worldshepherd_sara.fusion_audit_bridge import (
+    fusion_record_to_sara_event,
+    fusion_records_to_sara_events,
+)
+from worldshepherd_sara.fusion_control import FusionAuditLedger
+
+
+def ledger_with_two_records():
+    ledger = FusionAuditLedger()
+    ledger.append("fusion_sensor_sample", {"value": 1}, timestamp=1.0)
+    ledger.append("fusion_gate_decision", {"accepted": True}, timestamp=2.0)
+    return ledger
+
+
+def test_bridge_preserves_hash_evidence_and_sara_shape():
+    ledger = ledger_with_two_records()
+    event = fusion_record_to_sara_event(ledger.records[0])
+
+    assert event["ts"] == 1.0
+    assert event["event"] == "fusion.fusion_sensor_sample"
+    assert event["actor"] == "SARA_FUSION_SIM"
+    assert event["payload"]["fusion_sequence"] == 0
+    assert event["payload"]["fusion_previous_hash"] == "GENESIS"
+    assert event["payload"]["fusion_record_hash"] == ledger.records[0].record_hash
+    assert event["payload"]["fusion_payload"] == {"value": 1}
+
+
+def test_bridge_cannot_impersonate_privileged_sara_actor():
+    ledger = ledger_with_two_records()
+    for actor in ("admin", "operator", "SSPADAWANZZ_ADMIN"):
+        with pytest.raises(ValueError, match="cannot_impersonate"):
+            fusion_record_to_sara_event(ledger.records[0], actor=actor)
+
+
+def test_batch_bridge_requires_contiguous_sequence():
+    ledger = ledger_with_two_records()
+    events = fusion_records_to_sara_events(ledger.records)
+    assert [event["payload"]["fusion_sequence"] for event in events] == [0, 1]
+
+    ledger._records[1].sequence = 3
+    with pytest.raises(ValueError, match="sequence_not_contiguous"):
+        fusion_records_to_sara_events(ledger.records)

--- a/tests/test_fusion_consensus.py
+++ b/tests/test_fusion_consensus.py
@@ -1,0 +1,82 @@
+from worldshepherd_sara.fusion_consensus import StateConsensusGate, StateConsensusPolicy
+from worldshepherd_sara.fusion_control import PlasmaStateEstimate
+
+
+def estimate(estimator_id: str, displacement: float, *, confidence: float = 0.95, timestamp: float = 1.0, shot_id: str = "consensus-shot") -> PlasmaStateEstimate:
+    return PlasmaStateEstimate(
+        timestamp=timestamp,
+        shot_id=shot_id,
+        vertical_displacement_m=displacement,
+        confidence=confidence,
+        estimator_id=estimator_id,
+        source_diagnostics=(f"source:{estimator_id}",),
+    )
+
+
+def gate() -> StateConsensusGate:
+    return StateConsensusGate(
+        StateConsensusPolicy(
+            minimum_estimators=2,
+            minimum_confidence=0.80,
+            maximum_time_skew_s=0.01,
+            maximum_abs_disagreement_m=0.005,
+        )
+    )
+
+
+def test_distinct_close_estimates_are_accepted():
+    result = gate().evaluate([
+        estimate("optical-demo", 0.010),
+        estimate("independent-observer", 0.012, confidence=0.90, timestamp=1.001),
+    ])
+    assert result.accepted is True
+    assert result.reason == "consensus_accepted"
+    assert result.vertical_displacement_m is not None
+    assert 0.010 <= result.vertical_displacement_m <= 0.012
+    assert result.confidence == 0.90
+
+
+def test_duplicate_estimator_identity_is_not_treated_as_independent():
+    result = gate().evaluate([
+        estimate("same-estimator", 0.010),
+        estimate("same-estimator", 0.011),
+    ])
+    assert result.accepted is False
+    assert result.reason == "estimators_not_independent_by_identity"
+
+
+def test_cross_shot_estimates_are_rejected():
+    result = gate().evaluate([
+        estimate("one", 0.010, shot_id="shot-a"),
+        estimate("two", 0.011, shot_id="shot-b"),
+    ])
+    assert result.accepted is False
+    assert result.reason == "shot_id_mismatch"
+
+
+def test_low_confidence_estimate_blocks_consensus():
+    result = gate().evaluate([
+        estimate("one", 0.010),
+        estimate("two", 0.011, confidence=0.79),
+    ])
+    assert result.accepted is False
+    assert result.reason == "estimator_confidence_below_policy"
+
+
+def test_excessive_estimator_disagreement_blocks_consensus():
+    result = gate().evaluate([
+        estimate("one", 0.010),
+        estimate("two", 0.020),
+    ])
+    assert result.accepted is False
+    assert result.reason == "estimator_disagreement_exceeded"
+    assert result.disagreement_span_m == 0.01
+
+
+def test_excessive_time_skew_blocks_consensus():
+    result = gate().evaluate([
+        estimate("one", 0.010, timestamp=1.0),
+        estimate("two", 0.011, timestamp=1.02),
+    ])
+    assert result.accepted is False
+    assert result.reason == "estimator_time_skew_exceeded"

--- a/tests/test_fusion_control.py
+++ b/tests/test_fusion_control.py
@@ -1,0 +1,116 @@
+from worldshepherd_sara.fusion_control import (
+    ControlProposal,
+    DifferentialOpticalEstimator,
+    FusionAuditLedger,
+    PrimeSafetyGate,
+    SafetyEnvelope,
+    SensorSample,
+    run_simulated_control_cycle,
+)
+
+
+def sample(name: str, value: float, uncertainty: float = 1.0, valid: bool = True):
+    return SensorSample(
+        timestamp=1000.0,
+        shot_id="test-shot",
+        diagnostic=name,
+        value=value,
+        unit="arb",
+        uncertainty=uncertainty,
+        valid=valid,
+        quality="test",
+        provenance=f"test:{name}",
+    )
+
+
+def gate(minimum_confidence: float = 0.80):
+    return PrimeSafetyGate([
+        SafetyEnvelope(
+            actuator="virtual_vertical_balance",
+            minimum=-1.0,
+            maximum=1.0,
+            max_abs_slew_per_s=10.0,
+            unit="arb",
+            minimum_confidence=minimum_confidence,
+        )
+    ])
+
+
+def test_simulated_cycle_accepts_bounded_high_confidence_command():
+    result = run_simulated_control_cycle(sample("upper", 112.0), sample("lower", 88.0))
+    assert result.decision.accepted is True
+    assert result.decision.applied_value is not None
+    assert result.ledger_ok is True
+
+
+def test_invalid_sensor_is_rejected_before_control():
+    estimator = DifferentialOpticalEstimator()
+    try:
+        estimator.estimate(sample("upper", 100.0, valid=False), sample("lower", 100.0))
+    except ValueError as exc:
+        assert "sensor_invalid" in str(exc)
+    else:
+        raise AssertionError("invalid sensor sample was not rejected")
+
+
+def test_out_of_bounds_command_is_rejected():
+    safety_gate = gate()
+    decision = safety_gate.evaluate(ControlProposal(
+        timestamp=1000.0,
+        shot_id="test-shot",
+        actuator="virtual_vertical_balance",
+        requested_value=2.0,
+        unit="arb",
+        model_id="test-model",
+        confidence=0.99,
+        rationale="test",
+    ))
+    assert decision.accepted is False
+    assert decision.applied_value is None
+    assert decision.reason == "requested_value_out_of_bounds"
+
+
+def test_low_confidence_command_is_rejected():
+    safety_gate = gate(minimum_confidence=0.90)
+    decision = safety_gate.evaluate(ControlProposal(
+        timestamp=1000.0,
+        shot_id="test-shot",
+        actuator="virtual_vertical_balance",
+        requested_value=0.1,
+        unit="arb",
+        model_id="test-model",
+        confidence=0.50,
+        rationale="test",
+    ))
+    assert decision.accepted is False
+    assert decision.reason == "proposal_confidence_below_threshold"
+
+
+def test_unknown_actuator_is_rejected():
+    safety_gate = gate()
+    decision = safety_gate.evaluate(ControlProposal(
+        timestamp=1000.0,
+        shot_id="test-shot",
+        actuator="real_coil_current",
+        requested_value=0.1,
+        unit="arb",
+        model_id="test-model",
+        confidence=0.99,
+        rationale="test",
+    ))
+    assert decision.accepted is False
+    assert decision.reason == "actuator_not_allowlisted"
+
+
+def test_hash_chain_detects_tampering():
+    ledger = FusionAuditLedger()
+    ledger.append("one", {"value": 1}, timestamp=1.0)
+    ledger.append("two", {"value": 2}, timestamp=2.0)
+    ok, reason = ledger.verify()
+    assert ok is True
+    assert reason == "ok"
+
+    ledger._records[0].payload["value"] = 999
+    ok, reason = ledger.verify()
+    assert ok is False
+    assert reason.startswith("record_hash_mismatch")

--- a/tests/test_fusion_faults.py
+++ b/tests/test_fusion_faults.py
@@ -1,10 +1,16 @@
 from worldshepherd_sara.fusion_control import SensorSample
 from worldshepherd_sara.fusion_faults import (
+    FAULT_DELAYED_LOWER,
+    FAULT_DIAGNOSTIC_COLLISION,
     FAULT_DROP_LOWER,
+    FAULT_DUPLICATE_PAIR,
     FAULT_INVALID_FLAG,
     FAULT_MISSING_PROVENANCE,
+    FAULT_MISSING_QUALITY,
+    FAULT_MISSING_UNIT,
     FAULT_NONFINITE_VALUE,
     FAULT_PAIR_TIME_SKEW,
+    FAULT_REORDERED_PAIR,
     FAULT_SHOT_MISMATCH,
     run_fault_case,
     run_standard_fault_campaign,
@@ -42,7 +48,7 @@ def test_baseline_fixture_replays_before_fault_injection():
 def test_standard_fault_campaign_fails_safe_for_all_cases():
     upper, lower = paired_series()
     results = run_standard_fault_campaign(FusionReplayRunner(), upper, lower)
-    assert len(results) == 6
+    assert len(results) == 12
     assert all(result.safe_failure for result in results)
 
 
@@ -73,7 +79,37 @@ def test_corrupted_sample_integrity_faults_stop_before_valid_control():
         (FAULT_MISSING_PROVENANCE, "provenance_missing"),
         (FAULT_NONFINITE_VALUE, "value_not_finite"),
         (FAULT_INVALID_FLAG, "sensor_invalid"),
+        (FAULT_MISSING_UNIT, "unit_missing"),
+        (FAULT_MISSING_QUALITY, "quality_missing"),
     ):
         result = run_fault_case(FusionReplayRunner(), upper, lower, fault)
         assert result.safe_failure is True
         assert expected in result.observed_reason
+
+
+def test_duplicate_pair_is_rejected_by_monotonic_time_invariant():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_DUPLICATE_PAIR)
+    assert result.safe_failure is True
+    assert "replay_time_not_strictly_increasing" in result.observed_reason
+
+
+def test_delayed_lower_stream_is_rejected_by_pair_skew_invariant():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_DELAYED_LOWER)
+    assert result.safe_failure is True
+    assert "paired_timestamp_skew_exceeded" in result.observed_reason
+
+
+def test_reordered_pair_is_rejected_by_monotonic_time_invariant():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_REORDERED_PAIR)
+    assert result.safe_failure is True
+    assert "replay_time_not_strictly_increasing" in result.observed_reason
+
+
+def test_contradictory_diagnostic_identity_is_rejected():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_DIAGNOSTIC_COLLISION)
+    assert result.safe_failure is True
+    assert "optical diagnostic identity collision" in result.observed_reason

--- a/tests/test_fusion_faults.py
+++ b/tests/test_fusion_faults.py
@@ -1,0 +1,79 @@
+from worldshepherd_sara.fusion_control import SensorSample
+from worldshepherd_sara.fusion_faults import (
+    FAULT_DROP_LOWER,
+    FAULT_INVALID_FLAG,
+    FAULT_MISSING_PROVENANCE,
+    FAULT_NONFINITE_VALUE,
+    FAULT_PAIR_TIME_SKEW,
+    FAULT_SHOT_MISMATCH,
+    run_fault_case,
+    run_standard_fault_campaign,
+)
+from worldshepherd_sara.fusion_replay import FusionReplayRunner
+
+
+def sample(ts: float, name: str, value: float) -> SensorSample:
+    return SensorSample(
+        timestamp=ts,
+        shot_id="fault-shot",
+        diagnostic=name,
+        value=value,
+        unit="arb",
+        uncertainty=0.5,
+        valid=True,
+        quality="fault-fixture",
+        provenance=f"fixture:{name}:{ts}",
+    )
+
+
+def paired_series():
+    upper = [sample(1.0, "upper", 110.0), sample(2.0, "upper", 108.0)]
+    lower = [sample(1.0, "lower", 90.0), sample(2.0, "lower", 92.0)]
+    return upper, lower
+
+
+def test_baseline_fixture_replays_before_fault_injection():
+    upper, lower = paired_series()
+    report = FusionReplayRunner().replay(upper, lower)
+    assert report.ledger_ok is True
+    assert report.cycle_count == 2
+
+
+def test_standard_fault_campaign_fails_safe_for_all_cases():
+    upper, lower = paired_series()
+    results = run_standard_fault_campaign(FusionReplayRunner(), upper, lower)
+    assert len(results) == 6
+    assert all(result.safe_failure for result in results)
+
+
+def test_drop_lower_sample_stops_replay():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_DROP_LOWER)
+    assert result.safe_failure is True
+    assert "paired_series_length_mismatch" in result.observed_reason
+
+
+def test_pair_time_skew_stops_replay():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_PAIR_TIME_SKEW)
+    assert result.safe_failure is True
+    assert "paired_timestamp_skew_exceeded" in result.observed_reason
+
+
+def test_shot_mismatch_stops_replay():
+    upper, lower = paired_series()
+    result = run_fault_case(FusionReplayRunner(), upper, lower, FAULT_SHOT_MISMATCH)
+    assert result.safe_failure is True
+    assert "shot_id_mismatch" in result.observed_reason
+
+
+def test_corrupted_sample_integrity_faults_stop_before_valid_control():
+    upper, lower = paired_series()
+    for fault, expected in (
+        (FAULT_MISSING_PROVENANCE, "provenance_missing"),
+        (FAULT_NONFINITE_VALUE, "value_not_finite"),
+        (FAULT_INVALID_FLAG, "sensor_invalid"),
+    ):
+        result = run_fault_case(FusionReplayRunner(), upper, lower, fault)
+        assert result.safe_failure is True
+        assert expected in result.observed_reason

--- a/tests/test_fusion_replay.py
+++ b/tests/test_fusion_replay.py
@@ -1,0 +1,82 @@
+from worldshepherd_sara.fusion_control import SensorSample
+from worldshepherd_sara.fusion_replay import FusionReplayRunner
+
+
+def sample(ts: float, name: str, value: float, uncertainty: float = 0.5) -> SensorSample:
+    return SensorSample(
+        timestamp=ts,
+        shot_id="replay-shot",
+        diagnostic=name,
+        value=value,
+        unit="arb",
+        uncertainty=uncertainty,
+        valid=True,
+        quality="test",
+        provenance=f"fixture:{name}:{ts}",
+    )
+
+
+def series():
+    upper = [
+        sample(1.0, "upper", 112.0),
+        sample(2.0, "upper", 108.0),
+        sample(3.0, "upper", 104.0),
+    ]
+    lower = [
+        sample(1.0, "lower", 88.0),
+        sample(2.0, "lower", 92.0),
+        sample(3.0, "lower", 96.0),
+    ]
+    return upper, lower
+
+
+def test_identical_input_produces_identical_replay_fingerprint():
+    upper, lower = series()
+    runner = FusionReplayRunner()
+    first = runner.replay(upper, lower)
+    second = runner.replay(upper, lower)
+
+    assert first.ledger_ok is True
+    assert second.ledger_ok is True
+    assert first.fingerprint_sha256 == second.fingerprint_sha256
+    assert first.cycles == second.cycles
+    assert first.cycle_count == 3
+
+
+def test_changed_input_changes_replay_fingerprint():
+    upper, lower = series()
+    runner = FusionReplayRunner()
+    baseline = runner.replay(upper, lower)
+
+    altered = list(upper)
+    altered[1] = sample(2.0, "upper", 107.0)
+    changed = runner.replay(altered, lower)
+
+    assert baseline.fingerprint_sha256 != changed.fingerprint_sha256
+
+
+def test_replay_rejects_pair_time_skew():
+    upper, lower = series()
+    lower[1] = sample(2.01, "lower", 92.0)
+    runner = FusionReplayRunner(maximum_pair_time_skew_s=1e-4)
+
+    try:
+        runner.replay(upper, lower)
+    except ValueError as exc:
+        assert "paired_timestamp_skew_exceeded" in str(exc)
+    else:
+        raise AssertionError("time-skewed diagnostic pair was not rejected")
+
+
+def test_replay_rejects_non_increasing_time():
+    upper, lower = series()
+    upper[2] = sample(2.0, "upper", 104.0)
+    lower[2] = sample(2.0, "lower", 96.0)
+    runner = FusionReplayRunner()
+
+    try:
+        runner.replay(upper, lower)
+    except ValueError as exc:
+        assert "replay_time_not_strictly_increasing" in str(exc)
+    else:
+        raise AssertionError("non-increasing replay time was not rejected")

--- a/tests/test_observer_authority.py
+++ b/tests/test_observer_authority.py
@@ -1,0 +1,65 @@
+from worldshepherd_sara.observer_authority import (
+    ObserverAuthorityPacket,
+    REQUIRED_AUTHORITY_FIELDS,
+    missing_authorities,
+)
+
+
+def complete_packet() -> ObserverAuthorityPacket:
+    return ObserverAuthorityPacket(
+        device="MAST",
+        reconstruction_family="external-equilibrium-observer",
+        authority_provenance={
+            "diagnostic_geometry_and_calibration": "authority:diagnostic-geometry-calibration",
+            "passive_structure_model": "authority:passive-structure",
+            "response_matrices_or_generation_method": "authority:response-model",
+            "reconstruction_settings": "authority:solver-settings",
+            "coordinate_conventions": "authority:coordinate-conventions",
+        },
+        validated_by="authoritative-source-review",
+        validation_reference="authority-review:fixture",
+    )
+
+
+def test_complete_authority_packet_passes_completeness_gate():
+    packet = complete_packet()
+    assert packet.validate() == (True, "ok")
+    assert packet.authority_complete is True
+    assert missing_authorities(packet) == ()
+
+
+def test_each_required_authority_fails_closed_when_missing():
+    baseline = complete_packet()
+    for field in REQUIRED_AUTHORITY_FIELDS:
+        authorities = dict(baseline.authority_provenance)
+        authorities[field] = ""
+        packet = ObserverAuthorityPacket(
+            device=baseline.device,
+            reconstruction_family=baseline.reconstruction_family,
+            authority_provenance=authorities,
+            validated_by=baseline.validated_by,
+            validation_reference=baseline.validation_reference,
+        )
+        assert packet.validate() == (False, f"authority_missing:{field}")
+        assert field in missing_authorities(packet)
+
+
+def test_validation_identity_and_reference_are_required():
+    baseline = complete_packet()
+    missing_validator = ObserverAuthorityPacket(
+        device=baseline.device,
+        reconstruction_family=baseline.reconstruction_family,
+        authority_provenance=baseline.authority_provenance,
+        validated_by="",
+        validation_reference=baseline.validation_reference,
+    )
+    assert missing_validator.validate() == (False, "validated_by_missing")
+
+    missing_reference = ObserverAuthorityPacket(
+        device=baseline.device,
+        reconstruction_family=baseline.reconstruction_family,
+        authority_provenance=baseline.authority_provenance,
+        validated_by=baseline.validated_by,
+        validation_reference="",
+    )
+    assert missing_reference.validate() == (False, "validation_reference_missing")

--- a/worldshepherd_sara/archive_readiness.py
+++ b/worldshepherd_sara/archive_readiness.py
@@ -1,0 +1,75 @@
+"""Claims-controlled readiness classification for archived fusion evidence.
+
+This module prevents analysis-grade archive evidence from being silently
+promoted to control-grade evidence.  It evaluates an evidence record's own
+quality/uncertainty/control flags; it does not infer missing uncertainty or
+machine qualification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Tuple
+
+
+@dataclass(frozen=True)
+class ArchiveReadinessDecision:
+    analysis_eligible: bool
+    control_evidence_eligible: bool
+    reasons: Tuple[str, ...]
+
+
+def evaluate_archive_evidence(evidence: Mapping[str, Any]) -> ArchiveReadinessDecision:
+    reasons: list[str] = []
+
+    readiness = evidence.get("readiness")
+    if not isinstance(readiness, Mapping):
+        return ArchiveReadinessDecision(False, False, ("readiness_section_missing",))
+
+    archive_reachable = readiness.get("archive_reachability_confirmed") is True
+    integrity_hashed = readiness.get("chunk_integrity_hashed") is True
+    decoded_shape = readiness.get("decoded_shape_confirmed") is True
+    all_finite = readiness.get("all_values_finite") is True
+    time_increasing = readiness.get("time_strictly_increasing") is True
+    upstream_quality = str(readiness.get("upstream_quality", "")).strip()
+    uncertainty_available = readiness.get("uncertainty_metadata_available") is True
+
+    if not archive_reachable:
+        reasons.append("archive_reachability_not_confirmed")
+    if not integrity_hashed:
+        reasons.append("chunk_integrity_not_hashed")
+    if not decoded_shape:
+        reasons.append("decoded_shape_not_confirmed")
+    if not all_finite:
+        reasons.append("nonfinite_values_present_or_unverified")
+    if not time_increasing:
+        reasons.append("time_base_not_strictly_increasing")
+
+    analysis_eligible = not reasons
+
+    control_reasons = list(reasons)
+    if not uncertainty_available:
+        control_reasons.append("uncertainty_metadata_unavailable")
+    if not upstream_quality or upstream_quality.lower() in {"not checked", "unchecked", "unknown"}:
+        control_reasons.append("upstream_quality_not_control_qualified")
+
+    claims = evidence.get("claims_boundary")
+    if not isinstance(claims, Mapping):
+        control_reasons.append("claims_boundary_missing")
+    else:
+        if claims.get("real_plasma_state_estimation_validated") is not True:
+            control_reasons.append("real_plasma_state_estimation_not_validated")
+        if claims.get("real_machine_control_validated") is not True:
+            control_reasons.append("real_machine_control_not_validated")
+
+    declared_control = readiness.get("control_evidence_eligible") is True
+    if not declared_control:
+        control_reasons.append("source_record_declares_control_ineligible")
+
+    # Deduplicate without losing deterministic order.
+    deduped_control = tuple(dict.fromkeys(control_reasons))
+    return ArchiveReadinessDecision(
+        analysis_eligible=analysis_eligible,
+        control_evidence_eligible=(analysis_eligible and not deduped_control),
+        reasons=deduped_control if deduped_control else tuple(reasons),
+    )

--- a/worldshepherd_sara/control_admission.py
+++ b/worldshepherd_sara/control_admission.py
@@ -1,0 +1,45 @@
+"""Explicit admission boundary between archive analysis and control evidence.
+
+Callers must pass a claims-controlled archive evidence record through this gate
+before using that archive as control evidence.  This prevents a downstream
+caller from upgrading an analysis-only dataset by supplying ad-hoc uncertainty
+or confidence values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Tuple
+
+from worldshepherd_sara.archive_readiness import ArchiveReadinessDecision, evaluate_archive_evidence
+
+
+@dataclass(frozen=True)
+class ControlAdmissionResult:
+    admitted: bool
+    reason: str
+    blockers: Tuple[str, ...]
+
+
+class ArchiveControlAdmissionGate:
+    def evaluate(self, evidence: Mapping[str, Any]) -> ControlAdmissionResult:
+        readiness = evaluate_archive_evidence(evidence)
+        if not readiness.analysis_eligible:
+            return ControlAdmissionResult(
+                admitted=False,
+                reason="archive_not_analysis_eligible",
+                blockers=readiness.reasons,
+            )
+        if not readiness.control_evidence_eligible:
+            return ControlAdmissionResult(
+                admitted=False,
+                reason="archive_not_control_evidence_eligible",
+                blockers=readiness.reasons,
+            )
+        return ControlAdmissionResult(True, "control_evidence_admitted", ())
+
+    def require(self, evidence: Mapping[str, Any]) -> None:
+        decision = self.evaluate(evidence)
+        if not decision.admitted:
+            joined = ",".join(decision.blockers)
+            raise ValueError(f"{decision.reason}:{joined}")

--- a/worldshepherd_sara/external_observer.py
+++ b/worldshepherd_sara/external_observer.py
@@ -1,0 +1,81 @@
+"""Provenance-gated adapter for externally supplied state estimates.
+
+This adapter deliberately does not implement a magnetic/equilibrium estimator.
+It accepts a state estimate produced by an independent external method, validates
+its identity/provenance/quality envelope, and converts it into the common
+PlasmaStateEstimate contract for the consensus gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Tuple
+
+from worldshepherd_sara.fusion_control import PlasmaStateEstimate
+
+
+@dataclass(frozen=True)
+class ExternalObserverRecord:
+    timestamp: float
+    shot_id: str
+    vertical_displacement_m: float
+    confidence: float
+    estimator_id: str
+    method: str
+    source_diagnostics: Tuple[str, ...]
+    provenance: str
+    quality: str
+    validated_by_source: bool
+
+    def validate(self) -> Tuple[bool, str]:
+        if not math.isfinite(self.timestamp):
+            return False, "timestamp_not_finite"
+        if not self.shot_id.strip():
+            return False, "shot_id_missing"
+        if not math.isfinite(self.vertical_displacement_m):
+            return False, "state_not_finite"
+        if not (0.0 <= self.confidence <= 1.0):
+            return False, "confidence_out_of_range"
+        if not self.estimator_id.strip():
+            return False, "estimator_id_missing"
+        if not self.method.strip():
+            return False, "method_missing"
+        if not self.source_diagnostics or any(not item.strip() for item in self.source_diagnostics):
+            return False, "source_diagnostics_missing"
+        if not self.provenance.strip():
+            return False, "provenance_missing"
+        if not self.quality.strip():
+            return False, "quality_missing"
+        if not self.validated_by_source:
+            return False, "external_estimate_not_source_validated"
+        return True, "ok"
+
+
+class ExternalObserverAdapter:
+    """Fail-closed conversion into the shared state-estimate contract."""
+
+    def __init__(self, *, minimum_confidence: float = 0.80) -> None:
+        self.minimum_confidence = float(minimum_confidence)
+        if not 0.0 <= self.minimum_confidence <= 1.0:
+            raise ValueError("minimum_confidence_out_of_range")
+
+    def adapt(self, record: ExternalObserverRecord) -> PlasmaStateEstimate:
+        ok, reason = record.validate()
+        if not ok:
+            raise ValueError(reason)
+        if record.confidence < self.minimum_confidence:
+            raise ValueError("external_estimate_confidence_below_policy")
+
+        estimate = PlasmaStateEstimate(
+            timestamp=record.timestamp,
+            shot_id=record.shot_id,
+            vertical_displacement_m=record.vertical_displacement_m,
+            confidence=record.confidence,
+            estimator_id=record.estimator_id,
+            source_diagnostics=record.source_diagnostics,
+        )
+        estimate_ok, estimate_reason = estimate.validate()
+        if not estimate_ok:
+            raise ValueError(f"adapted_state_invalid:{estimate_reason}")
+        return estimate

--- a/worldshepherd_sara/fair_mast_adapter.py
+++ b/worldshepherd_sara/fair_mast_adapter.py
@@ -1,0 +1,231 @@
+"""Read-only FAIR-MAST adapter for WS-FUSION-CTRL-001.
+
+This module converts public FAIR-MAST metadata/series references into the
+simulator-only SensorSample contract.  It deliberately contains no actuator,
+EPICS, CODAC, RTF, coil, gas, or heating command path.
+
+FAIR-MAST publishes shot metadata through a JSON API and diagnostic arrays as
+Zarr objects in a public S3 bucket.  The adapter keeps those source identities
+in every generated provenance string so downstream replay can identify the
+exact archive level, shot, diagnostic group, signal, and sample index.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from worldshepherd_sara.fusion_control import SensorSample
+
+
+FAIR_MAST_API_BASE = "https://mastapp.site/json"
+FAIR_MAST_S3_ENDPOINT = "https://s3.echo.stfc.ac.uk"
+FAIR_MAST_BUCKET = "mast"
+_ALLOWED_API_HOSTS = {"mastapp.site"}
+_ALLOWED_LEVELS = {"level1", "level2"}
+
+
+@dataclass(frozen=True)
+class FairMastSource:
+    shot_id: int
+    diagnostic_group: str
+    signal: str
+    level: str = "level1"
+
+    def validate(self) -> Tuple[bool, str]:
+        if int(self.shot_id) <= 0:
+            return False, "shot_id_invalid"
+        if self.level not in _ALLOWED_LEVELS:
+            return False, "data_level_not_allowlisted"
+        if not self.diagnostic_group.strip():
+            return False, "diagnostic_group_missing"
+        if not self.signal.strip():
+            return False, "signal_missing"
+        if "/" in self.diagnostic_group.strip("/"):
+            return False, "diagnostic_group_must_be_single_path_component"
+        if "/" in self.signal.strip("/"):
+            return False, "signal_must_be_single_path_component"
+        return True, "ok"
+
+    @property
+    def zarr_uri(self) -> str:
+        ok, reason = self.validate()
+        if not ok:
+            raise ValueError(reason)
+        return (
+            f"s3://{FAIR_MAST_BUCKET}/{self.level}/shots/{int(self.shot_id)}.zarr/"
+            f"{self.diagnostic_group}"
+        )
+
+    @property
+    def diagnostic_name(self) -> str:
+        return f"{self.diagnostic_group}/{self.signal}"
+
+    def provenance_for_index(self, index: int) -> str:
+        return (
+            f"fair-mast|endpoint={FAIR_MAST_S3_ENDPOINT}|uri={self.zarr_uri}"
+            f"|signal={self.signal}|index={int(index)}|level={self.level}"
+        )
+
+
+class FairMastQualityPolicy:
+    """Conservative source-quality rules for replay/analysis preparation.
+
+    A published FAIR-MAST issue reports severe quantization in at least one
+    Level-2 magnetics dataset and recommends Level-1 raw data for analyses that
+    depend on derivatives.  Until the scope is resolved, derivative-sensitive
+    Level-2 magnetic signals are blocked by default instead of silently treated
+    as equivalent to Level-1 data.
+    """
+
+    @staticmethod
+    def evaluate(source: FairMastSource, *, derivative_sensitive: bool = False) -> Tuple[bool, str]:
+        ok, reason = source.validate()
+        if not ok:
+            return False, reason
+
+        name = source.diagnostic_name.lower()
+        looks_magnetic = (
+            "magnet" in name
+            or "mirnov" in name
+            or "saddle" in name
+            or "b_field" in name
+        )
+        if derivative_sensitive and source.level == "level2" and looks_magnetic:
+            return False, "level2_magnetics_derivative_quality_risk"
+        return True, "ok"
+
+
+class FairMastReadOnlyMetadataClient:
+    """Strict GET-only client for FAIR-MAST shot metadata.
+
+    Network access is not used by unit tests.  The client is intentionally
+    host-allowlisted and exposes no arbitrary-URL fetch method.
+    """
+
+    def __init__(self, base_url: str = FAIR_MAST_API_BASE, timeout_s: float = 10.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_s = float(timeout_s)
+        self._validate_base_url()
+
+    def _validate_base_url(self) -> None:
+        parsed = urlparse(self.base_url)
+        if parsed.scheme != "https":
+            raise ValueError("FAIR-MAST API must use https")
+        if parsed.hostname not in _ALLOWED_API_HOSTS:
+            raise ValueError("FAIR-MAST API host not allowlisted")
+        if not parsed.path.startswith("/json"):
+            raise ValueError("FAIR-MAST API base path must start with /json")
+        if not math.isfinite(self.timeout_s) or self.timeout_s <= 0 or self.timeout_s > 60:
+            raise ValueError("timeout_s must be in (0, 60]")
+
+    def shot_url(self, shot_id: int) -> str:
+        shot = int(shot_id)
+        if shot <= 0:
+            raise ValueError("shot_id_invalid")
+        return f"{self.base_url}/shots/{shot}"
+
+    def fetch_shot_metadata(self, shot_id: int) -> Dict[str, Any]:
+        request = Request(
+            self.shot_url(shot_id),
+            method="GET",
+            headers={"Accept": "application/json", "User-Agent": "Worldshepherd-FAIR-MAST-readonly/0.1"},
+        )
+        with urlopen(request, timeout=self.timeout_s) as response:  # nosec B310: URL host is allowlisted above
+            status = getattr(response, "status", 200)
+            if status != 200:
+                raise RuntimeError(f"FAIR-MAST metadata request returned HTTP {status}")
+            payload = response.read()
+        decoded = json.loads(payload.decode("utf-8"))
+        if not isinstance(decoded, dict):
+            raise ValueError("FAIR-MAST metadata payload must be a JSON object")
+        return decoded
+
+
+def _expand_uncertainty(uncertainty: float | Sequence[float], count: int) -> List[float]:
+    if isinstance(uncertainty, (int, float)):
+        values = [float(uncertainty)] * count
+    else:
+        values = [float(value) for value in uncertainty]
+        if len(values) != count:
+            raise ValueError("uncertainty_length_mismatch")
+    if any((not math.isfinite(value) or value < 0) for value in values):
+        raise ValueError("uncertainty_invalid")
+    return values
+
+
+def series_to_sensor_samples(
+    source: FairMastSource,
+    timestamps: Sequence[float],
+    values: Sequence[float],
+    *,
+    unit: str,
+    uncertainty: float | Sequence[float],
+    valid: Optional[Sequence[bool]] = None,
+    quality: str = "archive",
+    derivative_sensitive: bool = False,
+) -> List[SensorSample]:
+    """Convert an already-read FAIR-MAST series into Worldshepherd samples.
+
+    Reading Zarr arrays is intentionally kept outside this core adapter so
+    archive access cannot be confused with control authority.  Callers provide
+    arrays/series, and this function performs source-policy checks, shape
+    checks, and provenance attachment.
+    """
+
+    policy_ok, policy_reason = FairMastQualityPolicy.evaluate(
+        source,
+        derivative_sensitive=derivative_sensitive,
+    )
+    if not policy_ok:
+        raise ValueError(policy_reason)
+
+    if not unit.strip():
+        raise ValueError("unit_missing")
+    if not quality.strip():
+        raise ValueError("quality_missing")
+    if len(timestamps) != len(values):
+        raise ValueError("timestamp_value_length_mismatch")
+    count = len(values)
+    if count == 0:
+        return []
+
+    uncertainties = _expand_uncertainty(uncertainty, count)
+    validity = [True] * count if valid is None else [bool(value) for value in valid]
+    if len(validity) != count:
+        raise ValueError("validity_length_mismatch")
+
+    samples: List[SensorSample] = []
+    previous_ts: Optional[float] = None
+    for index, (timestamp, value, sample_uncertainty, is_valid) in enumerate(
+        zip(timestamps, values, uncertainties, validity)
+    ):
+        ts = float(timestamp)
+        sample_value = float(value)
+        if not math.isfinite(ts):
+            raise ValueError(f"timestamp_not_finite:{index}")
+        if previous_ts is not None and ts < previous_ts:
+            raise ValueError(f"timestamp_not_monotonic:{index}")
+        previous_ts = ts
+
+        sample = SensorSample(
+            timestamp=ts,
+            shot_id=str(int(source.shot_id)),
+            diagnostic=source.diagnostic_name,
+            value=sample_value,
+            unit=unit,
+            uncertainty=sample_uncertainty,
+            valid=is_valid and math.isfinite(sample_value),
+            quality=f"{quality};fair-mast-{source.level}",
+            provenance=source.provenance_for_index(index),
+        )
+        ok, reason = sample.validate()
+        if not ok and reason != "sensor_invalid":
+            raise ValueError(f"sample_invalid:{index}:{reason}")
+        samples.append(sample)
+
+    return samples

--- a/worldshepherd_sara/fair_mast_probe.py
+++ b/worldshepherd_sara/fair_mast_probe.py
@@ -1,0 +1,136 @@
+"""Bounded read-only metadata probe for a pinned FAIR-MAST Zarr source.
+
+The probe intentionally reads only Zarr metadata objects (.zgroup, .zattrs,
+.zarray).  It never fetches array chunk payloads and has no control-system
+transport.  The result is a provenance report containing URL, size, SHA-256,
+and parsed metadata for the exact objects inspected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Tuple
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+JsonFetcher = Callable[[str], Tuple[Dict[str, Any], bytes]]
+
+
+def zarr_http_base(endpoint: str, zarr_uri: str) -> str:
+    endpoint_parsed = urlparse(endpoint)
+    if endpoint_parsed.scheme != "https":
+        raise ValueError("endpoint_must_use_https")
+    if endpoint_parsed.hostname != "s3.echo.stfc.ac.uk":
+        raise ValueError("endpoint_host_not_allowlisted")
+
+    zarr_parsed = urlparse(zarr_uri)
+    if zarr_parsed.scheme != "s3" or not zarr_parsed.netloc:
+        raise ValueError("zarr_uri_must_be_s3")
+    if zarr_parsed.netloc != "mast":
+        raise ValueError("zarr_bucket_not_allowlisted")
+
+    return f"{endpoint.rstrip('/')}/{zarr_parsed.netloc}{zarr_parsed.path.rstrip('/')}"
+
+
+def fetch_json_object(url: str, *, timeout_s: float = 20.0, max_bytes: int = 2_000_000) -> Tuple[Dict[str, Any], bytes]:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname != "s3.echo.stfc.ac.uk":
+        raise ValueError("probe_url_not_allowlisted")
+    request = Request(
+        url,
+        method="GET",
+        headers={"Accept": "application/json", "User-Agent": "Worldshepherd-FAIR-MAST-metadata-probe/0.1"},
+    )
+    with urlopen(request, timeout=timeout_s) as response:  # nosec B310: host is allowlisted above
+        status = getattr(response, "status", 200)
+        if status != 200:
+            raise RuntimeError(f"metadata_object_http_status:{status}:{url}")
+        raw = response.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ValueError(f"metadata_object_too_large:{url}")
+    decoded = json.loads(raw.decode("utf-8"))
+    if not isinstance(decoded, dict):
+        raise ValueError(f"metadata_object_not_json_object:{url}")
+    return decoded, raw
+
+
+def _evidence(url: str, payload: Mapping[str, Any], raw: bytes) -> Dict[str, Any]:
+    return {
+        "url": url,
+        "bytes": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "metadata": dict(payload),
+    }
+
+
+def probe_source_manifest(manifest: Mapping[str, Any], *, fetcher: JsonFetcher = fetch_json_object) -> Dict[str, Any]:
+    if manifest.get("status") != "SOURCE_MANIFEST_ONLY_NO_ARCHIVED_VALUES_EMBEDDED":
+        raise ValueError("manifest_status_not_source_only")
+    endpoint = str(manifest["s3_endpoint"])
+    zarr_uri = str(manifest["zarr_uri"])
+    signals = manifest.get("signals")
+    if not isinstance(signals, list) or not signals:
+        raise ValueError("manifest_signals_missing")
+
+    base = zarr_http_base(endpoint, zarr_uri)
+    objects: Dict[str, Any] = {}
+
+    for relative in (".zgroup", ".zattrs"):
+        url = f"{base}/{relative}"
+        payload, raw = fetcher(url)
+        objects[relative] = _evidence(url, payload, raw)
+
+    signal_objects: Dict[str, Any] = {}
+    for signal in signals:
+        signal_name = str(signal).strip()
+        if not signal_name or "/" in signal_name:
+            raise ValueError(f"invalid_manifest_signal:{signal_name}")
+        signal_evidence: Dict[str, Any] = {}
+        for relative in (".zarray", ".zattrs"):
+            url = f"{base}/{signal_name}/{relative}"
+            payload, raw = fetcher(url)
+            signal_evidence[relative] = _evidence(url, payload, raw)
+        signal_objects[signal_name] = signal_evidence
+
+    canonical = {
+        "schema": "worldshepherd.fair_mast.metadata_probe.v1",
+        "archive": manifest.get("archive"),
+        "shot_id": manifest.get("shot_id"),
+        "data_level": manifest.get("data_level"),
+        "diagnostic_group": manifest.get("diagnostic_group"),
+        "zarr_uri": zarr_uri,
+        "http_base": base,
+        "objects": objects,
+        "signals": signal_objects,
+        "array_chunks_fetched": False,
+        "machine_control_authority": False,
+    }
+    report_bytes = json.dumps(canonical, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    canonical["report_sha256"] = hashlib.sha256(report_bytes).hexdigest()
+    return canonical
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--manifest",
+        default="data/fair_mast/shot_30420_amc_manifest.json",
+    )
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    report = probe_source_manifest(manifest)
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worldshepherd_sara/fusion_audit_bridge.py
+++ b/worldshepherd_sara/fusion_audit_bridge.py
@@ -1,0 +1,56 @@
+"""Map fusion replay evidence into the existing SARA audit event shape.
+
+This bridge is intentionally non-mutating: it returns dictionaries compatible
+with the SARA audit schema but does not write files, call server endpoints, or
+change admin/operator authority.  A later reviewed integration can choose how
+to persist these mapped events.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, Iterable, List
+
+from worldshepherd_sara.fusion_control import AuditRecord
+
+
+DEFAULT_FUSION_AUDIT_ACTOR = "SARA_FUSION_SIM"
+
+
+def fusion_record_to_sara_event(
+    record: AuditRecord,
+    *,
+    actor: str = DEFAULT_FUSION_AUDIT_ACTOR,
+) -> Dict[str, Any]:
+    actor = actor.strip()
+    if not actor:
+        raise ValueError("audit_actor_missing")
+    if actor.lower() in {"admin", "operator", "sspadawanzz_admin"}:
+        raise ValueError("fusion_bridge_cannot_impersonate_privileged_actor")
+
+    return {
+        "ts": float(record.timestamp),
+        "event": f"fusion.{record.event}",
+        "actor": actor,
+        "payload": {
+            "fusion_sequence": int(record.sequence),
+            "fusion_previous_hash": record.previous_hash,
+            "fusion_record_hash": record.record_hash,
+            "fusion_payload": dict(record.payload),
+        },
+    }
+
+
+def fusion_records_to_sara_events(
+    records: Iterable[AuditRecord],
+    *,
+    actor: str = DEFAULT_FUSION_AUDIT_ACTOR,
+) -> List[Dict[str, Any]]:
+    events = [fusion_record_to_sara_event(record, actor=actor) for record in records]
+    for expected_sequence, event in enumerate(events):
+        sequence = event["payload"]["fusion_sequence"]
+        if sequence != expected_sequence:
+            raise ValueError(
+                f"fusion_audit_sequence_not_contiguous:{expected_sequence}:{sequence}"
+            )
+    return events

--- a/worldshepherd_sara/fusion_consensus.py
+++ b/worldshepherd_sara/fusion_consensus.py
@@ -1,0 +1,119 @@
+"""Estimator-consensus gate for WS-FUSION-CTRL-001.
+
+The gate does not estimate plasma state and does not command actuators.  It is a
+policy boundary between independently produced state estimates and downstream
+control proposals.  A proposal path can require multiple distinct estimators
+to agree within explicitly configured limits before their state is considered
+consensus-eligible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Sequence, Tuple
+
+from worldshepherd_sara.fusion_control import PlasmaStateEstimate
+
+
+@dataclass(frozen=True)
+class StateConsensusPolicy:
+    minimum_estimators: int = 2
+    minimum_confidence: float = 0.80
+    maximum_time_skew_s: float = 0.001
+    maximum_abs_disagreement_m: float = 0.01
+
+    def validate(self) -> None:
+        if self.minimum_estimators < 2:
+            raise ValueError("minimum_estimators_must_be_at_least_two")
+        if not (0.0 <= self.minimum_confidence <= 1.0):
+            raise ValueError("minimum_confidence_out_of_range")
+        if not math.isfinite(self.maximum_time_skew_s) or self.maximum_time_skew_s < 0:
+            raise ValueError("maximum_time_skew_invalid")
+        if not math.isfinite(self.maximum_abs_disagreement_m) or self.maximum_abs_disagreement_m < 0:
+            raise ValueError("maximum_abs_disagreement_invalid")
+
+
+@dataclass(frozen=True)
+class StateConsensusResult:
+    accepted: bool
+    reason: str
+    shot_id: str
+    timestamp: float
+    vertical_displacement_m: float | None
+    confidence: float
+    estimator_ids: Tuple[str, ...]
+    disagreement_span_m: float | None
+
+
+class StateConsensusGate:
+    def __init__(self, policy: StateConsensusPolicy | None = None) -> None:
+        self.policy = policy or StateConsensusPolicy()
+        self.policy.validate()
+
+    def evaluate(self, estimates: Sequence[PlasmaStateEstimate]) -> StateConsensusResult:
+        if len(estimates) < self.policy.minimum_estimators:
+            return self._reject("insufficient_estimators", estimates)
+
+        estimator_ids = tuple(estimate.estimator_id.strip() for estimate in estimates)
+        if any(not estimator_id for estimator_id in estimator_ids):
+            return self._reject("estimator_id_missing", estimates)
+        if len(set(estimator_ids)) != len(estimator_ids):
+            return self._reject("estimators_not_independent_by_identity", estimates)
+
+        shot_ids = {estimate.shot_id for estimate in estimates}
+        if len(shot_ids) != 1 or "" in shot_ids:
+            return self._reject("shot_id_mismatch", estimates)
+
+        timestamps = [float(estimate.timestamp) for estimate in estimates]
+        displacements = [float(estimate.vertical_displacement_m) for estimate in estimates]
+        confidences = [float(estimate.confidence) for estimate in estimates]
+        if any(not math.isfinite(value) for value in timestamps + displacements + confidences):
+            return self._reject("nonfinite_estimator_output", estimates)
+        if any(confidence < self.policy.minimum_confidence or confidence > 1.0 for confidence in confidences):
+            return self._reject("estimator_confidence_below_policy", estimates)
+
+        time_skew = max(timestamps) - min(timestamps)
+        if time_skew > self.policy.maximum_time_skew_s:
+            return self._reject("estimator_time_skew_exceeded", estimates)
+
+        disagreement = max(displacements) - min(displacements)
+        if disagreement > self.policy.maximum_abs_disagreement_m:
+            return self._reject("estimator_disagreement_exceeded", estimates, disagreement)
+
+        total_weight = sum(confidences)
+        if total_weight <= 0:
+            return self._reject("invalid_consensus_weight", estimates, disagreement)
+        fused = sum(value * confidence for value, confidence in zip(displacements, confidences)) / total_weight
+
+        return StateConsensusResult(
+            accepted=True,
+            reason="consensus_accepted",
+            shot_id=next(iter(shot_ids)),
+            timestamp=max(timestamps),
+            vertical_displacement_m=fused,
+            confidence=min(confidences),
+            estimator_ids=estimator_ids,
+            disagreement_span_m=disagreement,
+        )
+
+    def _reject(
+        self,
+        reason: str,
+        estimates: Sequence[PlasmaStateEstimate],
+        disagreement: float | None = None,
+    ) -> StateConsensusResult:
+        estimator_ids = tuple(estimate.estimator_id for estimate in estimates)
+        shot_id = estimates[0].shot_id if estimates else ""
+        finite_times = [float(e.timestamp) for e in estimates if math.isfinite(float(e.timestamp))]
+        finite_confidences = [float(e.confidence) for e in estimates if math.isfinite(float(e.confidence))]
+        return StateConsensusResult(
+            accepted=False,
+            reason=reason,
+            shot_id=shot_id,
+            timestamp=max(finite_times) if finite_times else 0.0,
+            vertical_displacement_m=None,
+            confidence=min(finite_confidences) if finite_confidences else 0.0,
+            estimator_ids=estimator_ids,
+            disagreement_span_m=disagreement,
+        )

--- a/worldshepherd_sara/fusion_control.py
+++ b/worldshepherd_sara/fusion_control.py
@@ -44,6 +44,10 @@ class SensorSample:
             return False, "uncertainty_invalid"
         if not self.diagnostic.strip():
             return False, "diagnostic_missing"
+        if not self.unit.strip():
+            return False, "unit_missing"
+        if not self.quality.strip():
+            return False, "quality_missing"
         if not self.provenance.strip():
             return False, "provenance_missing"
         return True, "ok"
@@ -288,6 +292,8 @@ class DifferentialOpticalEstimator:
             raise ValueError("optical sample unit mismatch")
         if upper.shot_id != lower.shot_id:
             raise ValueError("shot mismatch")
+        if upper.diagnostic == lower.diagnostic:
+            raise ValueError("optical diagnostic identity collision")
 
         denominator = abs(upper.value) + abs(lower.value)
         if denominator <= 0:

--- a/worldshepherd_sara/fusion_control.py
+++ b/worldshepherd_sara/fusion_control.py
@@ -1,0 +1,398 @@
+"""Worldshepherd fusion-control demonstrator core.
+
+This module is intentionally simulator-only.  It contains no hardware driver,
+EPICS client, coil command path, gas command path, heating command path, or
+machine-control transport.  It is designed to exercise the Worldshepherd
+pattern:
+
+    measurement -> validation -> state estimate -> control proposal
+    -> deterministic PRIME-style gate -> audit/replay record
+
+The safety gate is deterministic and independent of the proposal generator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+import math
+import time
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class SensorSample:
+    timestamp: float
+    shot_id: str
+    diagnostic: str
+    value: float
+    unit: str
+    uncertainty: float
+    valid: bool
+    quality: str
+    provenance: str
+
+    def validate(self) -> Tuple[bool, str]:
+        if not self.valid:
+            return False, "sensor_invalid"
+        if not math.isfinite(self.timestamp):
+            return False, "timestamp_not_finite"
+        if not math.isfinite(self.value):
+            return False, "value_not_finite"
+        if not math.isfinite(self.uncertainty) or self.uncertainty < 0:
+            return False, "uncertainty_invalid"
+        if not self.diagnostic.strip():
+            return False, "diagnostic_missing"
+        if not self.provenance.strip():
+            return False, "provenance_missing"
+        return True, "ok"
+
+
+@dataclass(frozen=True)
+class PlasmaStateEstimate:
+    timestamp: float
+    shot_id: str
+    vertical_displacement_m: float
+    confidence: float
+    estimator_id: str
+    source_diagnostics: Tuple[str, ...]
+
+    def validate(self) -> Tuple[bool, str]:
+        if not math.isfinite(self.vertical_displacement_m):
+            return False, "state_not_finite"
+        if not (0.0 <= self.confidence <= 1.0):
+            return False, "confidence_out_of_range"
+        if not self.estimator_id.strip():
+            return False, "estimator_id_missing"
+        if not self.source_diagnostics:
+            return False, "source_diagnostics_missing"
+        return True, "ok"
+
+
+@dataclass(frozen=True)
+class ControlProposal:
+    timestamp: float
+    shot_id: str
+    actuator: str
+    requested_value: float
+    unit: str
+    model_id: str
+    confidence: float
+    rationale: str
+
+
+@dataclass(frozen=True)
+class SafetyEnvelope:
+    actuator: str
+    minimum: float
+    maximum: float
+    max_abs_slew_per_s: float
+    unit: str
+    minimum_confidence: float = 0.80
+
+    def validate(self) -> Tuple[bool, str]:
+        if not self.actuator.strip():
+            return False, "actuator_missing"
+        if not all(math.isfinite(v) for v in (self.minimum, self.maximum, self.max_abs_slew_per_s)):
+            return False, "envelope_not_finite"
+        if self.minimum >= self.maximum:
+            return False, "envelope_range_invalid"
+        if self.max_abs_slew_per_s <= 0:
+            return False, "slew_limit_invalid"
+        if not (0.0 <= self.minimum_confidence <= 1.0):
+            return False, "minimum_confidence_invalid"
+        return True, "ok"
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    timestamp: float
+    shot_id: str
+    actuator: str
+    accepted: bool
+    reason: str
+    requested_value: float
+    applied_value: Optional[float]
+    unit: str
+    proposal_model_id: str
+    proposal_confidence: float
+
+
+@dataclass
+class AuditRecord:
+    sequence: int
+    event: str
+    timestamp: float
+    payload: Dict[str, Any]
+    previous_hash: str
+    record_hash: str = ""
+
+    def seal(self) -> "AuditRecord":
+        material = {
+            "sequence": self.sequence,
+            "event": self.event,
+            "timestamp": self.timestamp,
+            "payload": self.payload,
+            "previous_hash": self.previous_hash,
+        }
+        encoded = json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.record_hash = hashlib.sha256(encoded).hexdigest()
+        return self
+
+
+class FusionAuditLedger:
+    """Minimal append-only, hash-chained event ledger for replay demonstrations."""
+
+    def __init__(self) -> None:
+        self._records: List[AuditRecord] = []
+
+    @property
+    def records(self) -> Sequence[AuditRecord]:
+        return tuple(self._records)
+
+    def append(self, event: str, payload: Mapping[str, Any], timestamp: Optional[float] = None) -> AuditRecord:
+        ts = time.time() if timestamp is None else float(timestamp)
+        previous_hash = self._records[-1].record_hash if self._records else "GENESIS"
+        record = AuditRecord(
+            sequence=len(self._records),
+            event=event,
+            timestamp=ts,
+            payload=dict(payload),
+            previous_hash=previous_hash,
+        ).seal()
+        self._records.append(record)
+        return record
+
+    def verify(self) -> Tuple[bool, str]:
+        previous_hash = "GENESIS"
+        for index, record in enumerate(self._records):
+            if record.sequence != index:
+                return False, f"sequence_mismatch:{index}"
+            if record.previous_hash != previous_hash:
+                return False, f"previous_hash_mismatch:{index}"
+            expected = AuditRecord(
+                sequence=record.sequence,
+                event=record.event,
+                timestamp=record.timestamp,
+                payload=dict(record.payload),
+                previous_hash=record.previous_hash,
+            ).seal().record_hash
+            if record.record_hash != expected:
+                return False, f"record_hash_mismatch:{index}"
+            previous_hash = record.record_hash
+        return True, "ok"
+
+    def to_jsonl(self) -> str:
+        return "\n".join(json.dumps(asdict(r), sort_keys=True) for r in self._records)
+
+
+class PrimeSafetyGate:
+    """Deterministic command gate for abstract virtual actuators.
+
+    The gate does not know how a proposal was generated.  It only evaluates
+    whether the proposal satisfies explicit, reviewable constraints.
+    """
+
+    def __init__(self, envelopes: Iterable[SafetyEnvelope], ledger: Optional[FusionAuditLedger] = None) -> None:
+        self.envelopes: Dict[str, SafetyEnvelope] = {}
+        for envelope in envelopes:
+            ok, reason = envelope.validate()
+            if not ok:
+                raise ValueError(f"invalid safety envelope for {envelope.actuator}: {reason}")
+            self.envelopes[envelope.actuator] = envelope
+        self.ledger = ledger or FusionAuditLedger()
+        self._last_applied: Dict[str, Tuple[float, float]] = {}
+
+    def evaluate(self, proposal: ControlProposal) -> GateDecision:
+        envelope = self.envelopes.get(proposal.actuator)
+        reason = "accepted"
+        accepted = True
+        applied_value: Optional[float] = proposal.requested_value
+
+        if envelope is None:
+            accepted = False
+            reason = "actuator_not_allowlisted"
+        elif proposal.unit != envelope.unit:
+            accepted = False
+            reason = "unit_mismatch"
+        elif not proposal.model_id.strip():
+            accepted = False
+            reason = "model_id_missing"
+        elif not math.isfinite(proposal.requested_value):
+            accepted = False
+            reason = "requested_value_not_finite"
+        elif not (0.0 <= proposal.confidence <= 1.0):
+            accepted = False
+            reason = "proposal_confidence_invalid"
+        elif proposal.confidence < envelope.minimum_confidence:
+            accepted = False
+            reason = "proposal_confidence_below_threshold"
+        elif not (envelope.minimum <= proposal.requested_value <= envelope.maximum):
+            accepted = False
+            reason = "requested_value_out_of_bounds"
+        else:
+            previous = self._last_applied.get(proposal.actuator)
+            if previous is not None:
+                previous_ts, previous_value = previous
+                dt = proposal.timestamp - previous_ts
+                if dt <= 0:
+                    accepted = False
+                    reason = "non_monotonic_command_time"
+                else:
+                    slew = abs(proposal.requested_value - previous_value) / dt
+                    if slew > envelope.max_abs_slew_per_s:
+                        accepted = False
+                        reason = "slew_limit_exceeded"
+
+        if not accepted:
+            applied_value = None
+        else:
+            self._last_applied[proposal.actuator] = (proposal.timestamp, proposal.requested_value)
+
+        decision = GateDecision(
+            timestamp=proposal.timestamp,
+            shot_id=proposal.shot_id,
+            actuator=proposal.actuator,
+            accepted=accepted,
+            reason=reason,
+            requested_value=proposal.requested_value,
+            applied_value=applied_value,
+            unit=proposal.unit,
+            proposal_model_id=proposal.model_id,
+            proposal_confidence=proposal.confidence,
+        )
+        self.ledger.append("fusion_gate_decision", asdict(decision), timestamp=proposal.timestamp)
+        return decision
+
+
+class DifferentialOpticalEstimator:
+    """Simple differential-emission estimator for simulator/replay use.
+
+    It is not a validated plasma-physics estimator.  It exists to exercise the
+    data contract, confidence handling, fallback logic, and audit trail.
+    """
+
+    def __init__(self, gain_m_per_normalized_difference: float = 0.01, estimator_id: str = "ws-optical-diff-v0.1") -> None:
+        self.gain = float(gain_m_per_normalized_difference)
+        self.estimator_id = estimator_id
+
+    def estimate(self, upper: SensorSample, lower: SensorSample) -> PlasmaStateEstimate:
+        upper_ok, upper_reason = upper.validate()
+        lower_ok, lower_reason = lower.validate()
+        if not upper_ok:
+            raise ValueError(f"upper sample invalid: {upper_reason}")
+        if not lower_ok:
+            raise ValueError(f"lower sample invalid: {lower_reason}")
+        if upper.unit != lower.unit:
+            raise ValueError("optical sample unit mismatch")
+        if upper.shot_id != lower.shot_id:
+            raise ValueError("shot mismatch")
+
+        denominator = abs(upper.value) + abs(lower.value)
+        if denominator <= 0:
+            raise ValueError("optical differential denominator is zero")
+
+        normalized_difference = (upper.value - lower.value) / denominator
+        displacement = self.gain * normalized_difference
+
+        relative_uncertainty = min(
+            1.0,
+            (upper.uncertainty + lower.uncertainty) / max(denominator, 1e-12),
+        )
+        confidence = max(0.0, min(1.0, 1.0 - relative_uncertainty))
+
+        return PlasmaStateEstimate(
+            timestamp=max(upper.timestamp, lower.timestamp),
+            shot_id=upper.shot_id,
+            vertical_displacement_m=displacement,
+            confidence=confidence,
+            estimator_id=self.estimator_id,
+            source_diagnostics=(upper.diagnostic, lower.diagnostic),
+        )
+
+
+class ProportionalVirtualActuatorController:
+    """Produces an abstract virtual-actuator proposal for simulation only."""
+
+    def __init__(
+        self,
+        actuator: str = "virtual_vertical_balance",
+        gain: float = -25.0,
+        model_id: str = "ws-p-v0.1",
+        unit: str = "arb",
+    ) -> None:
+        self.actuator = actuator
+        self.gain = float(gain)
+        self.model_id = model_id
+        self.unit = unit
+
+    def propose(self, state: PlasmaStateEstimate) -> ControlProposal:
+        ok, reason = state.validate()
+        if not ok:
+            raise ValueError(f"invalid plasma state: {reason}")
+        requested = self.gain * state.vertical_displacement_m
+        return ControlProposal(
+            timestamp=state.timestamp,
+            shot_id=state.shot_id,
+            actuator=self.actuator,
+            requested_value=requested,
+            unit=self.unit,
+            model_id=self.model_id,
+            confidence=state.confidence,
+            rationale="proportional correction of simulated vertical displacement",
+        )
+
+
+@dataclass
+class DemoResult:
+    state: PlasmaStateEstimate
+    proposal: ControlProposal
+    decision: GateDecision
+    ledger_ok: bool
+    ledger_reason: str
+
+
+def run_simulated_control_cycle(
+    upper: SensorSample,
+    lower: SensorSample,
+    *,
+    estimator: Optional[DifferentialOpticalEstimator] = None,
+    controller: Optional[ProportionalVirtualActuatorController] = None,
+    gate: Optional[PrimeSafetyGate] = None,
+) -> DemoResult:
+    ledger = gate.ledger if gate is not None else FusionAuditLedger()
+    estimator = estimator or DifferentialOpticalEstimator()
+    controller = controller or ProportionalVirtualActuatorController()
+    gate = gate or PrimeSafetyGate(
+        [
+            SafetyEnvelope(
+                actuator="virtual_vertical_balance",
+                minimum=-1.0,
+                maximum=1.0,
+                max_abs_slew_per_s=10.0,
+                unit="arb",
+                minimum_confidence=0.80,
+            )
+        ],
+        ledger=ledger,
+    )
+
+    ledger.append("fusion_sensor_sample", asdict(upper), timestamp=upper.timestamp)
+    ledger.append("fusion_sensor_sample", asdict(lower), timestamp=lower.timestamp)
+
+    state = estimator.estimate(upper, lower)
+    ledger.append("fusion_state_estimate", asdict(state), timestamp=state.timestamp)
+
+    proposal = controller.propose(state)
+    ledger.append("fusion_control_proposal", asdict(proposal), timestamp=proposal.timestamp)
+
+    decision = gate.evaluate(proposal)
+    ledger_ok, ledger_reason = ledger.verify()
+    return DemoResult(
+        state=state,
+        proposal=proposal,
+        decision=decision,
+        ledger_ok=ledger_ok,
+        ledger_reason=ledger_reason,
+    )

--- a/worldshepherd_sara/fusion_faults.py
+++ b/worldshepherd_sara/fusion_faults.py
@@ -9,7 +9,6 @@ as valid.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-import math
 from typing import Dict, Sequence, Tuple
 
 from worldshepherd_sara.fusion_control import SensorSample
@@ -22,6 +21,12 @@ FAULT_SHOT_MISMATCH = "shot_mismatch"
 FAULT_MISSING_PROVENANCE = "missing_provenance"
 FAULT_NONFINITE_VALUE = "nonfinite_value"
 FAULT_INVALID_FLAG = "invalid_sensor_flag"
+FAULT_DUPLICATE_PAIR = "duplicate_pair"
+FAULT_DELAYED_LOWER = "delayed_lower_stream"
+FAULT_REORDERED_PAIR = "reordered_pair"
+FAULT_DIAGNOSTIC_COLLISION = "diagnostic_identity_collision"
+FAULT_MISSING_UNIT = "missing_unit_metadata"
+FAULT_MISSING_QUALITY = "missing_quality_metadata"
 
 _SUPPORTED_FAULTS = {
     FAULT_DROP_LOWER,
@@ -30,6 +35,12 @@ _SUPPORTED_FAULTS = {
     FAULT_MISSING_PROVENANCE,
     FAULT_NONFINITE_VALUE,
     FAULT_INVALID_FLAG,
+    FAULT_DUPLICATE_PAIR,
+    FAULT_DELAYED_LOWER,
+    FAULT_REORDERED_PAIR,
+    FAULT_DIAGNOSTIC_COLLISION,
+    FAULT_MISSING_UNIT,
+    FAULT_MISSING_QUALITY,
 }
 
 _EXPECTED_REASON_FRAGMENT: Dict[str, str] = {
@@ -39,6 +50,12 @@ _EXPECTED_REASON_FRAGMENT: Dict[str, str] = {
     FAULT_MISSING_PROVENANCE: "provenance_missing",
     FAULT_NONFINITE_VALUE: "value_not_finite",
     FAULT_INVALID_FLAG: "sensor_invalid",
+    FAULT_DUPLICATE_PAIR: "replay_time_not_strictly_increasing",
+    FAULT_DELAYED_LOWER: "paired_timestamp_skew_exceeded",
+    FAULT_REORDERED_PAIR: "replay_time_not_strictly_increasing",
+    FAULT_DIAGNOSTIC_COLLISION: "optical diagnostic identity collision",
+    FAULT_MISSING_UNIT: "unit_missing",
+    FAULT_MISSING_QUALITY: "quality_missing",
 }
 
 
@@ -77,6 +94,23 @@ def inject_fault(
         upper[0] = replace(upper[0], value=float("nan"))
     elif fault == FAULT_INVALID_FLAG:
         upper[0] = replace(upper[0], valid=False)
+    elif fault == FAULT_DUPLICATE_PAIR:
+        upper.insert(1, upper[0])
+        lower.insert(1, lower[0])
+    elif fault == FAULT_DELAYED_LOWER:
+        index = 1 if len(lower) > 1 else 0
+        lower[index] = replace(lower[index], timestamp=lower[index].timestamp + float(skew_s))
+    elif fault == FAULT_REORDERED_PAIR:
+        if len(upper) < 2 or len(lower) < 2:
+            raise ValueError("reordered_pair_requires_at_least_two_pairs")
+        upper[0], upper[1] = upper[1], upper[0]
+        lower[0], lower[1] = lower[1], lower[0]
+    elif fault == FAULT_DIAGNOSTIC_COLLISION:
+        lower[0] = replace(lower[0], diagnostic=upper[0].diagnostic)
+    elif fault == FAULT_MISSING_UNIT:
+        upper[0] = replace(upper[0], unit="")
+    elif fault == FAULT_MISSING_QUALITY:
+        upper[0] = replace(upper[0], quality="")
 
     return tuple(upper), tuple(lower)
 
@@ -132,5 +166,11 @@ def run_standard_fault_campaign(
             FAULT_MISSING_PROVENANCE,
             FAULT_NONFINITE_VALUE,
             FAULT_INVALID_FLAG,
+            FAULT_DUPLICATE_PAIR,
+            FAULT_DELAYED_LOWER,
+            FAULT_REORDERED_PAIR,
+            FAULT_DIAGNOSTIC_COLLISION,
+            FAULT_MISSING_UNIT,
+            FAULT_MISSING_QUALITY,
         )
     )

--- a/worldshepherd_sara/fusion_faults.py
+++ b/worldshepherd_sara/fusion_faults.py
@@ -1,0 +1,136 @@
+"""Deterministic diagnostic fault injection for WS-FUSION-CTRL-001.
+
+The campaign mutates offline SensorSample fixtures only.  It has no network or
+hardware side effects.  Its purpose is to demonstrate that malformed or
+inconsistent diagnostic streams stop before a virtual command can be treated
+as valid.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import math
+from typing import Dict, Sequence, Tuple
+
+from worldshepherd_sara.fusion_control import SensorSample
+from worldshepherd_sara.fusion_replay import FusionReplayRunner
+
+
+FAULT_DROP_LOWER = "drop_lower_sample"
+FAULT_PAIR_TIME_SKEW = "pair_time_skew"
+FAULT_SHOT_MISMATCH = "shot_mismatch"
+FAULT_MISSING_PROVENANCE = "missing_provenance"
+FAULT_NONFINITE_VALUE = "nonfinite_value"
+FAULT_INVALID_FLAG = "invalid_sensor_flag"
+
+_SUPPORTED_FAULTS = {
+    FAULT_DROP_LOWER,
+    FAULT_PAIR_TIME_SKEW,
+    FAULT_SHOT_MISMATCH,
+    FAULT_MISSING_PROVENANCE,
+    FAULT_NONFINITE_VALUE,
+    FAULT_INVALID_FLAG,
+}
+
+_EXPECTED_REASON_FRAGMENT: Dict[str, str] = {
+    FAULT_DROP_LOWER: "paired_series_length_mismatch",
+    FAULT_PAIR_TIME_SKEW: "paired_timestamp_skew_exceeded",
+    FAULT_SHOT_MISMATCH: "shot_id_mismatch",
+    FAULT_MISSING_PROVENANCE: "provenance_missing",
+    FAULT_NONFINITE_VALUE: "value_not_finite",
+    FAULT_INVALID_FLAG: "sensor_invalid",
+}
+
+
+@dataclass(frozen=True)
+class FaultCampaignResult:
+    fault: str
+    safe_failure: bool
+    observed_reason: str
+    expected_reason_fragment: str
+
+
+def inject_fault(
+    upper_samples: Sequence[SensorSample],
+    lower_samples: Sequence[SensorSample],
+    fault: str,
+    *,
+    skew_s: float = 0.01,
+) -> Tuple[Tuple[SensorSample, ...], Tuple[SensorSample, ...]]:
+    if fault not in _SUPPORTED_FAULTS:
+        raise ValueError(f"unsupported_fault:{fault}")
+    if not upper_samples or not lower_samples:
+        raise ValueError("fault_campaign_requires_nonempty_paired_input")
+
+    upper = list(upper_samples)
+    lower = list(lower_samples)
+
+    if fault == FAULT_DROP_LOWER:
+        lower = lower[:-1]
+    elif fault == FAULT_PAIR_TIME_SKEW:
+        lower[0] = replace(lower[0], timestamp=lower[0].timestamp + float(skew_s))
+    elif fault == FAULT_SHOT_MISMATCH:
+        lower[0] = replace(lower[0], shot_id=f"{lower[0].shot_id}-MISMATCH")
+    elif fault == FAULT_MISSING_PROVENANCE:
+        upper[0] = replace(upper[0], provenance="")
+    elif fault == FAULT_NONFINITE_VALUE:
+        upper[0] = replace(upper[0], value=float("nan"))
+    elif fault == FAULT_INVALID_FLAG:
+        upper[0] = replace(upper[0], valid=False)
+
+    return tuple(upper), tuple(lower)
+
+
+def run_fault_case(
+    runner: FusionReplayRunner,
+    upper_samples: Sequence[SensorSample],
+    lower_samples: Sequence[SensorSample],
+    fault: str,
+    *,
+    skew_s: float = 0.01,
+) -> FaultCampaignResult:
+    expected = _EXPECTED_REASON_FRAGMENT.get(fault)
+    if expected is None:
+        raise ValueError(f"unsupported_fault:{fault}")
+
+    upper, lower = inject_fault(
+        upper_samples,
+        lower_samples,
+        fault,
+        skew_s=skew_s,
+    )
+    try:
+        runner.replay(upper, lower)
+    except ValueError as exc:
+        reason = str(exc)
+        return FaultCampaignResult(
+            fault=fault,
+            safe_failure=expected in reason,
+            observed_reason=reason,
+            expected_reason_fragment=expected,
+        )
+
+    return FaultCampaignResult(
+        fault=fault,
+        safe_failure=False,
+        observed_reason="fault_was_not_rejected",
+        expected_reason_fragment=expected,
+    )
+
+
+def run_standard_fault_campaign(
+    runner: FusionReplayRunner,
+    upper_samples: Sequence[SensorSample],
+    lower_samples: Sequence[SensorSample],
+) -> Tuple[FaultCampaignResult, ...]:
+    return tuple(
+        run_fault_case(runner, upper_samples, lower_samples, fault)
+        for fault in (
+            FAULT_DROP_LOWER,
+            FAULT_PAIR_TIME_SKEW,
+            FAULT_SHOT_MISMATCH,
+            FAULT_MISSING_PROVENANCE,
+            FAULT_NONFINITE_VALUE,
+            FAULT_INVALID_FLAG,
+        )
+    )

--- a/worldshepherd_sara/fusion_replay.py
+++ b/worldshepherd_sara/fusion_replay.py
@@ -1,0 +1,150 @@
+"""Deterministic replay engine for WS-FUSION-CTRL-001.
+
+Replay consumes already-ingested SensorSample sequences.  It does not read from
+or write to any machine-control interface.  Its job is to prove that a fixed
+input stream plus fixed estimator/controller/gate configuration yields a stable
+sequence of virtual decisions and a stable evidence fingerprint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from worldshepherd_sara.fusion_control import (
+    DemoResult,
+    DifferentialOpticalEstimator,
+    FusionAuditLedger,
+    PrimeSafetyGate,
+    ProportionalVirtualActuatorController,
+    SafetyEnvelope,
+    SensorSample,
+)
+
+
+@dataclass(frozen=True)
+class ReplayCycle:
+    index: int
+    timestamp: float
+    accepted: bool
+    reason: str
+    requested_value: float
+    applied_value: Optional[float]
+    confidence: float
+
+
+@dataclass(frozen=True)
+class ReplayReport:
+    shot_id: str
+    cycle_count: int
+    accepted_count: int
+    rejected_count: int
+    ledger_ok: bool
+    ledger_reason: str
+    fingerprint_sha256: str
+    cycles: Tuple[ReplayCycle, ...]
+
+
+def _canonical_fingerprint_payload(
+    shot_id: str,
+    cycles: Sequence[ReplayCycle],
+    ledger: FusionAuditLedger,
+) -> bytes:
+    payload = {
+        "shot_id": shot_id,
+        "cycles": [asdict(cycle) for cycle in cycles],
+        "ledger": [asdict(record) for record in ledger.records],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+
+
+class FusionReplayRunner:
+    """Replay paired diagnostic sequences through the simulator control chain."""
+
+    def __init__(
+        self,
+        *,
+        estimator: Optional[DifferentialOpticalEstimator] = None,
+        controller: Optional[ProportionalVirtualActuatorController] = None,
+        envelope: Optional[SafetyEnvelope] = None,
+        maximum_pair_time_skew_s: float = 1e-6,
+    ) -> None:
+        self.estimator = estimator or DifferentialOpticalEstimator()
+        self.controller = controller or ProportionalVirtualActuatorController()
+        self.envelope = envelope or SafetyEnvelope(
+            actuator="virtual_vertical_balance",
+            minimum=-1.0,
+            maximum=1.0,
+            max_abs_slew_per_s=10.0,
+            unit="arb",
+            minimum_confidence=0.80,
+        )
+        self.maximum_pair_time_skew_s = float(maximum_pair_time_skew_s)
+        if self.maximum_pair_time_skew_s < 0:
+            raise ValueError("maximum_pair_time_skew_s must be non-negative")
+
+    def replay(
+        self,
+        upper_samples: Sequence[SensorSample],
+        lower_samples: Sequence[SensorSample],
+    ) -> ReplayReport:
+        if len(upper_samples) != len(lower_samples):
+            raise ValueError("paired_series_length_mismatch")
+        if not upper_samples:
+            raise ValueError("paired_series_empty")
+
+        shot_id = upper_samples[0].shot_id
+        ledger = FusionAuditLedger()
+        gate = PrimeSafetyGate([self.envelope], ledger=ledger)
+        cycles: List[ReplayCycle] = []
+
+        previous_timestamp: Optional[float] = None
+        for index, (upper, lower) in enumerate(zip(upper_samples, lower_samples)):
+            if upper.shot_id != shot_id or lower.shot_id != shot_id:
+                raise ValueError(f"shot_id_mismatch:{index}")
+            if abs(upper.timestamp - lower.timestamp) > self.maximum_pair_time_skew_s:
+                raise ValueError(f"paired_timestamp_skew_exceeded:{index}")
+            cycle_timestamp = max(upper.timestamp, lower.timestamp)
+            if previous_timestamp is not None and cycle_timestamp <= previous_timestamp:
+                raise ValueError(f"replay_time_not_strictly_increasing:{index}")
+            previous_timestamp = cycle_timestamp
+
+            ledger.append("fusion_sensor_sample", asdict(upper), timestamp=upper.timestamp)
+            ledger.append("fusion_sensor_sample", asdict(lower), timestamp=lower.timestamp)
+
+            state = self.estimator.estimate(upper, lower)
+            ledger.append("fusion_state_estimate", asdict(state), timestamp=state.timestamp)
+
+            proposal = self.controller.propose(state)
+            ledger.append("fusion_control_proposal", asdict(proposal), timestamp=proposal.timestamp)
+            decision = gate.evaluate(proposal)
+
+            cycles.append(
+                ReplayCycle(
+                    index=index,
+                    timestamp=decision.timestamp,
+                    accepted=decision.accepted,
+                    reason=decision.reason,
+                    requested_value=decision.requested_value,
+                    applied_value=decision.applied_value,
+                    confidence=decision.proposal_confidence,
+                )
+            )
+
+        ledger_ok, ledger_reason = ledger.verify()
+        fingerprint = hashlib.sha256(
+            _canonical_fingerprint_payload(shot_id, cycles, ledger)
+        ).hexdigest()
+        accepted_count = sum(1 for cycle in cycles if cycle.accepted)
+        return ReplayReport(
+            shot_id=shot_id,
+            cycle_count=len(cycles),
+            accepted_count=accepted_count,
+            rejected_count=len(cycles) - accepted_count,
+            ledger_ok=ledger_ok,
+            ledger_reason=ledger_reason,
+            fingerprint_sha256=fingerprint,
+            cycles=tuple(cycles),
+        )

--- a/worldshepherd_sara/observer_authority.py
+++ b/worldshepherd_sara/observer_authority.py
@@ -1,0 +1,65 @@
+"""Authority completeness checks for external fusion-state observers.
+
+This module does not decide whether a scientific source is actually authoritative.
+It verifies that an external observer packet explicitly carries the categories of
+machine/reconstruction authority needed for independent review before the observer
+can be promoted beyond an analysis-only integration candidate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Tuple
+
+
+REQUIRED_AUTHORITY_FIELDS = (
+    "diagnostic_geometry_and_calibration",
+    "passive_structure_model",
+    "response_matrices_or_generation_method",
+    "reconstruction_settings",
+    "coordinate_conventions",
+)
+
+OPTIONAL_AUTHORITY_FIELDS = (
+    "profile_or_kinetic_constraints",
+)
+
+
+@dataclass(frozen=True)
+class ObserverAuthorityPacket:
+    device: str
+    reconstruction_family: str
+    authority_provenance: Mapping[str, str]
+    validated_by: str
+    validation_reference: str
+
+    def validate(self) -> Tuple[bool, str]:
+        if not self.device.strip():
+            return False, "device_missing"
+        if not self.reconstruction_family.strip():
+            return False, "reconstruction_family_missing"
+        if not self.validated_by.strip():
+            return False, "validated_by_missing"
+        if not self.validation_reference.strip():
+            return False, "validation_reference_missing"
+
+        for field in REQUIRED_AUTHORITY_FIELDS:
+            value = self.authority_provenance.get(field, "")
+            if not isinstance(value, str) or not value.strip():
+                return False, f"authority_missing:{field}"
+
+        return True, "ok"
+
+    @property
+    def authority_complete(self) -> bool:
+        ok, _ = self.validate()
+        return ok
+
+
+def missing_authorities(packet: ObserverAuthorityPacket) -> Tuple[str, ...]:
+    missing = []
+    for field in REQUIRED_AUTHORITY_FIELDS:
+        value = packet.authority_provenance.get(field, "")
+        if not isinstance(value, str) or not value.strip():
+            missing.append(field)
+    return tuple(missing)


### PR DESCRIPTION
## WS-FUSION-CTRL-001

Simulator-only fusion-control **assurance** demonstrator on top of `worldshepherd-sspadawanzz-admin`. This remains a draft and contains no live fusion-machine actuator path.

### Implemented
- provenance-bearing diagnostic sample contract with explicit unit/quality/provenance checks
- demonstration differential optical estimator with diagnostic-identity collision rejection
- abstract virtual-actuator controller
- independent deterministic PRIME-style safety gate
- SHA-256 hash-chained audit ledger and deterministic replay
- strict read-only FAIR-MAST adapter and bounded metadata/data probes
- non-mutating SARA `ts/event/actor/payload` audit bridge
- **twelve-case** diagnostic fault campaign
- estimator-consensus/disagreement gate
- provenance-gated external observer adapter
- external-observer authority completeness gate
- archive readiness classifier
- explicit archive-to-control admission gate
- branch-scoped CI with read-only repository permissions

### Current CI evidence
At commit `b7d0cf4de45cc5a0e7568293032203ae67813830`:
- compile gate: PASS
- targeted suite: **57 passed in 0.15s**
- Python: 3.11.16
- pinned test dependency: `pytest==9.1.1`
- workflow permissions: `contents: read`

The subsequent documentation/CI-path synchronization commits preserve the same tested code baseline; CI continues to run on every push to this branch.

### Expanded stream fault campaign
The standard offline campaign now fails safe for:
- dropped paired sample
- excessive timestamp skew
- shot mismatch
- missing provenance
- non-finite value
- explicit invalid-sensor flag
- duplicated pair
- delayed lower stream
- reordered pair
- contradictory/colliding diagnostic identity
- missing unit metadata
- missing quality metadata

Duplicate/reordered pairs are rejected by the strictly increasing replay-time invariant. One-sided delay is rejected by the pair-time-skew invariant. Metadata corruption and diagnostic-identity collision stop before a valid state estimate can be produced.

### Real FAIR-MAST evidence acquired
Pinned historical MAST source: shot `30420`, Level-1 `amc`, `s3://mast/level1/shots/30420.zarr/amc`.

A metadata-only live probe confirmed:
- Zarr v2
- `time`: `[30000]`, float32, seconds
- `plasma_current`: `[30000]`, float32, kA
- source description: `Plasma Current and PF/TF Coil Currents`
- upstream quality: `Not Checked`
- no uncertainty field observed
- metadata report SHA-256: `ffddced3a27e0b479298e5a09203ad59bba1460dd58ef43954d0e248eb416c0b`

A separate bounded real-value probe fetched and decoded only the known `time/0` and `plasma_current/0` chunks, computed hashes/statistics, then discarded the raw arrays. Raw values were not committed.

Validated probe facts:
- 30,000/30,000 finite samples for both arrays
- time strictly increasing, approximately 0.000200033 s median interval
- time chunk SHA-256 `3d1f90c80e334a581dc2185e0718c4a0c26e0dddf00d1bb8898fdca46c0f8aae`
- plasma-current chunk SHA-256 `6766652b81e6af1586222aa9f5496f61f5dcf813d810fe1e2a7f2e55025a7a64`
- 0–0.35 s paired window: 1,750 finite pairs
- paired-window SHA-256 `636d6da6e4f74e112789d239e45c177bc78bfc4feffe169ab1e244f49f1b5f75`
- data-probe report SHA-256 `4d7823c39cca64353a35aa848542fc12b6e783377242a7f4b46dca427e552489`

Permanent evidence records:
- `evidence/fair_mast/shot_30420_amc_metadata_probe_20260912.json`
- `evidence/fair_mast/shot_30420_amc_data_probe_20260912.json`

### Claims/readiness boundary
The real shot-30420 source is currently classified:
- **analysis evidence eligible: YES**
- **control evidence eligible: NO**

Control blockers are machine-enforced:
- upstream signal quality is `Not Checked`
- uncertainty metadata is unavailable
- real plasma-state estimation is not validated
- real machine control is not validated

`control_admission.py` prevents an analysis archive from being upgraded into control evidence merely by supplying ad-hoc uncertainty or flipping a JSON flag.

### Independent observer and authority strategy
No fake magnetic/equilibrium estimator has been added. `ExternalObserverAdapter` accepts a genuine external estimate only when estimator identity, method, diagnostics, provenance, quality, confidence, and source validation are explicit. `StateConsensusGate` then requires distinct estimator identities and rejects shot mismatch, low confidence, time skew, and excessive disagreement.

`observer_authority.py` separately requires explicit provenance for:
- diagnostic geometry and calibration
- passive-structure model
- response matrices or their generation method
- reconstruction settings
- coordinate conventions

Profile/kinetic constraints remain optional because they are method-dependent. The authority packet also requires explicit validator identity and validation reference. This is a **completeness check**, not scientific certification.

A public FAIR-MAST issue (#231, opened 2026-07-24) independently requests these same authority categories for reproducible MAST equilibrium reconstruction. Worldshepherd records this only as supporting evidence; it is not treated as proof that UKAEA lacks or possesses them.

Claims-controlled evidence record:
- `evidence/fair_mast/observer_authority_gap_20260912.json`

### Explicit safety boundary
No EPICS/CODAC/RTF machine-control integration, magnet driver, gas command path, heating command path, neutral-beam command, RF-heating command, or other plasma-facing actuator transport is included. The only default actuator is `virtual_vertical_balance` in arbitrary simulator units.

### External data-quality guard
FAIR-MAST issue #211 documents severe quantization in at least one Level-2 magnetics case and derivative artifacts; Level-1 raw data avoided that specific problem. The adapter therefore blocks derivative-sensitive Level-2 magnetic-looking signals by default without generalizing the issue to every Level-2 signal.

### Not validated / not claimed
- real plasma-position estimation
- real tokamak control
- confinement/stability improvement
- ELM suppression
- fusion gain or net fusion power
- propulsion from these effects
- plasma shielding

### Next gates
1. Resolve authoritative calibration/uncertainty/quality evidence for selected diagnostics rather than inventing uncertainty.
2. Resolve the required observer-authority categories against primary UKAEA/lab documentation or a qualified partner package.
3. Attach a genuine independent equilibrium/state observer through the external-observer contract and validate disagreement behavior against authoritative data.
4. Build analysis-only replay for selected real signals where the physics mapping is justified; keep control admission closed.
5. Only after those gates pass, evaluate a **non-actuating, read-only EPICS-compatible telemetry adapter**.