### PR TITLE
Add upstream OSS contribution pack for resilience, policy, and audit semantics

### DIFF
--- a/.github/workflows/oss-semantic-health.yml
+++ b/.github/workflows/oss-semantic-health.yml
@@ -1,0 +1,34 @@
+name: OSS Semantic Health Reference
+
+on:
+  pull_request:
+    paths:
+      - "tools/oss_health/**"
+      - ".github/workflows/oss-semantic-health.yml"
+  push:
+    branches:
+      - main
+      - oss-contrib-2026-09-12
+    paths:
+      - "tools/oss_health/**"
+      - ".github/workflows/oss-semantic-health.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run semantic health tests
+        working-directory: tools/oss_health
+        run: python -m unittest -v test_semantic_health.py

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -73,8 +73,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Stored *.patch files are patch payloads. Lines such as `+ ` and the
+          # standard mail-patch separator `-- ` are meaningful patch content and
+          # look like trailing whitespace to git when the patch itself is stored
+          # as a repository file. Their structure is validated in the dedicated
+          # patch-artifact step above; keep diff --check strict for everything else.
           if git rev-parse --verify origin/main >/dev/null 2>&1; then
-            git diff --check origin/main...HEAD
+            git diff --check origin/main...HEAD -- . ':(exclude,glob)**/*.patch'
           else
-            git diff --check HEAD^
+            git diff --check HEAD^ -- . ':(exclude,glob)**/*.patch'
           fi

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,0 +1,76 @@
+name: Required Test and Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - oss-contrib-2026-09-12
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-build:
+    name: test-and-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out exact source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile semantic-health reference
+        run: python -m compileall -q tools/oss_health
+
+      - name: Run semantic-health regression tests
+        working-directory: tools/oss_health
+        run: python -m unittest -v test_semantic_health.py
+
+      - name: Validate upstream patch artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d docs/oss_contributions
+          mapfile -d '' patches < <(find docs/oss_contributions -type f -name '*.patch' -print0 | sort -z)
+          if (( ${#patches[@]} < 5 )); then
+            echo "Expected at least five patch-ready artifacts; found ${#patches[@]}" >&2
+            exit 1
+          fi
+          for patch in "${patches[@]}"; do
+            test -s "$patch"
+            grep -q '^--- a/' "$patch" || {
+              echo "Missing old-file patch header in $patch" >&2
+              exit 1
+            }
+            grep -q '^+++ b/' "$patch" || {
+              echo "Missing new-file patch header in $patch" >&2
+              exit 1
+            }
+          done
+
+      - name: Reject unresolved merge-conflict markers
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -R -n -E '^(<<<<<<< |>>>>>>> )' tools/oss_health docs/oss_contributions; then
+            echo "Unresolved merge-conflict marker found" >&2
+            exit 1
+          fi
+
+      - name: Check contribution diff for whitespace errors
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify origin/main >/dev/null 2>&1; then
+            git diff --check origin/main...HEAD
+          else
+            git diff --check HEAD^
+          fi

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -39,9 +39,13 @@ jobs:
         run: |
           set -euo pipefail
           test -d docs/oss_contributions
-          mapfile -d '' patches < <(find docs/oss_contributions -type f -name '*.patch' -print0 | sort -z)
+          test -d docs/oss/patches
+          mapfile -d '' patches < <(
+            find docs/oss_contributions docs/oss/patches \
+              -type f -name '*.patch' -print0 | sort -z
+          )
           if (( ${#patches[@]} < 5 )); then
-            echo "Expected at least five patch-ready artifacts; found ${#patches[@]}" >&2
+            echo "Expected at least five patch-ready artifacts across OSS patch directories; found ${#patches[@]}" >&2
             exit 1
           fi
           for patch in "${patches[@]}"; do
@@ -60,7 +64,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if grep -R -n -E '^(<<<<<<< |>>>>>>> )' tools/oss_health docs/oss_contributions; then
+          if grep -R -n -E '^(<<<<<<< |>>>>>>> )' tools/oss_health docs/oss_contributions docs/oss/patches; then
             echo "Unresolved merge-conflict marker found" >&2
             exit 1
           fi

--- a/docs/oss/CHAINLOOP_3436_COMPATIBILITY_NOTE.md
+++ b/docs/oss/CHAINLOOP_3436_COMPATIBILITY_NOTE.md
@@ -1,0 +1,60 @@
+# Chainloop #3436 compatibility note for fan-out resiliency
+
+Upstream inputs:
+
+- `chainloop-dev/chainloop#39` — durable/resilient integration fan-out problem
+- merged `chainloop-dev/chainloop#3436` — adjudication outcome fields in `ai-security-context-0.1`
+
+Claims state: **DESIGN ALIGNMENT / NOT UPSTREAM ACCEPTED**
+
+## Upstream change
+
+PR #3436 adds optional fields that describe adjudication outcomes:
+
+- `unresolved[].retryable`
+- `survivors[].verdict`
+- `survivors[].verdict_reason`
+- `stats.abandoned`
+
+These fields belong to the source evidence/adjudication model. A durable fan-out system should preserve them when present instead of creating competing outcome semantics.
+
+## Required separation
+
+Two independent questions must remain visible:
+
+1. **Evidence/adjudication outcome** — what the source artifact says about the commit or item.
+2. **Delivery outcome** — whether the integration fan-out successfully delivered that artifact.
+
+For example, a source item can have `retryable=false` while a network delivery is still retried because the target was temporarily unavailable. Retrying transport must not re-adjudicate or rewrite the source evidence.
+
+## Recommended durable receipt projection
+
+A delivery receipt may expose a bounded projection for operations/search while retaining the source digest as authority:
+
+```text
+source_schema                  ai-security-context-0.1
+source_digest                  sha256:...
+adjudication.retryable         bool/null
+adjudication.verdict           string/null
+adjudication.verdict_reason    string/null
+adjudication.abandoned_count   integer/null
+```
+
+Rules:
+
+- the signed/content-addressed source artifact remains authoritative;
+- projected values must exactly match the source identified by `source_digest`;
+- transport retry/dead-letter state never rewrites source verdict fields;
+- replay of a delivery never mutates the original adjudication record;
+- free-form verdict reasons should not be metric labels.
+
+## Additional test invariants
+
+Add these to the #39 proposal validation set:
+
+1. **Semantic separation:** source retryability and delivery retryability remain independently queryable.
+2. **Projection fidelity:** receipt projection equals the source artifact for the same digest.
+3. **Replay immutability:** re-delivery does not modify adjudication fields.
+4. **Backward compatibility:** artifacts without the new optional fields continue through the fan-out path unchanged.
+
+This note supplements `CHAINLOOP_FANOUT_RESILIENCY_PROPOSAL.md`; it does not claim that #3436 implements delivery resiliency or that #39 has accepted this design.

--- a/docs/oss/CHAINLOOP_FANOUT_RESILIENCY_PROPOSAL.md
+++ b/docs/oss/CHAINLOOP_FANOUT_RESILIENCY_PROPOSAL.md
@@ -1,0 +1,175 @@
+# Chainloop fan-out resiliency proposal
+
+Upstream target: `chainloop-dev/chainloop#39`
+
+## Problem
+
+Integration fan-out that is launched from an in-process goroutine has no durable delivery guarantee. A process restart can lose work, operators lack an authoritative receipt, and historical attestations cannot be replayed cleanly.
+
+The objective should be **durable at-least-once dispatch with deterministic idempotency and an auditable delivery ledger**. The queue/broker is transport; it should not become the sole source of truth.
+
+## Proposed architecture
+
+### 1. Persist fan-out intent
+
+When an attestation reaches the state at which integrations should fire, create an outbox record in the same logical commit boundary.
+
+Suggested fields:
+
+```text
+id                    UUID
+idempotency_key       string UNIQUE
+attestation_id        UUID
+integration_id        UUID
+event_kind            string
+payload_digest        string
+payload_ref           string/null
+state                 enum
+attempt_count         integer
+next_attempt_at       timestamp/null
+last_attempt_at       timestamp/null
+acked_at               timestamp/null
+last_error_class      string/null
+last_error_message    string/null
+replay_of             UUID/null
+requested_by          string/null
+request_reason        string/null
+created_at            timestamp
+updated_at            timestamp
+```
+
+Recommended deterministic idempotency key:
+
+```text
+sha256(attestation_id || integration_id || event_kind || payload_digest)
+```
+
+Retries use the same key. An explicit replay can either reuse the original key when the intended semantic is retry, or create a new delivery identity with `replay_of=<original id>` when the operator is intentionally reissuing the event.
+
+### 2. Explicit state machine
+
+```text
+PENDING
+  -> DISPATCHED
+      -> ACKED
+      -> RETRY_WAIT
+      -> DEAD_LETTER
+  -> CANCELLED
+
+RETRY_WAIT
+  -> DISPATCHED
+  -> DEAD_LETTER
+
+DEAD_LETTER
+  -> PENDING      (operator-approved replay/requeue)
+```
+
+State transitions should be compare-and-set/transactional so two workers cannot own the same delivery simultaneously without a lease expiring.
+
+### 3. Queue transport
+
+JetStream is a reasonable transport for the issue, but delivery correctness should not depend on JetStream retaining history indefinitely.
+
+Recommended flow:
+
+```text
+Attestation commit
+      |
+      v
+Persistent outbox
+      |
+      v
+Publisher -> JetStream subject
+      |
+      v
+Worker -> integration adapter
+      |
+      +--> durable target success -> ACKED
+      +--> retryable error        -> RETRY_WAIT
+      +--> terminal error         -> DEAD_LETTER
+```
+
+The worker should acknowledge the broker message only after the outbox transition is durable.
+
+### 4. Error taxonomy
+
+Adapters should normalize errors into a small transport-independent taxonomy:
+
+```text
+AUTHENTICATION_FAILED   terminal until configuration changes
+AUTHORIZATION_FAILED    terminal until configuration changes
+PAYLOAD_INVALID         terminal
+TARGET_NOT_FOUND        policy-dependent
+RATE_LIMITED            retryable; honor Retry-After when present
+TARGET_UNAVAILABLE      retryable
+TIMEOUT                 retryable
+CONNECTION_ERROR        retryable
+CONFLICT                adapter-specific; may represent idempotent success
+UNKNOWN                 retry with bounded policy, then dead-letter
+```
+
+This prevents every integration from inventing its own retry semantics.
+
+### 5. Replay semantics
+
+Replay should be an API/operator capability rather than an undocumented queue operation.
+
+A replay request should record:
+
+- original delivery ID;
+- requesting principal;
+- reason;
+- request timestamp;
+- whether the replay preserves or creates a new idempotency identity.
+
+The original attestation remains immutable.
+
+### 6. Observability
+
+Recommended metrics:
+
+```text
+chainloop.integration.delivery.pending
+chainloop.integration.delivery.acked
+chainloop.integration.delivery.retry
+chainloop.integration.delivery.dead_letter
+chainloop.integration.delivery.age
+chainloop.integration.delivery.attempts
+chainloop.integration.delivery.latency
+```
+
+Dimensions should stay bounded: integration type/name, result class, event kind. Avoid attestation IDs as metric labels.
+
+## Safety properties / testable invariants
+
+1. **No lost intent after commit:** once the attestation and outbox record are committed, killing the process at any later instruction boundary cannot erase the intended fan-out.
+2. **Retry stability:** retrying a delivery does not change its deterministic idempotency key.
+3. **Crash-after-effect safety:** if the target side effect succeeds and the worker crashes before local ACK, the retry is safe at an idempotent receiver.
+4. **Audit completeness:** every terminal state can be explained from persisted state without depending on ephemeral logs.
+5. **Replay immutability:** replay never modifies the original attestation or original delivery record.
+6. **Bounded failure:** a permanently failing integration cannot create an infinite hot retry loop.
+7. **Worker concurrency:** two workers cannot simultaneously advance the same delivery unless a lease expires and takeover is explicit.
+
+## Suggested implementation sequence
+
+### Phase A — semantics first
+
+- outbox model and migration;
+- state transitions;
+- replay/requeue API;
+- adapter error taxonomy;
+- unit/property tests around crash boundaries and idempotency.
+
+### Phase B — broker execution
+
+- JetStream publisher;
+- consumer workers;
+- leases/visibility timeout;
+- retry scheduling and dead-letter policy;
+- operational metrics.
+
+Separating the two phases makes the delivery contract independently testable from the message-broker choice.
+
+## Compatibility
+
+Existing integrations can initially be wrapped as adapters behind the new dispatcher. The public attestation contract need not change. A feature flag can permit gradual rollout while old goroutine dispatch remains available during migration.

--- a/docs/oss/OPA_AGENT_POLICY_ENVELOPE.md
+++ b/docs/oss/OPA_AGENT_POLICY_ENVELOPE.md
@@ -1,0 +1,181 @@
+# OPA AI-agent policy decision envelope
+
+Upstream target: `open-policy-agent/opa#8851`
+
+## Purpose
+
+A first-party AI-agent policy guide will be most reusable if it separates:
+
+- **PDP** — Open Policy Agent evaluates policy and returns a decision;
+- **PEP** — the agent runtime/executor enforces that decision;
+- **evidence/audit layer** — records the request, policy revision, decision, approval path, and resulting action outcome.
+
+OPA should remain the policy decision point. The runtime should not assume that an `allow` result itself performs or authorizes an external side effect.
+
+## Minimal input envelope
+
+```json
+{
+  "request_id": "01J...",
+  "actor": {
+    "id": "agent:planner-7",
+    "type": "ai_agent",
+    "tenant": "example"
+  },
+  "action": {
+    "name": "tool.execute",
+    "tool": "payments.transfer",
+    "operation": "create",
+    "resource": "account:destination",
+    "parameters": {
+      "amount": 125.00,
+      "currency": "USD"
+    }
+  },
+  "context": {
+    "environment": "production",
+    "mission_id": "mission-123",
+    "session_id": "session-456",
+    "human_present": true,
+    "network_state": "nominal"
+  },
+  "provenance": {
+    "model_id": "model-name-or-digest",
+    "agent_version": "git-or-build-digest",
+    "tool_schema_version": "v1"
+  }
+}
+```
+
+The input should describe the proposed effect, not an implementation-specific callback.
+
+## Structured decision envelope
+
+Instead of reducing every result to a boolean, the guide can recommend a small structured result:
+
+```json
+{
+  "decision": "escalate",
+  "reason": "human approval required above configured transfer threshold",
+  "decision_id": "dec-01J...",
+  "policy": {
+    "package": "agent.authz",
+    "revision": "sha256:..."
+  },
+  "requirements": {
+    "human_approval": true,
+    "mfa": false
+  },
+  "constraints": {
+    "max_amount": 100.00
+  },
+  "audit": {
+    "severity": "medium",
+    "retain": true
+  }
+}
+```
+
+Suggested decision vocabulary:
+
+```text
+allow
+ deny
+ escalate
+ audit_only
+```
+
+`escalate` is important because many agentic actions should not be represented as simply allowed or denied when a human approval path exists.
+
+## Enforcement contract
+
+A useful guide-level invariant is:
+
+> The executor MUST NOT perform the proposed side effect unless the current policy decision permits it and all returned requirements are satisfied.
+
+The PEP should bind the enforced action to the evaluated action. If the tool arguments change after policy evaluation, the runtime should re-evaluate rather than treating the old decision as valid.
+
+A simple binding can be represented with an action digest:
+
+```text
+action_digest = sha256(canonical_json(action))
+```
+
+The audit record then includes the same digest for the proposal and the executed action.
+
+## Example Rego
+
+```rego
+package agent.authz
+
+import rego.v1
+
+default decision := {
+  "decision": "deny",
+  "reason": "no matching allow rule",
+  "requirements": {},
+  "constraints": {},
+}
+
+decision := {
+  "decision": "allow",
+  "reason": "read-only tool permitted",
+  "requirements": {},
+  "constraints": {},
+} if {
+  input.action.operation == "read"
+}
+
+decision := {
+  "decision": "escalate",
+  "reason": "human approval required for production write",
+  "requirements": {"human_approval": true},
+  "constraints": {},
+} if {
+  input.context.environment == "production"
+  input.action.operation in {"create", "update", "delete"}
+}
+```
+
+This example deliberately keeps enforcement outside OPA.
+
+## Audit fields worth showing in the guide
+
+```text
+request_id
+decision_id
+actor.id
+action.name
+action.tool
+action.operation
+action_digest
+policy.package
+policy.revision
+decision
+reason
+requirements_satisfied
+approval_id
+execution_result
+execution_timestamp
+```
+
+These fields allow an operator to answer four distinct questions:
+
+1. What did the agent propose?
+2. Which policy version evaluated it?
+3. What did the policy decide and require?
+4. What was actually executed?
+
+## Test cases the guide should include
+
+- ordinary allow;
+- ordinary deny;
+- escalation requiring human approval;
+- changed tool arguments after evaluation causing re-evaluation;
+- policy bundle revision changing between two otherwise identical requests;
+- malformed or missing context failing closed for sensitive operations;
+- audit-only rule that records but does not block an action.
+
+## Scope boundary
+
+This proposal does not require OPA to become an executor, token issuer, workflow engine, or provenance database. It only gives the proposed guide a stable contract between the agent runtime and OPA and makes policy decisions auditable and enforceable by the surrounding runtime.

--- a/docs/oss/OTEL_AUDIT_EVENT_SEMCONV_PROPOSAL.md
+++ b/docs/oss/OTEL_AUDIT_EVENT_SEMCONV_PROPOSAL.md
@@ -1,0 +1,144 @@
+# OpenTelemetry audit-event semantic proposal
+
+Upstream target: `open-telemetry/semantic-conventions#2468`
+
+## Goal
+
+Define the smallest reusable audit-event envelope needed to correlate security-relevant events across access control, configuration changes, backup/restore, autonomous workflows, and other domain-specific events without replacing the domain semantic conventions that describe the underlying operation.
+
+The core idea is:
+
+> domain conventions describe **what happened**; a small audit envelope describes **why this event is security/audit relevant, who initiated it, and what the outcome was**.
+
+This avoids creating a parallel audit namespace containing copies of HTTP, RPC, messaging, configuration, or application attributes.
+
+## Proposed minimal attributes
+
+Names below are a design proposal, not a claim of accepted OpenTelemetry naming.
+
+```text
+audit.event.id          string   Stable identifier for this audit record.
+audit.category          enum     Broad audit classification.
+audit.action            string   Human/machine-readable action identifier.
+audit.outcome           enum     success | failure | unknown
+audit.reason            string   Optional concise reason/result detail.
+audit.initiator.type    enum     user | service | workload | device | ai_agent | unknown
+audit.initiator.id      string   Identifier for the initiating principal when appropriate.
+audit.target.type       string   Optional target/resource type.
+audit.target.id         string   Optional target/resource identifier.
+audit.policy.id         string   Optional policy identifier involved in the decision.
+audit.policy.decision   enum     allow | deny | escalate | audit_only | unknown
+audit.approval.id       string   Optional human/workflow approval correlation identifier.
+```
+
+Suggested audit categories aligned with IEC 62443-style needs while remaining general:
+
+```text
+access_control
+request_error
+control_system
+backup_restore
+configuration_change
+audit_system
+```
+
+Projects can add or use domain-specific categories through the normal semantic-convention process rather than turning the base list into an exhaustive ontology.
+
+## Reuse existing semantic conventions
+
+The audit envelope should reuse existing attributes for the operation itself wherever available:
+
+- identity/authentication attributes for authenticated users and services;
+- HTTP/RPC/messaging attributes for request failures;
+- device/resource attributes for hardware or edge components;
+- `error.type` and related error conventions for failures;
+- deployment/service/resource attributes for software components;
+- workflow/job/task conventions if/when standardized.
+
+Example: a denied HTTP configuration request should remain an HTTP event/span/log with ordinary HTTP and error attributes. The audit envelope only adds the security/audit classification, initiator/target correlation, policy decision, and audit event identity.
+
+## Event vs. resource identity
+
+`audit.event.id` should identify the audit record, not the monitored resource. Resource identity remains in standard resource attributes. This prevents overloaded fields such as `audit.source` from ambiguously meaning device, process, principal, service, or emitter.
+
+## Privacy and cardinality guidance
+
+Audit conventions must not imply that sensitive data should be emitted by default.
+
+Recommended guidance:
+
+- do not place secrets, tokens, raw credentials, or full tool/request payloads in audit attributes;
+- use stable opaque identifiers rather than email addresses or usernames where possible;
+- keep high-cardinality IDs out of metrics; audit IDs are appropriate for logs/events/traces;
+- `audit.reason` should be concise and sanitized because error strings can contain sensitive information;
+- payload evidence should be stored externally and referenced by digest/ID when necessary.
+
+## Example — policy-gated configuration change
+
+```text
+Event name: config.change
+
+service.name = "controller"
+config.key = "telemetry.sample_rate"
+config.previous_value = "0.1"
+config.new_value = "0.2"
+
+audit.event.id = "01J..."
+audit.category = "configuration_change"
+audit.action = "config.update"
+audit.outcome = "success"
+audit.initiator.type = "user"
+audit.initiator.id = "principal-42"
+audit.target.type = "service_configuration"
+audit.target.id = "controller/default"
+audit.policy.id = "prod-change-policy"
+audit.policy.decision = "allow"
+audit.approval.id = "approval-734"
+```
+
+The domain-specific configuration attributes stay outside the audit envelope.
+
+## Example — autonomous action escalated to a human
+
+```text
+Event name: workflow.action.decision
+
+audit.event.id = "01J..."
+audit.category = "control_system"
+audit.action = "tool.execute"
+audit.outcome = "success"
+audit.initiator.type = "ai_agent"
+audit.initiator.id = "planner-7"
+audit.target.type = "tool"
+audit.target.id = "vehicle.route.update"
+audit.policy.id = "mission-safety-v4"
+audit.policy.decision = "escalate"
+audit.approval.id = "approval-91"
+```
+
+Here `audit.outcome=success` means the audited decision/approval flow completed successfully. The eventual tool execution result should be represented by the domain event that records execution.
+
+## Why not one broad `audit.source` field?
+
+`source` becomes ambiguous across distributed systems. The emitter, initiator, device, service, process, and network peer can all be different entities. Existing resource/entity semantics should identify the emitter and system components. The audit envelope should explicitly identify the **initiating principal** and optional **target** instead.
+
+## Interoperability invariant
+
+A consumer that only understands the audit envelope should be able to answer:
+
+1. What audit category is this?
+2. Who or what initiated it?
+3. What action was attempted?
+4. What resource was targeted?
+5. What was the outcome?
+6. Did a policy decision or approval govern it?
+
+A consumer that understands the domain conventions should additionally be able to reconstruct the operation-specific details without any duplicated audit-specific schema.
+
+## Suggested path upstream
+
+1. Agree on the envelope concept and field semantics before final names.
+2. Prototype against at least two different domains, e.g. access control and configuration change.
+3. Validate privacy/cardinality guidance with the existing security and logging discussions.
+4. Add category-specific examples without moving domain attributes into the audit namespace.
+5. Keep the initial convention intentionally small and extend only where multiple domains demonstrate the same need.

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -1,26 +1,52 @@
 # Worldshepherd upstream contribution pack — 2026-09-12
 
-This directory contains contribution-ready technical proposals derived from Worldshepherd's implemented governance, audit, provenance, and bounded-automation patterns.
+This directory contains contribution-ready technical proposals derived from Worldshepherd's implemented governance, audit, provenance, semantic-health, and bounded-automation patterns.
 
 The artifacts are intentionally scoped to existing upstream issues rather than framed as replacement architectures.
 
-## Targets
+## Active targets
 
-1. **Chainloop** — durable integration fan-out / replay semantics for chainloop-dev/chainloop#39.
-2. **Open Policy Agent** — minimal policy decision envelope and PDP/PEP boundary for open-policy-agent/opa#8851.
-3. **OpenTelemetry Semantic Conventions** — narrow interoperable audit-event envelope for open-telemetry/semantic-conventions#2468.
+1. **Open-RMF** — per-robot failure containment (#553) and Python GIL/concurrency liveness (#549).
+2. **Eclipse Zenoh** — accept-path semantic health (#2780), silent-peer forwarding isolation (#2718), and metadata-only storage queries (#2783).
+3. **Chainloop** — durable integration fan-out/replay semantics (#39), with compatibility guidance for merged adjudication fields from #3436.
+4. **Keylime** — attestation truthfulness, cumulative failure history, and verifier cadence semantics (#1932/#1909/#1941).
+5. **Sigstore/Cosign** — publication atomicity and source/target registry policy separation (#5035/#5037).
+6. **Gazebo** — bounded observability and deterministic simulation qualification.
+7. **Open Policy Agent** — minimal agent-runtime policy decision envelope and explicit PDP/PEP boundary (#8851).
+8. **OpenTelemetry Semantic Conventions** — narrow interoperable audit-event envelope (#2468).
+
+## Upstream-resolved lane
+
+Eclipse Zenoh PR #2779 has merged an upstream fix for the peer-churn `StartConditions`/`ctrl_lock` deadlock related to #2637. Worldshepherd should retain any reproducer as validation evidence and monitor downstream adoption rather than submit a competing patch for that same root cause.
+
+## Key artifacts
+
+- `UPSTREAM_CONTRIBUTION_QUEUE.md` — current priority/status ledger.
+- `CHAINLOOP_FANOUT_RESILIENCY_PROPOSAL.md` — durable fan-out design.
+- `CHAINLOOP_3436_COMPATIBILITY_NOTE.md` — preservation of new adjudication outcome fields.
+- `OPA_AGENT_POLICY_ENVELOPE.md` — bounded agent policy contract.
+- `OTEL_AUDIT_EVENT_SEMCONV_PROPOSAL.md` — audit semantic-convention proposal.
+- `ZENOH_2783_METADATA_ONLY_PROPOSAL.md` — backend-independent metadata-only storage-query contract.
+- `patches/open-rmf-553-prevalidate-charger.patch` — Open-RMF #553 patch draft.
+- `patches/zenoh-2780-incoming-permit.patch` — Zenoh #2780 hardening draft.
+
+Additional patch/test artifacts live under `docs/oss_contributions/` and `external_anchor_pilots/`.
 
 ## Claims boundary
 
-These documents are design contributions. They do not claim upstream acceptance, conformance certification, production deployment in the upstream projects, or successful merge. Where Worldshepherd behavior is referenced, it is limited to software patterns already implemented or locally validated in Sara_pro.
+These documents include design contributions, test plans, and patch drafts. They do not claim upstream acceptance, conformance certification, production deployment in the upstream projects, or successful merge unless the referenced upstream repository itself shows that state.
+
+Where Worldshepherd behavior is referenced, it is limited to software patterns already implemented or locally validated in `Sara_pro`. Patch drafts that require ROS 2, Zenoh stress infrastructure, hardware, or other unavailable upstream-specific environments remain explicitly labeled as requiring external validation.
 
 ## Contribution rule
 
-Each proposal must provide:
+Each proposal should provide:
 
 - a narrowly defined problem;
 - explicit state semantics;
 - failure and recovery behavior;
 - deterministic evidence/audit fields;
 - testable invariants;
-- a migration path that preserves existing behavior where practical.
+- a migration/compatibility path;
+- an explicit claims state;
+- a reason not to duplicate an already-merged upstream solution.

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -1,0 +1,26 @@
+# Worldshepherd upstream contribution pack — 2026-09-12
+
+This directory contains contribution-ready technical proposals derived from Worldshepherd's implemented governance, audit, provenance, and bounded-automation patterns.
+
+The artifacts are intentionally scoped to existing upstream issues rather than framed as replacement architectures.
+
+## Targets
+
+1. **Chainloop** — durable integration fan-out / replay semantics for chainloop-dev/chainloop#39.
+2. **Open Policy Agent** — minimal policy decision envelope and PDP/PEP boundary for open-policy-agent/opa#8851.
+3. **OpenTelemetry Semantic Conventions** — narrow interoperable audit-event envelope for open-telemetry/semantic-conventions#2468.
+
+## Claims boundary
+
+These documents are design contributions. They do not claim upstream acceptance, conformance certification, production deployment in the upstream projects, or successful merge. Where Worldshepherd behavior is referenced, it is limited to software patterns already implemented or locally validated in Sara_pro.
+
+## Contribution rule
+
+Each proposal must provide:
+
+- a narrowly defined problem;
+- explicit state semantics;
+- failure and recovery behavior;
+- deterministic evidence/audit fields;
+- testable invariants;
+- a migration path that preserves existing behavior where practical.

--- a/docs/oss/UPSTREAM_CONTRIBUTION_QUEUE.md
+++ b/docs/oss/UPSTREAM_CONTRIBUTION_QUEUE.md
@@ -1,0 +1,198 @@
+# Live upstream contribution queue — 2026-09-12
+
+This queue converts the open-source screen into bounded engineering work. Priority is based on Worldshepherd fit, reproducibility, upstream usefulness, blast-radius reduction, and ability to prove improvement with tests.
+
+## P0 — Open-RMF: isolate per-robot failures from fleet health
+
+### Issue open-rmf/rmf_ros2#553
+
+`add_robot()` can throw from an asynchronous participant callback when no charger is reachable. The exception can terminate the fleet adapter process even though the failure is specific to one robot.
+
+**Worldshepherd contribution:** failure containment + semantic health reporting.
+
+Proposed acceptance criteria:
+
+- a robot with no reachable charger is rejected/faulted without terminating the adapter;
+- healthy robots continue to register and operate;
+- the caller receives a structured/catchable failure signal where practical;
+- async callback boundaries do not allow recoverable per-robot exceptions to escape to `std::terminate`;
+- tests include at least two robots so blast-radius isolation is proven rather than inferred;
+- health output distinguishes `process_alive` from `fleet_operational`.
+
+Suggested test matrix:
+
+```text
+robot A reachable charger, robot B unreachable charger -> adapter survives; A registered; B faulted
+both reachable -> both registered
+no charging waypoint exists anywhere -> deterministic error, no process abort
+callback invoked after fleet weak_ptr expired -> safe return
+```
+
+### Issue open-rmf/rmf_ros2#549
+
+Python bindings can retain the GIL during blocking RMF calls, creating a fleet-wide deadlock when worker callbacks simultaneously need Python.
+
+**Worldshepherd contribution:** concurrency boundary audit + liveness regression test.
+
+Acceptance criteria:
+
+- binding calls that may block on RMF internals release the GIL;
+- Python callbacks reacquire the GIL only for Python execution;
+- stress test runs concurrent `replan()`/issue creation and callback traffic for a bounded interval with a watchdog;
+- watchdog proves telemetry timestamps continue advancing, not merely that the process PID is alive.
+
+## P0 — Eclipse Zenoh: semantic transport health under DDIL/reconnect stress
+
+### Issue eclipse-zenoh/zenoh#2780
+
+Router can remain alive with listeners present while silently ceasing to accept new sessions.
+
+**Worldshepherd contribution:** accept-path accounting invariants + externally observable semantic readiness.
+
+Acceptance criteria:
+
+- `incoming`/pending-accept accounting cannot leak after cancellation, timeout, task abort, or panic;
+- rejection due to `accept_pending` saturation is visible above trace-only logging;
+- stress test repeatedly restarts router and rapidly connects/disconnects sessions;
+- readiness probe performs an actual short connection/round trip rather than checking PID/listen socket only;
+- test fails if kernel backlog grows while no application accept progress occurs.
+
+Useful invariant:
+
+```text
+accepted_links_started - accepted_links_finished == current_incoming_counter
+```
+
+The invariant should hold after every spawned accept task completes, times out, is cancelled, or is aborted.
+
+### Issue eclipse-zenoh/zenoh#2718
+
+A silently dead peer can cause roughly ten seconds of forwarding interruption between otherwise healthy peers during lease-expiry teardown.
+
+**Worldshepherd contribution:** failure-isolation benchmark.
+
+Acceptance criteria:
+
+- three-router minimum harness with A<->B traffic while C is blackholed without FIN;
+- measure forwarding gap distribution across repeated runs;
+- graceful shutdown is retained as a null/control case;
+- link teardown must not hold a global/shared forwarding critical section across blocking close/flush work;
+- regression threshold should be expressed in relation to normal forwarding cadence, not only an absolute wall-clock value.
+
+## P1 — Keylime: attestation truthfulness and history
+
+### keylime/keylime#1932
+
+Warn when a non-empty measured-boot reference state is supplied but `accept-all` means it is not enforced.
+
+Contribution shape:
+
+- explicit runtime warning at policy assignment/first evaluation;
+- audit field exposing effective measured-boot policy mode;
+- test proving warning occurs once and does not flood per quote.
+
+### keylime/keylime#1909
+
+Add cumulative attestation failure history.
+
+Contribution shape:
+
+- persistent `total_attestation_failures` counter;
+- migration + API exposure;
+- invariants: success resets consecutive failures but never total failures; failed verification increments total exactly once.
+
+### keylime/keylime#1941
+
+Inconsistent push attestation fallback intervals can silently change cadence.
+
+Contribution shape:
+
+- one authoritative fallback definition;
+- explicit degraded-cadence telemetry when fallback is used;
+- tests for malformed/missing verifier interval response.
+
+## P1 — Sigstore/Cosign: provenance publication failure semantics
+
+### sigstore/cosign#5035
+
+Define atomicity/rollback semantics across OCI artifact publication.
+
+**Worldshepherd contribution:** phase ledger and partial-success evidence.
+
+Candidate publication phases:
+
+```text
+VALIDATED
+BLOBS_UPLOADED
+ARTIFACT_MANIFEST_COMMITTED
+DISCOVERY_INDEX_UPDATED
+COMPLETE
+```
+
+On failure, return the original cause plus the highest durable commit point. Never imply rollback of shared content-addressed blobs unless exclusivity is proven.
+
+### sigstore/cosign#5037
+
+Separate source and target registry policies when `COSIGN_REPOSITORY` redirects artifacts.
+
+**Worldshepherd contribution:** policy-domain separation tests.
+
+Acceptance criteria:
+
+- credentials/clients/TLS policy never cross source->target boundary implicitly;
+- same canonical repository can preserve compatibility;
+- same host but different repository is treated as a separate policy boundary unless explicitly configured;
+- 401/403/TLS/timeout causes remain distinguishable.
+
+## P1 — Gazebo: make simulation a qualification/evidence engine
+
+### gazebosim/gz-sim#3891
+
+A failed integration test can emit gigabytes of repeated logs.
+
+Contribution shape:
+
+- rate-limit/deduplicate repeated terminal server-error logging;
+- fail test promptly when required remote model cannot be resolved;
+- assert bounded log volume in the regression test.
+
+### gazebosim/gz-sim#3881 and #3941
+
+Flaky communications/noise tests are useful candidates for deterministic statistical test design.
+
+Contribution shape:
+
+- fixed/recorded seeds where deterministic behavior is required;
+- statistically valid tolerances when randomness is part of the feature;
+- repeated-run CI helper that records failure rate and confidence bounds.
+
+## P2 — OpenTelemetry Semantic Conventions
+
+See `OTEL_AUDIT_EVENT_SEMCONV_PROPOSAL.md`.
+
+Primary objective is a narrow audit envelope that composes with domain semantic conventions rather than reproducing them.
+
+## P2 — Open Policy Agent
+
+See `OPA_AGENT_POLICY_ENVELOPE.md`.
+
+Primary objective is an agent-runtime guide with a structured decision contract and explicit PDP/PEP boundary.
+
+## P2 — Chainloop
+
+See `CHAINLOOP_FANOUT_RESILIENCY_PROPOSAL.md`.
+
+Primary objective is a durable, replayable, inspectable integration-delivery contract before broker-specific implementation.
+
+## Definition of an upstream-ready Worldshepherd contribution
+
+A contribution does not move from `CANDIDATE` to `UPSTREAM_READY` until it has:
+
+1. a live upstream issue or maintainer-confirmed need;
+2. a minimal reproducible case or explicit design gap;
+3. a bounded patch surface;
+4. tests that prove the claimed improvement;
+5. failure/recovery semantics;
+6. compatibility analysis;
+7. claims labeling that distinguishes local validation from upstream acceptance;
+8. no dependence on Worldshepherd-specific branding in the upstream interface unless maintainers explicitly want it.

--- a/docs/oss/UPSTREAM_CONTRIBUTION_QUEUE.md
+++ b/docs/oss/UPSTREAM_CONTRIBUTION_QUEUE.md
@@ -2,6 +2,12 @@
 
 This queue converts the open-source screen into bounded engineering work. Priority is based on Worldshepherd fit, reproducibility, upstream usefulness, blast-radius reduction, and ability to prove improvement with tests.
 
+## Current scan delta
+
+- **Eclipse Zenoh PR #2779 — MERGED / upstream-resolved lane.** The `StartConditions`/`ctrl_lock` peer-churn deadlock has an accepted upstream fix on `main`. Any Worldshepherd work aimed at the same #2637/#2779 root cause should be retained only as validation evidence, not submitted as a competing implementation. This does **not** supersede #2780 or #2718, which are distinct failure modes.
+- **Eclipse Zenoh #2783 — NEW HIGH-FIT CANDIDATE.** Metadata-only storage queries would allow freshness, HLC timestamp, existence, and payload-size inspection without transferring large images/point clouds. Contribution target: backend-independent metadata contract plus compatibility/regression tests.
+- **Chainloop PR #3436 — MERGED / compatibility input.** The `ai-security-context-0.1` model now carries `unresolved[].retryable`, `survivors[].verdict`, `survivors[].verdict_reason`, and `stats.abandoned`. The #39 durable fan-out proposal should preserve these adjudication outcomes when they are present rather than inventing parallel outcome semantics.
+
 ## P0 — Open-RMF: isolate per-robot failures from fleet health
 
 ### Issue open-rmf/rmf_ros2#553
@@ -9,6 +15,8 @@ This queue converts the open-source screen into bounded engineering work. Priori
 `add_robot()` can throw from an asynchronous participant callback when no charger is reachable. The exception can terminate the fleet adapter process even though the failure is specific to one robot.
 
 **Worldshepherd contribution:** failure containment + semantic health reporting.
+
+Status: **PATCH DRAFT IMPLEMENTED / REQUIRES UPSTREAM BUILD+TEST VALIDATION**.
 
 Proposed acceptance criteria:
 
@@ -32,14 +40,18 @@ callback invoked after fleet weak_ptr expired -> safe return
 
 Python bindings can retain the GIL during blocking RMF calls, creating a fleet-wide deadlock when worker callbacks simultaneously need Python.
 
-**Worldshepherd contribution:** concurrency boundary audit + liveness regression test.
+**Worldshepherd contribution:** concurrency-boundary patch + semantic-liveness regression test.
+
+Status: **MAINTAINER-WELCOMED / PATCH DRAFT IMPLEMENTED / REGRESSION PLAN IMPLEMENTED / REQUIRES ROS 2 HUMBLE BUILD+STRESS VALIDATION**.
 
 Acceptance criteria:
 
 - binding calls that may block on RMF internals release the GIL;
 - Python callbacks reacquire the GIL only for Python execution;
 - stress test runs concurrent `replan()`/issue creation and callback traffic for a bounded interval with a watchdog;
-- watchdog proves telemetry timestamps continue advancing, not merely that the process PID is alive.
+- watchdog proves telemetry timestamps continue advancing, not merely that the process PID is alive;
+- no guarded method directly manipulates Python objects while the GIL is released;
+- callback-bearing `std::function` arguments are validated under contention to confirm trampoline GIL reacquisition.
 
 ## P0 — Eclipse Zenoh: semantic transport health under DDIL/reconnect stress
 
@@ -48,6 +60,8 @@ Acceptance criteria:
 Router can remain alive with listeners present while silently ceasing to accept new sessions.
 
 **Worldshepherd contribution:** accept-path accounting invariants + externally observable semantic readiness.
+
+Status: **PATCH DRAFT IMPLEMENTED / ROOT CAUSE NOT YET PROVEN / REQUIRES UPSTREAM STRESS VALIDATION**.
 
 Acceptance criteria:
 
@@ -78,6 +92,33 @@ Acceptance criteria:
 - graceful shutdown is retained as a null/control case;
 - link teardown must not hold a global/shared forwarding critical section across blocking close/flush work;
 - regression threshold should be expressed in relation to normal forwarding cadence, not only an absolute wall-clock value.
+
+### Issue eclipse-zenoh/zenoh#2783
+
+Metadata-only storage queries would let clients inspect existence, original payload length, HLC timestamp, and attachments without transferring large payloads.
+
+**Worldshepherd contribution:** metadata contract + storage-manager compatibility tests.
+
+Status: **NEW FEATURE REQUEST / DESIGN CONTRIBUTION CANDIDATE**.
+
+Acceptance criteria:
+
+- one reserved selector parameter with unambiguous namespace and behavior;
+- zero original payload bytes transferred in metadata-only mode;
+- original HLC timestamp preserved exactly;
+- original payload length exposed as a typed/defined metadata field;
+- original attachment preserved without creating recursive or ambiguous wrapping;
+- identical logical behavior across filesystem, RocksDB, and S3 storage backends;
+- unknown/unsupported selector behavior remains backward-compatible;
+- future backend fast paths cannot change the wire-level contract.
+
+See `ZENOH_2783_METADATA_ONLY_PROPOSAL.md`.
+
+### Upstream-resolved Zenoh lane: PR #2779 / related #2637
+
+Status: **MERGED UPSTREAM — DO NOT DUPLICATE**.
+
+The peer-churn `StartConditions` deadlock is now fixed upstream by making the relevant start-condition synchronization synchronous and removing the `block_in_place` scheduling dependency under `ctrl_lock`. Worldshepherd should keep any reproducer/stress evidence as a validation asset and monitor downstream `rmw_zenoh` uptake rather than submit a competing patch.
 
 ## P1 — Keylime: attestation truthfulness and history
 
@@ -182,7 +223,7 @@ Primary objective is an agent-runtime guide with a structured decision contract 
 
 See `CHAINLOOP_FANOUT_RESILIENCY_PROPOSAL.md`.
 
-Primary objective is a durable, replayable, inspectable integration-delivery contract before broker-specific implementation.
+Primary objective is a durable, replayable, inspectable integration-delivery contract before broker-specific implementation. As of Chainloop PR #3436, delivery evidence should preserve upstream adjudication metadata such as retryability, terminal verdict/reason, and abandoned counts when those fields exist.
 
 ## Definition of an upstream-ready Worldshepherd contribution
 

--- a/docs/oss/ZENOH_2783_METADATA_ONLY_PROPOSAL.md
+++ b/docs/oss/ZENOH_2783_METADATA_ONLY_PROPOSAL.md
@@ -1,0 +1,156 @@
+# Zenoh #2783 — metadata-only storage query proposal
+
+Upstream target: `eclipse-zenoh/zenoh#2783`
+
+Claims state: **DESIGN CONTRIBUTION CANDIDATE / NOT IMPLEMENTED UPSTREAM / REQUIRES MAINTAINER REVIEW**
+
+## Problem
+
+Zenoh storage queries currently return the full stored `Sample`. For large images, point clouds, model artifacts, or other binary payloads, clients cannot cheaply ask whether a key exists, whether its HLC timestamp is fresh enough, or how large the payload is before transferring it.
+
+The proposed upstream feature is a metadata-only selector mode. The strongest contribution is to define the wire-level contract before backend-specific optimizations are added.
+
+## Proposed contract
+
+Use one reserved selector parameter owned by the storage-manager plugin, for example:
+
+```text
+_meta_only=true
+```
+
+A metadata-only reply should preserve the identity and timing semantics of the stored sample while omitting the original payload bytes.
+
+### Reply requirements
+
+```text
+key_expr:       unchanged
+kind:           unchanged
+encoding:       defined behavior; see below
+timestamp:      exact stored HLC timestamp
+payload:        zero bytes
+attachment:     metadata envelope
+```
+
+Recommended metadata envelope:
+
+```json
+{
+  "zenoh.storage.meta.version": 1,
+  "payload_len": 1234567,
+  "original_encoding": "application/octet-stream",
+  "original_attachment": "<opaque-preserved-value-if-present>"
+}
+```
+
+The exact serialization should follow Zenoh conventions chosen by maintainers; the important requirement is semantic stability.
+
+## Design constraints
+
+### 1. Backend-independent behavior first
+
+The initial implementation should live at the storage-manager layer if practical so filesystem, RocksDB, S3, and future backends expose the same behavior without each implementing their own selector semantics.
+
+Backend-specific fast paths can be added later, provided they are observationally equivalent.
+
+### 2. Do not overload an empty payload
+
+An actually stored zero-length payload must remain distinguishable from a metadata-only response. The reply therefore needs an explicit metadata-mode marker/version, not just `payload == empty`.
+
+### 3. Preserve HLC exactly
+
+Freshness checks are a primary use case. Metadata-only mode must return the exact stored timestamp rather than generating a new reply timestamp that could be mistaken for data freshness.
+
+### 4. Preserve attachment semantics without recursion
+
+If the original sample has an attachment, the metadata response should preserve it in a defined field or side structure. Avoid recursively embedding an envelope that itself looks like a normal application attachment without a version marker.
+
+### 5. Define encoding behavior
+
+The response payload is metadata, not the original application object. Returning the original encoding while sending an empty payload can be misleading. Two viable options for maintainer review:
+
+- keep reply `encoding` as the original encoding and make `_meta_only` authoritative; or
+- use a defined metadata encoding and expose `original_encoding` in the metadata envelope.
+
+The second option is semantically cleaner, but compatibility should drive the final choice.
+
+### 6. Selector namespace
+
+The reserved selector must not collide with backend/application query parameters. The storage manager should either reserve a clearly documented prefix or reject ambiguous duplicate forms.
+
+## Suggested processing path
+
+```text
+query arrives
+   |
+   +-- normal query --------------------> existing backend path
+   |
+   +-- metadata-only requested
+          |
+          v
+      resolve stored sample
+          |
+          v
+      capture original length/timestamp/encoding/attachment
+          |
+          v
+      strip payload before wire serialization
+          |
+          v
+      return metadata response
+```
+
+The critical bandwidth property is that stripping occurs before serialization/transmission, not after receipt by the client.
+
+## Acceptance tests
+
+### Common behavior
+
+1. Store a non-empty binary payload with timestamp and attachment.
+2. Normal `get` returns the original payload unchanged.
+3. Metadata-only `get` returns zero original payload bytes.
+4. `payload_len` equals the original byte length exactly.
+5. HLC timestamp equals the normal stored sample timestamp exactly.
+6. Original attachment is preserved according to the documented contract.
+7. A zero-length stored value is distinguishable from metadata-only mode.
+8. Missing keys preserve normal not-found/query behavior.
+9. Unknown selector parameters preserve existing compatibility behavior.
+
+### Cross-backend matrix
+
+Run the same logical tests against:
+
+```text
+filesystem
+RocksDB
+S3
+```
+
+A backend-specific optimization passes only if its externally visible result matches the generic storage-manager implementation.
+
+### Large-payload bandwidth test
+
+Store a payload large enough to make accidental transfer obvious (for example tens of megabytes). Capture transmitted bytes or instrument serialization and assert that metadata-only mode does not serialize/transmit the original payload.
+
+### Concurrency/freshness test
+
+Update the same key while alternating metadata-only and normal queries. Assert that each response's HLC timestamp and `payload_len` correspond to one coherent stored version; do not allow timestamp from one version and length from another.
+
+## Worldshepherd relevance
+
+This feature has direct value for semantic-health and provenance workflows:
+
+- check whether remote evidence is newer before transfer;
+- inspect image/point-cloud size before downloading over DDIL links;
+- validate that stored telemetry exists and is recent without paying payload cost;
+- gate retrieval by policy using timestamp/size metadata;
+- distinguish repository/process liveness from actual fresh data availability.
+
+Those use cases support the design, but the upstream interface should remain generic Zenoh functionality with no Worldshepherd-specific namespace.
+
+## Non-goals
+
+- no new authorization bypass;
+- no claim that metadata proves payload integrity unless a digest is separately provided and verified;
+- no backend-specific API exposed to clients;
+- no mutation of stored samples;
+- no claim of upstream acceptance until maintainers review the contract.

--- a/docs/oss/patches/open-rmf-553-prevalidate-charger.patch
+++ b/docs/oss/patches/open-rmf-553-prevalidate-charger.patch
@@ -1,0 +1,79 @@
+From: Worldshepherd contribution preparation
+Subject: [PATCH] fleet_adapter: validate reachable charger before async participant creation
+
+Target: open-rmf/rmf_ros2, humble branch
+Issue: https://github.com/open-rmf/rmf_ros2/issues/553
+
+This draft moves the nearest-charger validation into FleetUpdateHandle::add_robot()
+itself. The invalid-start condition is therefore reported synchronously to the
+caller instead of throwing from async_make_participant's worker callback, where
+it can escape to std::terminate and abort the whole fleet adapter process.
+
+The asynchronous callback receives the already validated charger waypoint and
+contains no throw for this recoverable per-robot condition.
+
+---
+ rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp | 21 ++++++++++-----------
+ 1 file changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
++++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+@@
+   if (start.empty())
+   {
+     // *INDENT-OFF*
+     throw std::runtime_error(
+       "[FleetUpdateHandle::add_robot] StartSet is empty. Adding a robot to a "
+       "fleet requires at least one rmf_traffic::agv::Plan::Start to be "
+       "specified.");
+     // *INDENT-ON*
+   }
++
++  const auto charger_wp = _pimpl->get_nearest_charger(start[0]);
++  if (!charger_wp.has_value())
++  {
++    // *INDENT-OFF*
++    throw std::runtime_error(
++      "[FleetUpdateHandle::add_robot] Unable to find nearest charging "
++      "waypoint. Adding a robot to a fleet requires at least one reachable "
++      "charging waypoint to be present in its navigation graph.");
++    // *INDENT-ON*
++  }
+ 
+   rmf_traffic::schedule::ParticipantDescription description(
+     name,
+     _pimpl->name,
+     rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+@@
+     [worker = _pimpl->worker,
+     command = std::move(command),
+     start = std::move(start),
++    charger_wp = charger_wp.value(),
+     handle_cb = std::move(handle_cb),
+     fleet_wptr = weak_from_this()](
+       rmf_traffic::schedule::Participant participant)
+     {
+       auto fleet = fleet_wptr.lock();
+       if (!fleet)
+         return;
+-
+-      const auto charger_wp = fleet->_pimpl->get_nearest_charger(start[0]);
+-
+-      if (!charger_wp.has_value())
+-      {
+-        // *INDENT-OFF*
+-        throw std::runtime_error(
+-          "[FleetUpdateHandle::add_robot] Unable to find nearest charging "
+-          "waypoint. Adding a robot to a fleet requires at least one charging"
+-          "waypoint to be present in its navigation graph.");
+-        // *INDENT-ON*
+-      }
+ 
+       rmf_task::State state;
+-      state.load_basic(start[0], charger_wp.value(), 1.0);
++      state.load_basic(start[0], charger_wp, 1.0);
+ 
+       auto context = std::make_shared<RobotContext>(
+-- 
+2.43.0

--- a/docs/oss/patches/zenoh-2780-incoming-permit.patch
+++ b/docs/oss/patches/zenoh-2780-incoming-permit.patch
@@ -1,0 +1,113 @@
+From: Worldshepherd contribution preparation
+Subject: [PATCH] transport: make incoming accept accounting cancellation-safe
+
+Target: eclipse-zenoh/zenoh at 646f2d1b730e584a570015a77bee9f6db08be9d1
+Issue: https://github.com/eclipse-zenoh/zenoh/issues/2780
+
+STATUS: DRAFT / REQUIRES UPSTREAM TESTING
+
+This hardening patch does two things around unicast incoming acceptance:
+
+1. Replaces the separate `load >= limit` / `fetch_add` sequence with an atomic
+   permit acquisition, preventing concurrent arrivals from racing past
+   `accept_pending`.
+2. Associates the increment with an RAII guard whose Drop implementation
+   decrements the counter. If the spawned accept future is cancelled or unwinds,
+   accounting is restored without relying on reaching the last statement of the
+   task.
+
+It also raises saturation visibility from trace to debug and reports pending/limit.
+This does not by itself prove the root cause of #2780; it makes the counter
+invariant robust across cancellation and unwind and should be paired with a
+restart/connect-disconnect stress regression.
+
+---
+ io/zenoh-transport/src/unicast/manager.rs | 43 ++++++++++++++++++++++++++-----
+ 1 file changed, 37 insertions(+), 6 deletions(-)
+
+diff --git a/io/zenoh-transport/src/unicast/manager.rs b/io/zenoh-transport/src/unicast/manager.rs
+--- a/io/zenoh-transport/src/unicast/manager.rs
++++ b/io/zenoh-transport/src/unicast/manager.rs
+@@
+ pub struct TransportManagerStateUnicast {
+     // Incoming uninitialized transports
+     pub(super) incoming: Arc<AtomicUsize>,
+@@
+     pub(super) authenticator: Arc<Auth>,
+ }
++
++struct IncomingAcceptPermit {
++    incoming: Arc<AtomicUsize>,
++}
++
++impl IncomingAcceptPermit {
++    fn try_acquire(incoming: Arc<AtomicUsize>, limit: usize) -> Option<Self> {
++        incoming
++            .fetch_update(SeqCst, SeqCst, |current| {
++                (current < limit).then_some(current + 1)
++            })
++            .ok()?;
++
++        Some(Self { incoming })
++    }
++}
++
++impl Drop for IncomingAcceptPermit {
++    fn drop(&mut self) {
++        self.incoming.fetch_sub(1, SeqCst);
++    }
++}
+@@
+     pub(crate) async fn handle_new_link_unicast(&self, link: LinkUnicast) {
+         let incoming_counter = self.state.unicast.incoming.clone();
+-        if incoming_counter.load(SeqCst) >= self.config.unicast.accept_pending {
++        let incoming_permit = match IncomingAcceptPermit::try_acquire(
++            incoming_counter.clone(),
++            self.config.unicast.accept_pending,
++        ) {
++            Some(permit) => permit,
++            None => {
+             // We reached the limit of concurrent incoming transport, this means two things:
+             // - the values configured for ZN_OPEN_INCOMING_PENDING and ZN_OPEN_TIMEOUT
+             //   are too small for the scenario zenoh is deployed in;
+             // - there is a tentative of DoS attack.
+             // In both cases, let's close the link straight away with no additional notification
+-            tracing::trace!("Closing link for preventing potential DoS: {}", link);
+-            let _ = link.close().await;
+-            return;
+-        }
++                tracing::debug!(
++                    "Closing link because incoming accept limit is reached ({}/{}): {}",
++                    incoming_counter.load(SeqCst),
++                    self.config.unicast.accept_pending,
++                    link
++                );
++                let _ = link.close().await;
++                return;
++            }
++        };
+ 
+         // A new link is available
+         tracing::trace!("Accepting link... {}", link);
+-        self.state.unicast.incoming.fetch_add(1, SeqCst);
+ 
+         // Spawn a task to accept the link
+         let c_manager = self.clone();
+         self.task_controller
+             .spawn_with_rt(zenoh_runtime::ZRuntime::Acceptor, async move {
++                // Keep the permit for the full lifetime of the accept future.
++                // Cancellation or unwind drops it and restores accounting.
++                let _incoming_permit = incoming_permit;
+                 if tokio::time::timeout(
+                     c_manager.config.unicast.accept_timeout,
+                     super::establishment::accept::accept_link(link, &c_manager),
+@@
+                         c_manager.config.unicast.accept_timeout.as_millis()
+                     );
+                 }
+-                incoming_counter.fetch_sub(1, SeqCst);
+             });
+     }
+ }
+-- 
+2.43.0

--- a/docs/oss_contributions/gazebo_3976_priority_registration.patch
+++ b/docs/oss_contributions/gazebo_3976_priority_registration.patch
@@ -1,0 +1,61 @@
+From: Worldshepherd OSS contribution workbench
+Subject: [PATCH DRAFT] systems: register configure-priority interfaces for Physics and UserCommands
+Upstream target: gazebosim/gz-sim#3976
+Claims state: PATCH-READY / REQUIRES UPSTREAM BUILD+REGRESSION TEST
+
+Problem
+-------
+Physics and UserCommands inherit ISystemConfigurePriority and provide declared
+non-default priorities, but their dynamic plugin registration metadata omits
+that interface. Dynamic loading therefore falls back to priority 0 even though
+in-memory C++ instances expose the intended priority interface.
+
+The issue report includes a deterministic dynamic-plugin regression in which
+both systems land in the wrong scheduler bucket; adding the omitted interface
+registrations reportedly makes the reproducer pass.
+
+--- a/src/systems/physics/Physics.cc
++++ b/src/systems/physics/Physics.cc
+@@
+ GZ_ADD_PLUGIN(Physics,
+                     System,
++                    Physics::ISystemConfigurePriority,
+                     Physics::ISystemConfigure,
+                     Physics::ISystemReset,
+                     Physics::ISystemUpdate)
+
+--- a/src/systems/user_commands/UserCommands.cc
++++ b/src/systems/user_commands/UserCommands.cc
+@@
+ GZ_ADD_PLUGIN(UserCommands, System,
++  UserCommands::ISystemConfigurePriority,
+   UserCommands::ISystemConfigure,
+   UserCommands::ISystemPreUpdate
+ )
+
+Regression requirements
+-----------------------
+1. Dynamically load Physics and assert QueryInterface<ISystemConfigurePriority>()
+   is non-null.
+2. Dynamically load UserCommands and assert the same.
+3. Assert Physics is placed in the kPhysicsPriority scheduler bucket rather
+   than kDefaultPriority.
+4. Assert UserCommands is placed in the kUserCommandsPriority bucket rather
+   than kDefaultPriority.
+5. Keep ForceTorque as a positive-control dynamic plugin because it already
+   registers ISystemConfigurePriority.
+6. Run existing gz-sim plugin/system tests to catch registration ABI regressions.
+
+Why this is high priority for Worldshepherd
+-------------------------------------------
+Simulation ordering is part of evidence quality. A simulator that silently
+runs systems at priority 0 can invalidate timing-sensitive fault-injection and
+resilience experiments while still appearing nominal. This fix therefore maps
+directly to Worldshepherd's simulation-evidence and semantic-health lanes.
+
+Scope boundary
+--------------
+This draft only adds the missing registration metadata. It does not modify
+scheduler semantics, physics behavior, system priorities, or plugin loading
+policy. No upstream acceptance is claimed until Gazebo maintainers review and
+run their regression suite.

--- a/docs/oss_contributions/keylime_1941_verifier_interval.patch
+++ b/docs/oss_contributions/keylime_1941_verifier_interval.patch
@@ -1,0 +1,55 @@
+From: Worldshepherd OSS contribution workbench
+Subject: [PATCH DRAFT] verifier: use consistent quote_interval fallback
+Upstream target: keylime/keylime#1941
+Claims state: IMPLEMENTED AS PATCH DRAFT / REQUIRES UPSTREAM TESTS
+
+Problem
+-------
+The verifier documents quote_interval=2 seconds as its default but two push
+model paths diverge: attestation_controller.py caps retry delay with
+fallback=60 and Attestation.next_attestation_expected_after reads quote_interval
+without a fallback. The config option also accepts floating-point values, so
+using getfloat is the least surprising common behavior.
+
+--- a/keylime/web/verifier/attestation_controller.py
++++ b/keylime/web/verifier/attestation_controller.py
+@@
+-            max_interval = config.getint("verifier", "quote_interval", fallback=60)
++            max_interval = config.getfloat("verifier", "quote_interval", fallback=2.0)
+             consecutive_failures = agent.consecutive_attestation_failures or 1  # type: ignore[union-attr]
+
+--- a/keylime/models/verifier/attestation.py
++++ b/keylime/models/verifier/attestation.py
+@@
+     @property
+     def next_attestation_expected_after(self):
+         if self.evidence_received_at:
+-            return self.evidence_received_at + timedelta(seconds=config.getint("verifier", "quote_interval"))
++            quote_interval = config.getfloat("verifier", "quote_interval", fallback=2.0)
++            return self.evidence_received_at + timedelta(seconds=quote_interval)
+         return self.capabilities_received_at
+
+Test changes required
+---------------------
+1. In test/test_attestation_model.py, patch config.getfloat for
+   next_attestation_expected_after tests instead of config.getint.
+2. Add a test that config.getfloat is called with
+   ("verifier", "quote_interval", fallback=2.0).
+3. Add a test using quote_interval=2.5 and assert the resulting timestamp is
+   evidence_received_at + 2.5 seconds. This protects the documented support
+   for floating-point intervals.
+4. In test/test_attestation_controller.py, update the quote-interval mock from
+   getint to getfloat and assert the cap uses fallback=2.0 when the option is
+   absent.
+5. Preserve existing exponential-backoff assertions: this patch changes only
+   the configured cap source and fallback, not retry.retry_time semantics.
+
+Why this is deliberately limited
+--------------------------------
+This patch fixes the verifier-side inconsistency only. It does not change the
+Rust agent's general retry interval. The agent's 60-second local measurement
+interval is also used for registration/attestation failure retries, so globally
+changing it to 2 seconds could unintentionally create a retry storm during a
+verifier outage. A separate rust-keylime patch should distinguish 'accepted
+response is malformed/missing cadence metadata' from 'network/authentication
+failure retry cadence'.

--- a/docs/oss_contributions/open_rmf_549_binding_audit.md
+++ b/docs/oss_contributions/open_rmf_549_binding_audit.md
@@ -1,0 +1,122 @@
+# Open-RMF #549 — Python binding GIL boundary audit
+
+Upstream: `open-rmf/rmf_ros2#549`
+Target: `rmf_fleet_adapter_python` on ROS 2 Humble
+Claims state: **PATCH DRAFT REVIEW / REQUIRES UPSTREAM BUILD + CONTENTION VALIDATION**
+
+## Maintainer signal
+
+The upstream maintainer explicitly welcomed a contribution on issue #549. No competing GIL-release PR was found in the current repository scan.
+
+## Failure mechanism under review
+
+The reported inversion is:
+
+```text
+Python caller owns GIL
+  -> enters bound RMF method
+  -> waits on RMF worker/mutex
+
+RMF worker owns/needs RMF state
+  -> invokes Python RobotCommandHandle callback
+  -> waits on GIL
+```
+
+The required property is not merely process survival. Callback progress, updater-call progress, and fleet telemetry must continue advancing.
+
+## Canonical patch surface
+
+The canonical draft is `docs/oss_contributions/open_rmf_549_gil_release.patch` because it includes the schedule participant path in addition to the `RobotUpdateHandle` methods.
+
+### Guard in first patch
+
+| Binding | Reason | Validation emphasis |
+|---|---|---|
+| `interrupted` / `replan` | Explicitly implicated by #549; may wait on worker state | concurrent Python callback progress |
+| `update_current_waypoint` | Position update can contend with RMF state | timer-driven callback + updater loop |
+| `update_current_lanes` | Same update path family | lane update under callback saturation |
+| `update_off_grid_position` | Same update path family | off-grid update under callback saturation |
+| `update_lost_position` | Same update path family | lost-position update under callback saturation |
+| `update_position(StartSet)` | Same update path family | start-set update under callback saturation |
+| `set_charger_waypoint` | Explicitly listed by issue | repeated setter under active fleet |
+| `update_battery_soc` | Explicitly listed by issue | high-rate battery update |
+| `create_issue` | Explicitly implicated by report | create/resolve tickets while callbacks fire |
+| `cancel_task` | Explicitly listed; carries Python callback | prove callback trampoline reacquires GIL |
+| `set_task_planner_params` | Explicitly listed by issue | build-time/runtime safety; no Python work inside released region |
+| `Participant.set_itinerary` | Explicitly listed by issue | itinerary update under schedule contention |
+
+## Do not expand without evidence
+
+The first upstream PR should remain narrow. These bindings may deserve later audit, but they should not be changed in the first patch unless profiling/reproduction shows the same blocking property:
+
+```text
+override_status
+log_info / log_warning / log_error
+interrupt
+kill_task
+submit_direct_request
+unstable_* accessors
+FleetUpdateHandle add/open/close-lane helpers
+```
+
+Adding `gil_scoped_release` everywhere increases review surface and can expose lifetime assumptions unnecessarily.
+
+## Python-object safety review
+
+`py::call_guard<py::gil_scoped_release>()` is suitable only when the underlying C++ call does not directly use Python APIs during the released region.
+
+Required checks:
+
+1. pybind argument conversion completes before the guard releases the GIL.
+2. return-value conversion occurs after the guard has reacquired the GIL.
+3. Python callbacks carried as `std::function` reacquire the GIL when invoked.
+4. no borrowed Python object/reference is dereferenced by C++ while the GIL is released.
+5. object lifetime is retained for the duration of the native call.
+
+`cancel_task()` therefore needs an explicit regression case: its `on_cancellation` Python callable must execute correctly while the outer bound method has released the caller's GIL.
+
+## Regression acceptance matrix
+
+| Scenario | Unpatched expectation | Patched requirement |
+|---|---|---|
+| patrol callbacks + repeated `replan()` | possible GIL/RMF inversion | no semantic stall |
+| callbacks + `create_issue()` | possible contention | callback and update counters advance |
+| callbacks + waypoint/battery updates | possible contention | telemetry timestamps remain fresh |
+| `cancel_task()` Python callback | may participate in inversion | callback executes and returns normally |
+| six robots, sustained load | issue reports fleet-wide freeze | no simultaneous callback/update stall |
+| process/PID check only | can remain green falsely | insufficient to pass |
+
+## Watchdog signals
+
+A run is passing only while all active signals stay within threshold:
+
+```text
+last_robot_command_callback
+last_update_call_return
+last_fleet_state_timestamp
+process_alive
+```
+
+Suggested CI thresholds from the regression plan:
+
+```text
+sample interval: 100 ms
+callback silence threshold: 3 s
+updater-call silence threshold: 3 s
+overall short test: 30-45 s
+repetitions: >= 20
+sustained validation: >= 10 min
+```
+
+## Submission gate
+
+Move from `PATCH DRAFT` to `UPSTREAM_READY` only after:
+
+- Humble build succeeds;
+- existing adapter tests pass;
+- unpatched branch reproduces the semantic stall at least once under the defined harness;
+- patched branch survives repeated short runs and one sustained run;
+- callback-bearing bindings are explicitly exercised;
+- patch is rebased on the upstream target branch and formatting/lint checks pass.
+
+Until those conditions are met, Worldshepherd may claim a **maintainer-welcomed patch draft and regression design**, not a proven fix.

--- a/docs/oss_contributions/open_rmf_549_gil_release.patch
+++ b/docs/oss_contributions/open_rmf_549_gil_release.patch
@@ -1,0 +1,138 @@
+From: Worldshepherd OSS contribution workbench
+Subject: [PATCH DRAFT] rmf_fleet_adapter_python: release GIL around blocking RMF calls
+Upstream target: open-rmf/rmf_ros2#549
+Claims state: IMPLEMENTED AS PATCH DRAFT / REQUIRES UPSTREAM BUILD+STRESS VALIDATION
+
+Rationale
+---------
+Python currently keeps the GIL while entering a set of RMF methods that may
+wait on internal worker state. If an RMF worker simultaneously owns an RMF
+mutex and needs the GIL to call a Python RobotCommandHandle callback, the two
+threads can deadlock. The process may remain alive while robot state telemetry
+freezes.
+
+This draft adds py::call_guard<py::gil_scoped_release>() only to the binding
+surfaces explicitly implicated by issue #549. Argument conversion happens
+before the guard is constructed and return conversion happens after the guard
+is destroyed, so Python object conversion remains GIL-protected.
+
+--- a/rmf_fleet_adapter_python/src/adapter.cpp
++++ b/rmf_fleet_adapter_python/src/adapter.cpp
+@@
+-  .def("interrupted", &agv::RobotUpdateHandle::replan)
+-  .def("replan", &agv::RobotUpdateHandle::replan)
++  .def("interrupted", &agv::RobotUpdateHandle::replan,
++    py::call_guard<py::gil_scoped_release>())
++  .def("replan", &agv::RobotUpdateHandle::replan,
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_current_waypoint",
+     py::overload_cast<std::size_t, double>(
+       &agv::RobotUpdateHandle::update_position),
+     py::arg("waypoint"),
+-    py::arg("orientation"))
++    py::arg("orientation"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_current_lanes",
+     py::overload_cast<const Eigen::Vector3d&,
+     const std::vector<std::size_t>&>(
+       &agv::RobotUpdateHandle::update_position),
+     py::arg("position"),
+-    py::arg("lanes"))
++    py::arg("lanes"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_off_grid_position",
+     py::overload_cast<const Eigen::Vector3d&,
+     std::size_t>(
+       &agv::RobotUpdateHandle::update_position),
+     py::arg("position"),
+-    py::arg("target_waypoint"))
++    py::arg("target_waypoint"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_lost_position",
+     py::overload_cast<const std::string&,
+     const Eigen::Vector3d&,
+@@
+     py::arg("position"),
+     py::arg("max_merge_waypoint_distance") = 0.1,
+     py::arg("max_merge_lane_distance") = 1.0,
+-    py::arg("min_lane_length") = 1e-8)
++    py::arg("min_lane_length") = 1e-8,
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_position",
+     py::overload_cast<rmf_traffic::agv::Plan::StartSet>(
+       &agv::RobotUpdateHandle::update_position),
+-    py::arg("start_set"))
++    py::arg("start_set"),
++    py::call_guard<py::gil_scoped_release>())
+   .def("set_charger_waypoint", &agv::RobotUpdateHandle::set_charger_waypoint,
+-    py::arg("charger_wp"))
++    py::arg("charger_wp"),
++    py::call_guard<py::gil_scoped_release>())
+   .def("update_battery_soc", &agv::RobotUpdateHandle::update_battery_soc,
+-    py::arg("battery_soc"))
++    py::arg("battery_soc"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("cancel_task",
+     &agv::RobotUpdateHandle::cancel_task,
+     py::arg("task_id"),
+     py::arg("labels"),
+-    py::arg("on_cancellation"))
++    py::arg("on_cancellation"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("create_issue",
+     &agv::RobotUpdateHandle::create_issue,
+     py::arg("tier"),
+     py::arg("category"),
+-    py::arg("detail"))
++    py::arg("detail"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("set_task_planner_params",
+     [&](agv::FleetUpdateHandle& self,
+@@
+     py::arg("recharge_soc"),
+     py::arg("account_for_battery_drain"),
+-    py::arg("finishing_request") = "nothing")
++    py::arg("finishing_request") = "nothing",
++    py::call_guard<py::gil_scoped_release>())
+
+--- a/rmf_fleet_adapter_python/src/schedule/schedule.cpp
++++ b/rmf_fleet_adapter_python/src/schedule/schedule.cpp
+@@
+   .def("set_itinerary",
+     [&](schedule::Participant& self,
+       const std::vector<rmf_traffic::Route>& itinerary)
+     {
+       self.set(self.assign_plan_id(), itinerary);
+     },
+-    py::arg("itinerary"));
++    py::arg("itinerary"),
++    py::call_guard<py::gil_scoped_release>());
+
+Validation required before upstream submission
+---------------------------------------------
+1. Build rmf_fleet_adapter_python on the target ROS 2 Humble toolchain.
+2. Run the existing Python test suite and rmf_fleet_adapter tests.
+3. Run a contention stress test with RobotCommandHandle callbacks entering
+   Python while a separate Python thread repeatedly invokes replan(),
+   create_issue(), update_position(), and cancel_task().
+4. Assert callback progress and telemetry freshness throughout the run; process
+   liveness alone is not a passing criterion.
+5. Run ThreadSanitizer/ASan-capable variants where practical to detect any
+   lifetime assumptions exposed by allowing concurrent Python/C++ progress.
+6. Review every added guard for methods that touch Python objects internally;
+   remove a guard if the underlying C++ call itself requires the GIL.
+
+Non-goals
+---------
+- No change to RMF scheduling semantics.
+- No change to RobotCommandHandle callback ordering.
+- No claim that every binding needs a GIL release.
+- No upstream acceptance claimed until maintainers review and CI/stress tests pass.

--- a/docs/oss_contributions/rust_keylime_1941_response_fallback.patch
+++ b/docs/oss_contributions/rust_keylime_1941_response_fallback.patch
@@ -1,0 +1,109 @@
+From: Worldshepherd OSS contribution workbench
+Subject: [PATCH DRAFT] push-model agent: retain verifier cadence on malformed accepted response
+Upstream target: keylime/keylime#1941 (agent side: keylime/rust-keylime)
+Claims state: IMPLEMENTED AS PATCH DRAFT / REQUIRES UPSTREAM TESTS
+
+Design goal
+-----------
+Do not globally change the agent's configured attestation_interval_seconds from
+60 to 2. That value is also used for retrying registration/attestation failures,
+so lowering it globally would change outage behavior and could create a retry
+storm.
+
+Instead, distinguish two cases:
+
+1. Verifier accepted evidence and supplied a valid
+   seconds_to_next_attestation: remember and use that cadence.
+2. Verifier accepted evidence but the cadence field is missing/malformed:
+   reuse the last valid verifier-provided cadence. If none has ever been seen,
+   use a dedicated accepted-response fallback of 2 seconds, matching the
+   verifier default.
+
+Network/authentication/registration failures continue using the configured
+measurement_interval and are outside this patch.
+
+--- a/keylime-push-model-agent/src/state_machine.rs
++++ b/keylime-push-model-agent/src/state_machine.rs
+@@
+ use std::time::Duration;
+ use tokio::time;
++
++const DEFAULT_VERIFIER_RESPONSE_INTERVAL_SECONDS: u64 = 2;
+@@
+ pub struct StateMachine<'a> {
+@@
+     measurement_interval: Duration,
++    last_verifier_interval: Option<Duration>,
+@@
+         Self {
+@@
+             measurement_interval,
++            last_verifier_interval: None,
+             registrar_tls_config,
+             privileged_resources,
+         }
+@@
+-    fn extract_next_attestation_interval(
+-        &self,
++    fn extract_next_attestation_interval(
++        &mut self,
+         response_body: &str,
+     ) -> Duration {
+@@
+                     if let Some(seconds) = meta.seconds_to_next_attestation {
+                         debug!("Using verifier-provided interval: {seconds} seconds");
+-                        return Duration::from_secs(seconds);
++                        let interval = Duration::from_secs(seconds);
++                        self.last_verifier_interval = Some(interval);
++                        return interval;
+                     } else {
+-                        warn!("seconds_to_next_attestation field not found in meta object, using default interval of {} seconds", self.measurement_interval.as_secs());
++                        warn!("seconds_to_next_attestation field not found in meta object");
+                     }
+                 } else {
+-                    warn!("meta object not found in verifier response, using default interval of {} seconds", self.measurement_interval.as_secs());
++                    warn!("meta object not found in verifier response");
+                 }
+             }
+             Err(e) => {
+-                warn!("Failed to parse verifier response as EvidenceHandlingResponse: {}, using default interval of {} seconds", e, self.measurement_interval.as_secs());
++                warn!("Failed to parse verifier response as EvidenceHandlingResponse: {e}");
+             }
+         }
+ 
+-        // Fallback to the default interval.
+-        self.measurement_interval
++        if let Some(interval) = self.last_verifier_interval {
++            warn!(
++                "Using last valid verifier-provided interval of {} seconds",
++                interval.as_secs()
++            );
++            return interval;
++        }
++
++        let fallback = Duration::from_secs(DEFAULT_VERIFIER_RESPONSE_INTERVAL_SECONDS);
++        warn!(
++            "No valid verifier-provided interval has been observed; using verifier-default fallback of {} seconds",
++            fallback.as_secs()
++        );
++        fallback
+     }
+
+Required tests
+--------------
+Add focused unit tests around extract_next_attestation_interval:
+
+- valid response with 7 seconds returns 7 and stores last_verifier_interval=7;
+- valid 7-second response followed by accepted response missing meta returns 7;
+- valid 7-second response followed by malformed JSON returns 7;
+- first accepted response missing meta returns 2;
+- first malformed accepted response returns 2;
+- measurement_interval remains unchanged and is still used by
+  RegistrationFailed/AttestationFailed branches.
+
+Safety boundary
+---------------
+This proposal changes only cadence fallback after HTTP success/ACCEPTED. It does
+not shorten retries after transport failure, authentication failure, registrar
+failure, or rejected evidence. That separation avoids converting a semantic
+fallback fix into a verifier-outage retry-rate change.

--- a/external_anchor_pilots/cosign_5035_publication_failure_contract.md
+++ b/external_anchor_pilots/cosign_5035_publication_failure_contract.md
@@ -1,0 +1,285 @@
+# Cosign #5035 — publication failure contract and fault-injection model
+
+Upstream: `sigstore/cosign#5035`
+Status: design contribution / source-reviewed recovery model
+Claims state: SUPPORTED BY SOURCE REVIEW; IMPLEMENTATION NOT YET CLAIMED
+
+## Scope
+
+This document does **not** duplicate the immediate local-layout ordering fix
+tracked by Cosign #5030 / PR #5031. It addresses the broader #5035 question:
+what Cosign can truthfully promise when an OCI publication consists of several
+registry mutations and one of them fails.
+
+## Source-reviewed observations
+
+`pkg/oci/remote/write.go` contains multiple publication shapes with different
+commit points:
+
+- `WriteSignatures` / `WriteAttestations`: GGCR image write to a mutable tag.
+- `WriteSignaturesExperimentalOCI`: subject `HEAD`, signature layer writes,
+  config write, then artifact-manifest `PUT`.
+- `WriteReferrer`: subject `HEAD`, config write, all layer writes, then
+  artifact-manifest `PUT` (manifest-last).
+- `WriteSignedImageIndexImages`: index/image writes, legacy signature and
+  attestation writes, then local-layout referrer processing. The reviewed code
+  currently writes empty config, then the referrer manifest, then referenced
+  bundle layers in that local-layout block; #5030/#5031 address this immediate
+  ordering defect.
+
+A manifest-last writer reduces invalid-manifest failures but does **not** make a
+multi-object operation transactional. Earlier blobs or manifests can already be
+durable when a later step fails.
+
+## Non-negotiable invariant
+
+**Never claim rollback unless the registry protocol provides a scoped operation
+that can be proven to affect only state owned by the current invocation.**
+
+Completed content-addressed blobs are not invocation-owned merely because this
+invocation uploaded them: the digest may have existed beforehand or may be
+shared by another manifest. Generic deletion is therefore not rollback.
+
+## Publication state machine
+
+Represent each writer as an ordered set of observable phases, not as a boolean
+success/failure:
+
+```text
+VALIDATE
+   |
+   v
+SUBJECT_RESOLVE          (optional/read-only)
+   |
+   v
+BLOB_PUBLISH*            (config + N layers)
+   |
+   v
+ARTIFACT_MANIFEST_PUBLISH  <-- digest-addressed commit point
+   |
+   v
+DISCOVERY_INDEX_UPDATE     (optional mutable fallback/tag/index)
+   |
+   v
+COMPLETE
+```
+
+Legacy mutable-tag writers have a different commit point:
+
+```text
+VALIDATE -> GGCR_BLOB_WORK -> MUTABLE_TAG_MANIFEST_PUBLISH -> COMPLETE
+```
+
+Multi-object workflows such as `cosign load` should be modeled as a sequence of
+publication units, each with its own commit point. A later unit failing does not
+rewind an earlier unit.
+
+## Failure result model
+
+Avoid flattening all failures into `error` text if maintainers are willing to
+add structured internal state. A useful internal record is:
+
+```go
+type PublicationPhase string
+
+const (
+    PhaseValidate       PublicationPhase = "validate"
+    PhaseSubjectResolve PublicationPhase = "subject_resolve"
+    PhaseBlobPublish    PublicationPhase = "blob_publish"
+    PhaseManifest       PublicationPhase = "artifact_manifest_publish"
+    PhaseDiscovery      PublicationPhase = "discovery_index_update"
+)
+
+type PublicationProgress struct {
+    Phase              PublicationPhase
+    Processed          []v1.Descriptor
+    ManifestCommitted  bool
+    DiscoveryCommitted bool
+}
+```
+
+The public API need not expose this exact type. The key requirement is that
+error wrapping preserve:
+
+1. original cause (`errors.Is` / `errors.As`);
+2. failed phase;
+3. whether a digest-addressed manifest was already committed;
+4. non-secret descriptor identities that successfully completed.
+
+Do not include authorization headers, registry credential material, raw client
+certificates, or registry response bodies that may contain secrets.
+
+## Retry semantics
+
+Idempotence must be claimed per operation, not per high-level command.
+
+### Generally safe to retry
+
+- content-addressed blob upload for an already-known digest;
+- digest-addressed artifact-manifest publication when byte-identical and the
+  registry accepts the same digest;
+- reads/HEAD operations.
+
+### Requires conflict semantics
+
+- mutable `.sig` / `.att` tag replacement;
+- fallback referrers indexes implemented as read-modify-write;
+- any tag used as a discovery index;
+- multi-object load/copy workflows.
+
+For these surfaces, retry needs a conditional-write or read/merge/conflict-loop
+contract. "Retry the command" is not equivalent to idempotence.
+
+## Discovery partial success
+
+A critical state is:
+
+```text
+artifact manifest committed = true
+discovery fallback update   = failed
+```
+
+That should be reported as **partial success**, not total failure implying
+nothing exists. Recovery should first probe for the digest-addressed artifact,
+then repair only the missing discovery/index state.
+
+This avoids re-uploading content unnecessarily and gives operators a truthful
+answer about registry state.
+
+## Upload-session cancellation boundary
+
+If a registry exposes an upload-session UUID/capability that is demonstrably
+owned by the current invocation, canceling that *incomplete upload session* may
+be safe.
+
+That does not authorize deletion of:
+
+- completed blobs;
+- artifact manifests;
+- mutable tags written earlier;
+- discovery indexes shared with other writers.
+
+Treat session cancellation as transport cleanup, not transaction rollback.
+
+## Fault-injection matrix
+
+Build a request-recording fake registry with deterministic failpoints. Each
+mutating request receives a monotonically increasing operation number and can
+be configured to fail before or after persistence.
+
+Test every writer with failures at:
+
+| Phase | Before persistence | After persistence / lost response |
+|---|---:|---:|
+| config blob | required | required |
+| each layer blob | required | required |
+| artifact manifest | required | required |
+| mutable tag manifest | required | required |
+| fallback discovery GET | required | n/a |
+| fallback discovery PUT | required | required |
+
+The "persisted but client saw failure" case is essential: networks can drop the
+response after the registry commits. Recovery logic must therefore probe state
+instead of assuming an error means no mutation happened.
+
+### Additional dimensions
+
+Repeat relevant failpoints with:
+
+- blob already existed before invocation;
+- blob newly uploaded by this invocation;
+- same digest referenced by another artifact;
+- deletion unsupported;
+- deletion forbidden;
+- cancellation during upload;
+- 401 and 403;
+- TLS failure;
+- context cancellation / deadline;
+- connection reset / EOF;
+- fallback index concurrent update conflict.
+
+## Lost-update test for fallback indexes
+
+Two publishers concurrently start from index revision R0:
+
+```text
+P1: read R0 -> add artifact A
+P2: read R0 -> add artifact B
+P1: write R1(A)
+P2: write R1(B)
+```
+
+An unconditional second write loses A. The accepted contract should require
+one of:
+
+- conditional request / ETag / digest precondition;
+- conflict detection and bounded read-merge-retry;
+- native OCI referrers API where available.
+
+A test passes only if both A and B remain discoverable or one writer returns a
+preserved conflict that can be safely retried.
+
+## Error taxonomy
+
+Keep at least these classes distinguishable through wrapping:
+
+```text
+VALIDATION
+AUTHENTICATION          (401)
+AUTHORIZATION           (403)
+NOT_FOUND               (only proven 404 semantics)
+UNSUPPORTED_REFERRERS
+CONFLICT
+CANCELED
+DEADLINE
+TLS
+TRANSPORT
+REGISTRY_PROTOCOL
+MANIFEST_REJECTED
+DISCOVERY_UPDATE_FAILED
+```
+
+A 401/403/TLS/cancellation error must never be recast as "not found" to trigger
+legacy fallback.
+
+## Observability / provenance
+
+For operator-safe diagnostics, an event can include:
+
+```text
+publication.writer
+publication.phase
+publication.unit_id
+publication.descriptor.digest
+publication.manifest_committed
+publication.discovery_committed
+publication.retry_attempt
+publication.error_class
+```
+
+Do not log token values, authorization headers, client-key material, or complete
+registry error bodies without sanitization.
+
+## Acceptance criteria
+
+A #5035 implementation should prove:
+
+1. all locally knowable validation occurs before the first mutation;
+2. all manifest-referenced blobs are published before manifest publication;
+3. original causes survive wrapping and are testable with `errors.Is/As`;
+4. failure reports identify the last successful commit point;
+5. no completed shared blob is deleted as generic rollback;
+6. retries are only called idempotent where tested/proven;
+7. fallback discovery updates are conflict-safe;
+8. artifact-manifest success + discovery failure is represented truthfully as
+   partial success/recoverable discovery state;
+9. fault injection covers both pre-commit failure and lost-response-after-
+   commit cases;
+10. logs/errors contain no registry credentials or secret-bearing headers.
+
+## Claims boundary
+
+This is a design and validation contribution based on Cosign's current writer
+implementations and open issue #5035. It does not claim that the cross-writer
+contract has been accepted upstream or that every registry implements the same
+cleanup capabilities.

--- a/external_anchor_pilots/cosign_5037_registry_role_separation.md
+++ b/external_anchor_pilots/cosign_5037_registry_role_separation.md
@@ -1,0 +1,230 @@
+# Cosign #5037 — source/target registry policy separation
+
+Upstream: `sigstore/cosign#5037`
+Status: design contribution / security boundary analysis
+Claims state: SUPPORTED BY SOURCE REVIEW; IMPLEMENTATION NOT YET CLAIMED
+
+## Source-reviewed problem
+
+Current `pkg/oci/remote/options.go` stores one GGCR remote-option slice:
+
+```go
+type options struct {
+    ...
+    TargetRepository name.Repository
+    ROpt             []remote.Option
+    NameOpts         []name.Option
+    OriginalOptions  []Option
+    ...
+}
+```
+
+`makeOptions()` initializes `ROpt` with the default keychain and
+`WithRemoteOptions()` replaces that one slice. The same option state is then
+used for source reads and for operations redirected to `TargetRepository`.
+
+`pkg/oci/remote/remote.go` demonstrates the role mixing:
+
+- `SignedEntity(ref, ...)` reads the source subject with `o.ROpt`.
+- `suffixTag()` may read the source subject with `o.ROpt`, then produces a tag
+  in `o.TargetRepository`.
+- `signatures()` and `attestations()` construct a target reference and call
+  `Signatures(..., o.OriginalOptions...)`, replaying the original option set.
+- attachment readers similarly construct target references while carrying
+  `OriginalOptions`.
+
+When `COSIGN_REPOSITORY` points at a different repository/registry, the
+reference role changes but the transport/auth policy can remain inherited.
+Opaque `remote.Option` functions make it impossible to prove that inherited
+state is safe for the target.
+
+## Security invariant
+
+**Repository redirection must never imply authorization-policy equivalence.**
+
+The following values are role-bound unless equality has been explicitly proven:
+
+- credentials and credential helpers;
+- bearer tokens and repository-scoped tokens;
+- mTLS client certificates/keys;
+- CA pools and TLS server names;
+- insecure/HTTP policy;
+- custom `http.Client` or `RoundTripper` instances;
+- retry/throttling clients that embed auth state;
+- request middleware capable of adding headers.
+
+A canonical-name match is necessary but not always sufficient for repository-
+scoped authorization. Same host / different repository must therefore remain a
+policy boundary unless maintainers deliberately define otherwise.
+
+## Recommended public seam
+
+Do not reinterpret existing `WithRemoteOptions` silently. Add an explicit target
+policy channel with presence tracked separately from the slice value:
+
+```go
+type options struct {
+    ...
+    ROpt                 []remote.Option // existing source/compat policy
+    TargetROpt           []remote.Option
+    TargetROptExplicit   bool
+    ...
+}
+
+func WithTargetRemoteOptions(opts ...remote.Option) Option {
+    return func(o *options) {
+        o.TargetROpt = append([]remote.Option(nil), opts...)
+        o.TargetROptExplicit = true
+    }
+}
+```
+
+Presence must be distinct from length. An explicit zero-length target option
+set can mean "use GGCR/default anonymous behavior" while absence means "the
+caller did not choose a target policy". If maintainers want a named Cosign
+keychain default, expose a separate option rather than overloading absence.
+
+This seam is intentionally additive and compile-compatible.
+
+## Redirect decision table
+
+| Relationship | Source policy reuse | Recommended behavior |
+|---|---:|---|
+| Exact same canonical repository | compatible | Existing behavior may continue |
+| Same registry, different repository | **not proven** | Require explicit target policy or an explicitly accepted compatibility mode |
+| Different registry | **no** | Require independent target policy |
+| DNS/CNAME alias | **no** | Do not infer equivalence from DNS |
+| Mirror/redirect | **no** | Preserve configured role policy; do not follow identity assumptions into credentials |
+| Explicit target options present | n/a | Use target options only for target operations |
+
+## Fail-closed rule for opaque options
+
+For a genuine redirect, opaque source `remote.Option` values cannot be audited.
+The safest contract is therefore:
+
+```text
+redirect && source-options-opaque && !target-policy-explicit
+    => fail before network mutation/read on target
+```
+
+If maintainers choose compatibility reuse instead, it should be an explicit
+security trade-off documented and covered by tests; it should not be described
+as isolation.
+
+## Four-role model for copy
+
+`copy` cannot be modeled as merely source + target. At minimum it has:
+
+1. source subject read policy;
+2. source redirected-artifact read policy;
+3. destination subject/check policy;
+4. destination artifact write policy.
+
+Credentials from role 2 must never become role 4 credentials merely because an
+option object is recursively reused.
+
+This suggests that the long-term internal representation should use named role
+objects instead of boolean target/source flags:
+
+```go
+type RegistryRolePolicy struct {
+    Repository name.Repository
+    RemoteOpts []remote.Option
+    NameOpts   []name.Option
+    Explicit   bool
+}
+```
+
+The public API does not need to expose this type initially; it can be an
+internal normalization target.
+
+## Required test harness
+
+Use two authenticated request-recording registries, A and B. Issue unique
+credentials and TLS/client material per registry. Record every request method,
+host, repository path, and authorization identity without logging raw secrets.
+
+### Core isolation tests
+
+1. Subject in A, `COSIGN_REPOSITORY` in B.
+2. Source credential A succeeds on A and is deliberately rejected by B.
+3. Target credential B succeeds on B and is deliberately rejected by A.
+4. Assert no request to B carries A's identity/material.
+5. Assert no request to A carries B's identity/material.
+
+### Same-host/different-repository test
+
+Use one registry host with repository-scoped tokens:
+
+```text
+registry.example/source/*  -> token S
+registry.example/sig/*     -> token T
+```
+
+Prove that host equality alone does not authorize source-token reuse.
+
+### Transport isolation tests
+
+Independently configure:
+
+- custom CA for A only;
+- custom CA for B only;
+- mTLS on A, not B;
+- mTLS on B, not A;
+- HTTP/insecure A versus TLS B;
+- custom clients with sentinel request headers.
+
+Sentinel headers provide a simple proof that a client or middleware did not
+cross the role boundary.
+
+### Error-preservation tests
+
+Target errors must remain distinguishable:
+
+- 401 authentication failure;
+- 403 authorization failure;
+- TLS verification failure;
+- canceled context;
+- deadline exceeded;
+- transport failure;
+- malformed claimed artifact.
+
+None may be converted to "artifact absent" or trigger a successful legacy
+fallback unless the code has positively identified an allowed not-found or
+unsupported-referrers condition.
+
+## Provenance / observability fields
+
+For debugging without secret leakage, record role metadata rather than raw
+credential details:
+
+```text
+registry.role = source_subject | source_artifact | destination_subject | destination_artifact
+registry.repository = canonical non-secret repository identity
+registry.policy.explicit = true|false
+registry.auth.kind = keychain | explicit | anonymous | custom_client
+registry.transport.kind = default | custom_ca | mtls | insecure_http | custom_client
+```
+
+These are diagnostic concepts, not a proposed OpenTelemetry namespace yet.
+
+## Acceptance criteria
+
+A contribution implementing #5037 should not be accepted until it proves:
+
+- source credentials/clients never reach a distinct target role;
+- target credentials/clients never reach source;
+- same-host/different-repository is tested with scoped authorization;
+- recursive constructors preserve role state explicitly;
+- `OriginalOptions` cannot silently reintroduce source policy after role switch;
+- caller-provided option slices are not mutated;
+- 401/403/TLS/cancellation causes survive wrapping;
+- diagnostics contain no credentials, tokens, client-cert private material, or
+  raw authorization headers.
+
+## Claims boundary
+
+This document is a design/test contribution derived from the current Cosign
+source and open issue #5037. It intentionally does not claim a code fix before
+maintainers select the compatibility/fail-closed contract requested by the
+issue.

--- a/external_anchor_pilots/keylime_1909_total_attestation_failures.patch
+++ b/external_anchor_pilots/keylime_1909_total_attestation_failures.patch
@@ -1,0 +1,226 @@
+From: Worldshepherd OSS contribution pack
+Subject: [PATCH DRAFT] verifier: persist cumulative attestation failure count
+Upstream issue: https://github.com/keylime/keylime/issues/1909
+Target: keylime/keylime master
+Claims state: DRAFT / REQUIRES UPSTREAM TEST + MIGRATION VALIDATION
+
+Rationale
+---------
+Keylime currently exposes cumulative successful attestations through
+`attestation_count` and the current failure streak through
+`consecutive_attestation_failures`. A successful attestation may reset the
+consecutive counter, so external monitoring cannot recover an agent's lifetime
+failure count without maintaining a separate durable event store.
+
+Add `total_attestation_failures` as a persistent, monotonic counter. It is
+independent of the existing streak counter:
+
+  attestation_count            = lifetime successful attestations
+  total_attestation_failures   = lifetime failed attestations
+  consecutive_attestation_failures = current failure streak / backoff state
+
+This patch deliberately updates both the newer VerifierAgent model and the
+legacy VerfierMain model. Keylime has previously needed a follow-up fix when
+`consecutive_attestation_failures` existed in the new model but was absent from
+the legacy model, preventing durable persistence in some deployments.
+
+--- a/keylime/models/verifier/verifier_agent.py
++++ b/keylime/models/verifier/verifier_agent.py
+@@
+         # Metrics and timestamps
+         cls._field("attestation_count", Integer)
++        cls._field("total_attestation_failures", Integer)
+ 
+         # ------------------------------------------------------------------ #
+         # PUSH-MODE ONLY FIELDS:
+
+--- a/keylime/db/verifier_db.py
++++ b/keylime/db/verifier_db.py
+@@
+     mtls_cert = Column(String(2048), nullable=True)
+     attestation_count = Column(Integer)
++    total_attestation_failures = Column(Integer, nullable=False, default=0, server_default="0")
+     last_received_quote = Column(Integer)
+     last_successful_attestation = Column(Integer)
+
+--- a/keylime/verification/tpm_engine.py
++++ b/keylime/verification/tpm_engine.py
+@@
+         else:
+             self.attestation.evaluation = "fail"
+ 
++            # Lifetime failure count is independent of the consecutive-failure
++            # streak. Use a null-safe increment so upgraded or partially
++            # initialized agent objects cannot lose the first failure.
++            self.attestation.agent.total_attestation_failures = (
++                (getattr(self.attestation.agent, "total_attestation_failures", None) or 0) + 1
++            )
++
+             # Increment consecutive failures counter for exponential backoff (per enhancement #103)
+             # Update the ORIGINAL agent object (self.attestation.agent), not the fresh agent (self.agent)
+             if self.attestation.agent.consecutive_attestation_failures is None:
+                 self.attestation.agent.consecutive_attestation_failures = 1
+
+--- a/keylime/cloud_verifier_tornado.py
++++ b/keylime/cloud_verifier_tornado.py
+@@
+         "mtls_cert",
+         "ak_tpm",
+         "attestation_count",
++        "total_attestation_failures",
+         "last_received_quote",
+         "last_successful_attestation",
+         "tpm_clockinfo",
+
+--- /dev/null
++++ b/keylime/migrations/versions/c8f0e21a7b4d_add_total_attestation_failures.py
+@@
++"""add total_attestation_failures column
++
++Revision ID: c8f0e21a7b4d
++Revises: a59cc9366774
++Create Date: 2026-09-12 00:00:00.000000
++
++"""
++
++import sqlalchemy as sa
++from alembic import op
++
++# revision identifiers, used by Alembic.
++revision = "c8f0e21a7b4d"
++down_revision = "a59cc9366774"
++branch_labels = None
++depends_on = None
++
++
++def upgrade(engine_name):
++    globals()[f"upgrade_{engine_name}"]()
++
++
++def downgrade(engine_name):
++    globals()[f"downgrade_{engine_name}"]()
++
++
++def upgrade_registrar():
++    pass
++
++
++def downgrade_registrar():
++    pass
++
++
++def upgrade_cloud_verifier():
++    op.add_column(
++        "verifiermain",
++        sa.Column(
++            "total_attestation_failures",
++            sa.Integer(),
++            nullable=False,
++            server_default=sa.text("0"),
++        ),
++    )
++
++
++def downgrade_cloud_verifier():
++    op.drop_column("verifiermain", "total_attestation_failures")
+
+--- a/test/test_tpm_engine.py
++++ b/test/test_tpm_engine.py
+@@
+         self.mock_agent = MagicMock()
+         self.mock_agent.agent_id = "test-agent-123"
+         self.mock_agent.attestation_count = 0
++        self.mock_agent.total_attestation_failures = 0
+         self.mock_agent.accept_attestations = True
+@@
+     def test_process_results_push_mode_failure_preserves_session(
+@@
+         # Evaluation should be set to fail
+         self.assertEqual(self.mock_attestation.evaluation, "fail")
++        self.assertEqual(self.mock_agent.total_attestation_failures, 1)
+@@
+     def test_process_results_pull_mode_failure_deletes_session(
+@@
+         # Evaluation should be set to fail
+         self.assertEqual(self.mock_attestation.evaluation, "fail")
++        self.assertEqual(self.mock_agent.total_attestation_failures, 1)
+@@
+     def test_process_results_success_extends_token(self, mock_getboolean):
+@@
+         # Attestation count should increment
+         self.assertEqual(self.mock_agent.attestation_count, 1)
++        # Lifetime failures are not reset by a successful attestation
++        self.assertEqual(self.mock_agent.total_attestation_failures, 0)
+@@
++    @patch("keylime.verification.tpm_engine.config.get")
++    @patch("keylime.verification.tpm_engine.config.getboolean")
++    @patch("keylime.verification.tpm_engine.AuthSession.delete_active_session_for_agent")
++    def test_total_attestation_failures_is_monotonic_across_recovery(
++        self, _mock_delete_session, mock_getboolean, mock_config_get
++    ):
++        mock_config_get.return_value = "pull"
++        mock_getboolean.return_value = False
++
++        failure = Failure(Component.QUOTE_VALIDATION)
++        failure.add_event("test_failure", "Test failure", True)
++
++        common_patches = (
++            patch.object(self.engine, "_select_ima_log_item", return_value=None),
++            patch.object(self.engine, "_determine_failure_reason"),
++            patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None),
++            patch.object(type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None),
++        )
++
++        with common_patches[0], common_patches[1], common_patches[2], common_patches[3]:
++            self.engine._process_results(failure)
++            self.engine._process_results(failure)
++
++        self.assertEqual(self.mock_agent.total_attestation_failures, 2)
++
++        # A later pass may reset the consecutive streak, but must not erase
++        # lifetime history.
++        with patch.object(self.engine, "_extend_auth_token"):
++            with patch.object(self.engine, "_select_ima_log_item", return_value=None):
++                with patch.object(self.engine, "_determine_failure_reason"):
++                    with patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None):
++                        with patch.object(
++                            type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None
++                        ):
++                            self.engine._process_results(None)
++
++        self.assertEqual(self.mock_agent.total_attestation_failures, 2)
++        self.assertEqual(self.mock_agent.attestation_count, 1)
+
+Validation required before upstream PR
+--------------------------------------
+1. Verify Alembic head before submission. This draft uses `a59cc9366774`, the
+   current indexed migration head observed during preparation; rebase if master
+   advances.
+2. Run migration upgrade/downgrade tests on SQLite, PostgreSQL, and MySQL/MariaDB
+   where maintained CI coverage exists.
+3. Run `test/test_tpm_engine.py` and verifier API tests.
+4. Verify a pre-existing agent row upgrades with value 0.
+5. Verify two failures -> success -> failure yields:
+      attestation_count = 1
+      total_attestation_failures = 3
+      consecutive_attestation_failures = 1 (subject to configured recovery semantics)
+6. Restart verifier and confirm `total_attestation_failures` is restored and
+   exposed by the API rather than reverting to an in-memory default.
+7. Update verifier REST API documentation/examples for the supported API
+   versions selected by maintainers.
+
+Operational value
+-----------------
+A monitoring layer can compute a lifetime failure ratio without maintaining a
+parallel persistent database:
+
+  failures / (successes + failures)
+
+The raw counters remain preferable to storing a derived rate because operators
+can choose their own windows and aggregation rules.
+
+Claims boundary
+---------------
+This is a source-reviewed patch draft. It has not been executed against
+Keylime's multi-database migration matrix in Worldshepherd CI and does not claim
+upstream acceptance.

--- a/external_anchor_pilots/open_rmf_549_gil_release.patch
+++ b/external_anchor_pilots/open_rmf_549_gil_release.patch
@@ -1,0 +1,133 @@
+From: Worldshepherd OSS contribution pack
+Subject: [PATCH DRAFT] rmf_fleet_adapter_python: release GIL around blocking RMF handle calls
+Upstream issue: https://github.com/open-rmf/rmf_ros2/issues/549
+Target branch: humble
+Claims state: DRAFT / REQUIRES UPSTREAM BUILD + STRESS VALIDATION
+
+Rationale
+---------
+The Python bindings currently hold the CPython GIL while entering RMF methods
+that can wait on internal worker state. A concurrent RMF worker may need the
+GIL to invoke a Python RobotCommandHandle callback, producing a lock inversion:
+
+  Python thread: GIL -> waits for RMF mutex
+  RMF worker:    RMF mutex -> waits for GIL
+
+The upstream issue reports fleet-wide stale telemetry and process liveness
+remaining green during this condition. The maintainer has explicitly welcomed
+a contribution on issue #549.
+
+This draft applies py::call_guard<py::gil_scoped_release>() only at binding
+boundaries identified in the issue as potentially blocking. Argument conversion
+happens before the guard is constructed, and pybind11 reacquires the GIL before
+return-value conversion. Python callbacks converted to std::function are
+expected to acquire the GIL when invoked.
+
+--- a/rmf_fleet_adapter_python/src/adapter.cpp
++++ b/rmf_fleet_adapter_python/src/adapter.cpp
+@@
+-  .def("interrupted", &agv::RobotUpdateHandle::replan)
+-  .def("replan", &agv::RobotUpdateHandle::replan)
++  .def("interrupted", &agv::RobotUpdateHandle::replan,
++    py::call_guard<py::gil_scoped_release>())
++  .def("replan", &agv::RobotUpdateHandle::replan,
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_current_waypoint",
+     py::overload_cast<std::size_t, double>(
+       &agv::RobotUpdateHandle::update_position),
+     py::arg("waypoint"),
+-    py::arg("orientation"))
++    py::arg("orientation"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_current_lanes",
+     py::overload_cast<const Eigen::Vector3d&,
+     const std::vector<std::size_t>&>(
+       &agv::RobotUpdateHandle::update_position),
+     py::arg("position"),
+-    py::arg("lanes"))
++    py::arg("lanes"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_off_grid_position",
+     py::overload_cast<const Eigen::Vector3d&,
+     std::size_t>(
+       &agv::RobotUpdateHandle::update_position),
+     py::arg("position"),
+-    py::arg("target_waypoint"))
++    py::arg("target_waypoint"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_lost_position",
+     py::overload_cast<const std::string&,
+     const Eigen::Vector3d&,
+     const double,
+@@
+     py::arg("position"),
+     py::arg("max_merge_waypoint_distance") = 0.1,
+     py::arg("max_merge_lane_distance") = 1.0,
+-    py::arg("min_lane_length") = 1e-8)
++    py::arg("min_lane_length") = 1e-8,
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("update_position",
+     py::overload_cast<rmf_traffic::agv::Plan::StartSet>(
+       &agv::RobotUpdateHandle::update_position),
+-    py::arg("start_set"))
++    py::arg("start_set"),
++    py::call_guard<py::gil_scoped_release>())
+   .def("set_charger_waypoint", &agv::RobotUpdateHandle::set_charger_waypoint,
+-    py::arg("charger_wp"))
++    py::arg("charger_wp"),
++    py::call_guard<py::gil_scoped_release>())
+   .def("update_battery_soc", &agv::RobotUpdateHandle::update_battery_soc,
+-    py::arg("battery_soc"))
++    py::arg("battery_soc"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("cancel_task",
+     &agv::RobotUpdateHandle::cancel_task,
+     py::arg("task_id"),
+     py::arg("labels"),
+-    py::arg("on_cancellation"))
++    py::arg("on_cancellation"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("create_issue",
+     &agv::RobotUpdateHandle::create_issue,
+     py::arg("tier"),
+     py::arg("category"),
+-    py::arg("detail"))
++    py::arg("detail"),
++    py::call_guard<py::gil_scoped_release>())
+@@
+   .def("set_task_planner_params",
+     [&](agv::FleetUpdateHandle& self,
+@@
+       return self.set_task_planner_params(
+@@
+-    py::arg("finishing_request") = "nothing")
++    py::arg("finishing_request") = "nothing",
++    py::call_guard<py::gil_scoped_release>())
+
+Validation required before upstream PR
+--------------------------------------
+1. Build rmf_fleet_adapter_python on ROS 2 Humble with warnings-as-errors where available.
+2. Run the existing Python and fleet-adapter test suites.
+3. Run a deterministic concurrency regression harness:
+   - Python thread repeatedly calls replan()/create_issue()/position updates.
+   - RMF worker concurrently invokes Python RobotCommandHandle callbacks.
+   - watchdog requires callback progress and position timestamp progress.
+   - fail if either stalls beyond bounded threshold while process remains alive.
+4. Exercise callback-bearing bindings (cancel_task) to confirm Python callbacks reacquire
+   the GIL and no callback is invoked while an RMF internal mutex is held in a way that
+   creates a new inversion.
+5. Run sustained saturation test (>= 10 minutes) with >= 6 simulated robots and overlapping
+   path/stop callbacks, matching the issue's reported workload shape.
+
+Review boundary
+---------------
+This patch intentionally does NOT add GIL release to every binding. Methods should be
+expanded only when their implementation is shown to block or contend on RMF worker state.
+That keeps Python lifetime/return-policy risk bounded and makes review tractable.

--- a/external_anchor_pilots/open_rmf_549_regression_plan.md
+++ b/external_anchor_pilots/open_rmf_549_regression_plan.md
@@ -1,0 +1,131 @@
+# Open-RMF #549 — deterministic regression plan
+
+Upstream: `open-rmf/rmf_ros2#549`
+Target: `rmf_fleet_adapter_python` (`humble`)
+Status: contribution-ready test design; requires ROS 2 / RMF execution environment
+
+## Failure contract
+
+The regression is not simply "the process did not crash." The reported failure mode leaves the process and DDS/C++ threads alive while Python robot-update activity and callback execution freeze. The test therefore needs independent progress signals.
+
+A passing run MUST demonstrate all of the following for the entire stress interval:
+
+1. Python `RobotCommandHandle` callbacks continue to execute.
+2. Python-side robot update loops continue to advance.
+3. `RobotUpdateHandle.replan()` and the other guarded calls return within a bounded interval.
+4. Fleet state timestamps continue to advance.
+5. No watchdog interval contains a simultaneous callback-progress and telemetry-progress stall.
+
+## Workload shape
+
+Use the existing `MockAdapter`, graph, battery, and `MockRobotCommand` patterns from `scripts/test_loop.py` and `scripts/test_utils.py` to minimize new test scaffolding.
+
+Create six robots. Dispatch a long-running patrol/loop workload so RMF workers repeatedly call into Python `follow_new_path()` / `stop()` while a Python stress thread concurrently invokes the affected update-handle APIs.
+
+Pseudo-flow:
+
+```python
+adapter = adpt.MockAdapter("GilReleaseRegression")
+fleet = build_existing_test_fleet(adapter)
+robots = [add_robot(f"T{i}") for i in range(6)]
+adapter.start()
+
+dispatch_long_patrols(robots)
+
+stop_event = threading.Event()
+progress = ProgressCounters()
+
+threading.Thread(target=stress_update_handles,
+                 args=(robots, progress, stop_event),
+                 daemon=True).start()
+
+run_rclpy_executor_and_watchdog(progress, stop_event, duration=30.0)
+```
+
+The stress worker should rotate through operations that are explicitly guarded by the patch:
+
+```python
+while not stop_event.is_set():
+    for robot in robots:
+        updater = robot.updater
+        updater.replan()
+        updater.update_battery_soc(0.95)
+        updater.update_current_waypoint(robot.current_waypoint, 0.0)
+        ticket = updater.create_issue(
+            adpt.robot_update_handle.Tier.Info,
+            "gil-regression",
+            {"sequence": progress.calls},
+        )
+        ticket.resolve({"reason": "test"})
+        progress.calls += 1
+```
+
+Instrument the command handle callbacks:
+
+```python
+class ProgressRobotCommand(MockRobotCommand):
+    def follow_new_path(self, *args):
+        self.progress.callback_count += 1
+        self.progress.last_callback = time.monotonic()
+        return super().follow_new_path(*args)
+
+    def stop(self):
+        self.progress.stop_count += 1
+        self.progress.last_callback = time.monotonic()
+        return super().stop()
+```
+
+Track the last successful Python-side updater operation as well:
+
+```python
+progress.last_update_return = time.monotonic()
+```
+
+## Watchdog
+
+A watchdog must run independently from the stress worker. Recommended thresholds for CI:
+
+- sample interval: 100 ms
+- maximum callback silence while patrols are active: 3 s
+- maximum updater-call return silence: 3 s
+- overall test timeout: 45 s
+
+Failure message should distinguish:
+
+- `CALLBACK_STALL`
+- `UPDATE_CALL_STALL`
+- `TELEMETRY_STALE`
+- `PROCESS_EXIT`
+
+The test should fail on semantic progress loss even if the process is alive.
+
+## Before/after expectation
+
+### Before GIL-release patch
+
+Under sufficient callback/update contention, the reproducer is expected to eventually reach the reported inversion:
+
+```text
+Python thread owns GIL -> enters bound RMF call -> waits on RMF worker/mutex
+RMF worker owns/needs RMF state -> invokes Python callback -> waits on GIL
+```
+
+The watchdog should report simultaneous callback/update stagnation without requiring a process crash.
+
+### After patch
+
+The Python caller releases the GIL while executing the selected C++ binding. An RMF worker that needs to execute a Python callback can therefore acquire the GIL and make progress.
+
+## Upstream acceptance sequence
+
+1. Confirm the unpatched branch can reproduce the watchdog failure under repeated runs.
+2. Apply `open_rmf_549_gil_release.patch`.
+3. Run existing `rmf_fleet_adapter_python` pytest suite.
+4. Run this stress harness repeatedly (recommended >= 20 CI/local repetitions).
+5. Run one sustained >= 10-minute six-robot test.
+6. Confirm callback-bearing methods such as `cancel_task()` correctly reacquire the GIL through the `std::function` trampoline.
+7. Submit patch and regression evidence to #549.
+
+## Claims boundary
+
+This document defines the regression criteria and workload. It does not claim that the deadlock has been reproduced or eliminated in the Worldshepherd CI environment, because that environment does not currently execute a ROS 2 Humble/RMF integration stack.

--- a/external_anchor_pilots/open_rmf_549_test_scaffold.md
+++ b/external_anchor_pilots/open_rmf_549_test_scaffold.md
@@ -1,0 +1,51 @@
+# Open-RMF #549 — upstream regression scaffold
+
+Status: **TEST DESIGN READY / REQUIRES ROS 2 HUMBLE EXECUTION**
+
+Use existing upstream scaffolding rather than a new simulator:
+
+- `rmf_fleet_adapter_python/scripts/test_loop.py` for graph, fleet, patrol dispatch, and `MockAdapter` setup.
+- `rmf_fleet_adapter_python/scripts/test_utils.py` for `MockRobotCommand.follow_new_path()`, `stop()`, and updater behavior.
+- `rmf_fleet_adapter_python/scripts/test_reporting.py` for fleet-state observation and `create_issue()`/`IssueTicket.resolve()` usage.
+
+## Required progress signals
+
+Instrument four independent signals:
+
+```text
+robot_command_callback_count
+last_robot_command_callback_time
+update_call_return_count
+last_update_call_return_time
+fleet_state_update_count
+last_fleet_state_update_time
+latest_fleet_unix_millis_time
+```
+
+A run fails if callbacks or update-call returns remain silent for more than 3 seconds after warm-up, or if fleet telemetry stops advancing while the process remains alive.
+
+## Contention workload
+
+Run six simulated robots with overlapping patrols. In a separate Python thread, repeatedly rotate through the guarded API set:
+
+```text
+replan()
+update_battery_soc()
+update_current_waypoint()
+create_issue() -> resolve()
+```
+
+Add a separate test for callback-bearing `cancel_task()` so its Python callback is proven to reacquire the GIL correctly.
+
+## Before/after protocol
+
+1. Run the harness on unpatched Humble repeatedly until the reported semantic stall is reproduced or a documented reproduction limit is reached.
+2. Apply `docs/oss_contributions/open_rmf_549_gil_release.patch`.
+3. Run existing Python/fleet-adapter tests.
+4. Run at least 20 short contention repetitions.
+5. Run one sustained test of at least 10 minutes.
+6. Pass only if callbacks, updater returns, and telemetry all continue progressing.
+
+## Claims rule
+
+Process survival alone is not evidence of success. Until the ROS/RMF execution matrix passes, the contribution remains **PATCH DRAFT / REQUIRES UPSTREAM BUILD+STRESS VALIDATION**.

--- a/tools/oss_health/semantic_health.py
+++ b/tools/oss_health/semantic_health.py
@@ -1,0 +1,110 @@
+"""Semantic service health primitives for upstream resilience test harnesses.
+
+This module intentionally distinguishes process liveness from useful service
+readiness.  It is small and dependency-free so it can be embedded in ROS 2,
+Zenoh, simulator, or CI probes without coupling an upstream project to
+Worldshepherd-specific infrastructure.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+
+class HealthState(str, Enum):
+    """Externally meaningful health state."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    STALE = "stale"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class HealthSample:
+    """Inputs used to determine semantic readiness.
+
+    `process_alive` answers only whether the process exists.
+    `endpoint_accepting` should be established with a real connection or
+    round-trip probe rather than a LISTEN-socket check.
+    `telemetry_age_seconds` is None when no telemetry has been observed.
+    `operational_entities` / `expected_min_entities` are optional and useful
+    for fleet-style systems where a process may be alive with no usable robots.
+    """
+
+    process_alive: bool
+    endpoint_accepting: bool
+    telemetry_age_seconds: Optional[float]
+    telemetry_max_age_seconds: float
+    operational_entities: Optional[int] = None
+    expected_min_entities: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class HealthAssessment:
+    state: HealthState
+    reasons: Tuple[str, ...]
+    process_alive: bool
+    service_ready: bool
+
+
+def assess(sample: HealthSample) -> HealthAssessment:
+    """Evaluate a health sample with deterministic precedence.
+
+    Precedence is UNAVAILABLE > STALE > DEGRADED > HEALTHY.  A stale service is
+    called out separately because frozen telemetry is a common silent-failure
+    mode even while the process and middleware remain alive.
+    """
+
+    if sample.telemetry_max_age_seconds < 0:
+        raise ValueError("telemetry_max_age_seconds must be non-negative")
+    if sample.telemetry_age_seconds is not None and sample.telemetry_age_seconds < 0:
+        raise ValueError("telemetry_age_seconds must be non-negative")
+    if sample.operational_entities is not None and sample.operational_entities < 0:
+        raise ValueError("operational_entities must be non-negative")
+    if sample.expected_min_entities is not None and sample.expected_min_entities < 0:
+        raise ValueError("expected_min_entities must be non-negative")
+
+    if not sample.process_alive:
+        return HealthAssessment(
+            state=HealthState.UNAVAILABLE,
+            reasons=("process_not_alive",),
+            process_alive=False,
+            service_ready=False,
+        )
+
+    reasons = []
+
+    if not sample.endpoint_accepting:
+        reasons.append("endpoint_not_accepting")
+
+    stale = sample.telemetry_age_seconds is None or (
+        sample.telemetry_age_seconds > sample.telemetry_max_age_seconds
+    )
+    if stale:
+        reasons.append(
+            "telemetry_missing"
+            if sample.telemetry_age_seconds is None
+            else "telemetry_stale"
+        )
+
+    if (
+        sample.expected_min_entities is not None
+        and sample.operational_entities is not None
+        and sample.operational_entities < sample.expected_min_entities
+    ):
+        reasons.append("operational_entity_count_below_minimum")
+
+    if not reasons:
+        state = HealthState.HEALTHY
+    elif stale:
+        state = HealthState.STALE
+    else:
+        state = HealthState.DEGRADED
+
+    return HealthAssessment(
+        state=state,
+        reasons=tuple(reasons),
+        process_alive=True,
+        service_ready=(state == HealthState.HEALTHY),
+    )

--- a/tools/oss_health/test_semantic_health.py
+++ b/tools/oss_health/test_semantic_health.py
@@ -1,0 +1,119 @@
+import unittest
+
+from semantic_health import HealthSample, HealthState, assess
+
+
+class SemanticHealthTests(unittest.TestCase):
+    def test_healthy_requires_process_endpoint_freshness_and_capacity(self):
+        result = assess(
+            HealthSample(
+                process_alive=True,
+                endpoint_accepting=True,
+                telemetry_age_seconds=1.0,
+                telemetry_max_age_seconds=5.0,
+                operational_entities=6,
+                expected_min_entities=1,
+            )
+        )
+        self.assertEqual(result.state, HealthState.HEALTHY)
+        self.assertTrue(result.service_ready)
+        self.assertEqual(result.reasons, ())
+
+    def test_dead_process_is_unavailable(self):
+        result = assess(
+            HealthSample(
+                process_alive=False,
+                endpoint_accepting=True,
+                telemetry_age_seconds=1.0,
+                telemetry_max_age_seconds=5.0,
+            )
+        )
+        self.assertEqual(result.state, HealthState.UNAVAILABLE)
+        self.assertFalse(result.service_ready)
+        self.assertEqual(result.reasons, ("process_not_alive",))
+
+    def test_live_router_that_cannot_accept_is_degraded(self):
+        result = assess(
+            HealthSample(
+                process_alive=True,
+                endpoint_accepting=False,
+                telemetry_age_seconds=1.0,
+                telemetry_max_age_seconds=5.0,
+            )
+        )
+        self.assertEqual(result.state, HealthState.DEGRADED)
+        self.assertIn("endpoint_not_accepting", result.reasons)
+
+    def test_live_process_with_frozen_telemetry_is_stale(self):
+        result = assess(
+            HealthSample(
+                process_alive=True,
+                endpoint_accepting=True,
+                telemetry_age_seconds=10.0,
+                telemetry_max_age_seconds=5.0,
+            )
+        )
+        self.assertEqual(result.state, HealthState.STALE)
+        self.assertIn("telemetry_stale", result.reasons)
+
+    def test_missing_telemetry_is_stale(self):
+        result = assess(
+            HealthSample(
+                process_alive=True,
+                endpoint_accepting=True,
+                telemetry_age_seconds=None,
+                telemetry_max_age_seconds=5.0,
+            )
+        )
+        self.assertEqual(result.state, HealthState.STALE)
+        self.assertIn("telemetry_missing", result.reasons)
+
+    def test_live_fleet_with_no_operational_robot_is_degraded(self):
+        result = assess(
+            HealthSample(
+                process_alive=True,
+                endpoint_accepting=True,
+                telemetry_age_seconds=1.0,
+                telemetry_max_age_seconds=5.0,
+                operational_entities=0,
+                expected_min_entities=1,
+            )
+        )
+        self.assertEqual(result.state, HealthState.DEGRADED)
+        self.assertIn("operational_entity_count_below_minimum", result.reasons)
+
+    def test_stale_takes_precedence_over_degraded_reasons(self):
+        result = assess(
+            HealthSample(
+                process_alive=True,
+                endpoint_accepting=False,
+                telemetry_age_seconds=10.0,
+                telemetry_max_age_seconds=5.0,
+                operational_entities=0,
+                expected_min_entities=1,
+            )
+        )
+        self.assertEqual(result.state, HealthState.STALE)
+        self.assertEqual(
+            set(result.reasons),
+            {
+                "endpoint_not_accepting",
+                "telemetry_stale",
+                "operational_entity_count_below_minimum",
+            },
+        )
+
+    def test_negative_threshold_is_rejected(self):
+        with self.assertRaises(ValueError):
+            assess(
+                HealthSample(
+                    process_alive=True,
+                    endpoint_accepting=True,
+                    telemetry_age_seconds=1.0,
+                    telemetry_max_age_seconds=-1.0,
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an upstream OSS contribution pack aligned with Worldshepherd's implemented governance/provenance strengths:

- Chainloop #39: durable fan-out outbox, idempotency, replay, retry/dead-letter semantics, and crash-boundary invariants.
- OPA #8851: AI-agent policy decision envelope, PDP/PEP separation, escalation semantics, action binding, and audit fields.
- OpenTelemetry semantic-conventions #2468: minimal cross-domain audit-event envelope that composes with existing domain conventions rather than duplicating them.
- Dependency-free semantic-health reference module distinguishing process liveness from endpoint acceptance, telemetry freshness, and operational-entity availability, with eight unit tests and focused CI.
- Open-RMF #553: patch-ready draft moving charger reachability validation out of an asynchronous callback into caller-visible `add_robot()` validation.
- Open-RMF #549: patch-ready GIL-release draft plus a concurrency regression plan that treats callback/telemetry progress—not PID liveness—as the pass criterion. Upstream maintainer explicitly welcomed a contribution on this issue.
- Zenoh #2780: atomic RAII accept-permit hardening draft so cancellation/unwind cannot leak pending-accept accounting; explicitly requires upstream stress validation because the reported root cause is not yet proven.
- Keylime #1909: persistent `total_attestation_failures` design/draft for cumulative reliability monitoring.
- Keylime #1941: verifier-side quote-interval consistency patch plus a separate rust-keylime proposal that retains the last valid verifier cadence after accepted-but-malformed responses without shortening network/authentication failure retry intervals.
- Keylime #1932 was removed from the active queue after another contributor received approval to work it.
- Cosign #5037: source-reviewed registry role-separation design for `COSIGN_REPOSITORY`, including explicit target-policy semantics, a four-role copy model, credential/client/TLS isolation invariants, and authenticated two-registry tests.
- Cosign #5035: source-reviewed cross-writer publication failure contract defining commit points, partial-success semantics, retry units, safe upload-session cancellation, conflict-safe fallback indexes, and a pre/post-commit fault-injection matrix.
- Gazebo #3976: patch-ready two-line dynamic-plugin metadata fix registering `ISystemConfigurePriority` for Physics and UserCommands, with a scheduler-bucket regression plan and ForceTorque positive control.
- Remaining live queue: Zenoh #2718, Gazebo lifecycle/removal issues, OpenTelemetry follow-ons, and additional Open-RMF resilience issues.

## Claims boundary

These are design/reference contributions, testable artifacts, and upstream patch drafts. This PR does not claim upstream acceptance or merge into the target projects. ROS 2 Humble/RMF stress validation, Keylime verifier/rust-keylime upstream test execution, Gazebo dynamic-plugin regression execution, and Keylime multi-database migration validation remain required before the corresponding drafts should be submitted upstream. The Zenoh patch remains a hypothesis-driven hardening draft pending reproduction/stress evidence. Cosign #5037 remains design-only pending maintainer selection of its public compatibility/security contract; Cosign #5035 is a failure/recovery contract proposal, not a claim of transactionality.

## Why this belongs in Sara_pro

The pack turns Worldshepherd governance concepts into narrowly scoped, externally reviewable interfaces, regression artifacts, and patches that can be submitted upstream when repository write/comment permissions allow.