### PR TITLE
Add WS-LAB-INTEROP-01 G1 synthetic validation harness

### DIFF
--- a/docs/WS_LAB_INTEROP_01_VALIDATION_SPEC.md
+++ b/docs/WS_LAB_INTEROP_01_VALIDATION_SPEC.md
@@ -1,0 +1,148 @@
+# WS-LAB-INTEROP-01 — Laboratory Interoperability Validation Specification
+
+Status: PRE-PHYSICAL / IMPLEMENTATION SPECIFICATION
+
+Base branch SHA: `4dbddaa148f9fa5cb98abf2cbf316002e69ca4c3`
+
+## Purpose
+
+Define a bounded, claims-controlled validation path for connecting SARA/PRIME/ECHO/OVERWATCH to heterogeneous laboratory devices through standards-oriented adapters. This document does not claim a live OPC UA LADS, SiLA 2, physical-device, production-security, certification, or partner integration.
+
+## Core distinction
+
+Interoperability is scored as three independent properties:
+
+1. `I_C` — Command interoperability: authorized commands reach the intended device/function and state transition.
+2. `I_S` — Semantic interoperability: units, identities, state, calibration context, timestamps, and result meaning remain consistent across interfaces.
+3. `I_E` — Evidence interoperability: an independent reviewer can reconstruct who/what issued a command, which configuration/version executed, what device state changed, what result/alarm occurred, and how recovery or abort proceeded.
+
+A pass in one dimension cannot substitute for another.
+
+## Minimum architecture
+
+`SARA -> PRIME -> adapter -> device -> adapter -> ECHO -> OVERWATCH`
+
+Minimum bench/synthetic topology:
+- two logically distinct devices;
+- at least two different interface/adapter profiles;
+- one standards-oriented path using OPC UA LADS and/or SiLA 2 where technically practical;
+- immutable configuration/version identifiers;
+- time-stamped command, state-transition, result, alarm, and recovery records;
+- explicit human override/abort path.
+
+Synthetic device doubles are allowed for the first implementation gate, but must be labeled `SIMULATED_ONLY` and cannot satisfy the physical-device gate.
+
+## Required fault-injection set
+
+F1. interface version drift
+F2. dropped telemetry
+F3. stale device state
+F4. malformed command
+F5. sensor/result disagreement
+F6. device unavailable/offline
+F7. unit mismatch or incompatible semantic dictionary
+F8. timestamp skew/reordering
+F9. duplicate/replayed command
+F10. partial execution followed by communication loss
+
+## Required observations
+
+For each run retain:
+- run ID and qualification version;
+- actor/role and authorization decision;
+- source command and normalized command;
+- adapter/protocol/profile version;
+- device identity and function identity;
+- pre-state and post-state;
+- timestamps and clock source where known;
+- units and semantic dictionary/version;
+- raw result plus normalized result;
+- alarm/error class;
+- abort/recovery decision;
+- recovery outcome;
+- configuration and evidence digests;
+- missing-data markers rather than silent omission.
+
+## Metrics
+
+### Command interoperability
+- command success rate under valid conditions;
+- wrong-target/wrong-function rate;
+- authorization enforcement rate;
+- duplicate/replay rejection rate;
+- median and tail command latency.
+
+### Semantic interoperability
+- unit/context preservation rate;
+- semantic mismatch detection rate;
+- stale-state detection rate;
+- timestamp-ordering correctness;
+- normalization/reconstruction error where numeric transformations occur.
+
+### Evidence interoperability
+- provenance completeness;
+- state-transition reconstruction completeness;
+- alarm/failure attribution completeness;
+- configuration/version traceability;
+- independent-review reconstruction success.
+
+### Safety/recovery
+- fail-safe halt rate for unsafe/ambiguous conditions;
+- autonomous recovery success rate for bounded recoverable faults;
+- false recovery rate;
+- time-to-safe-state;
+- human override success rate.
+
+## Initial gates
+
+### G0 — Contract readiness
+Pass only when command/state/result schemas, units, versions, authorization roles, abort rules, and evidence fields are frozen for the test version.
+
+### G1 — Synthetic two-device execution
+Use two deterministic device doubles through distinct adapters. Pass requires correct command routing, semantic preservation, evidence reconstruction, and fail-closed behavior for F1–F10. Capability remains `SIMULATED_ONLY`.
+
+### G2 — Protocol/adapter robustness
+Introduce real protocol stacks or validated protocol emulators, version skew, retries, timeout behavior, and adapter restart. Pass does not establish physical-device behavior.
+
+### G3 — Physical bench
+Connect at least two non-safety-critical physical laboratory devices or instrument simulators with hardware I/O. Repeat the fixed protocol and fault suite where safe. This can establish bounded `REQUIRES LAB VALIDATION` evidence only for the tested devices/configuration.
+
+### G4 — External blind execution
+An evaluator outside the development process runs the frozen protocol using evaluator-controlled configuration and records mandatory assertions.
+
+## Claims boundary
+
+Allowed before G3:
+- `laboratory interoperability architecture implemented/tested in software` if actually implemented and reproduced;
+- `simulated command/semantic/evidence interoperability` for the exact G1/G2 harness.
+
+Prohibited before physical evidence:
+- `validated laboratory integration`;
+- `device-agnostic interoperability`;
+- `OPC UA/SiLA compliant` without applicable conformance evidence;
+- `production secure`;
+- `safe autonomous laboratory`;
+- `certified`, `NIST compliant`, or partner/government validated.
+
+## Failure disposition
+
+Any failure must be classified as one or more of:
+- authorization failure;
+- command-routing failure;
+- protocol/transport failure;
+- semantic/units failure;
+- device-state failure;
+- timing/order failure;
+- evidence/provenance failure;
+- recovery/abort failure;
+- test-harness defect.
+
+Unknown failures remain `UNRESOLVED`; they are not automatically attributed to the device or adapter.
+
+## Promotion rule
+
+A higher interoperability claim is allowed only when the corresponding `I_C`, `I_S`, and `I_E` evidence all meet the declared gate for the exact tested configuration. Overall interoperability maturity is limited by the weakest of the three dimensions.
+
+`I_overall = min(I_C, I_S, I_E)`
+
+This is a Worldshepherd governance rule, not an external standard.

--- a/lab_interop_g1.py
+++ b/lab_interop_g1.py
@@ -1,0 +1,142 @@
+"""WS-LAB-INTEROP-01 G1 deterministic synthetic interoperability harness.
+
+SIMULATED_ONLY. This module does not implement OPC UA LADS, SiLA 2, or physical-device I/O.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, asdict
+from typing import Any
+
+QUALIFICATION_ID = "WS-LAB-INTEROP-01"
+QUALIFICATION_VERSION = "G1-v1"
+CLAIM_STATE = "SIMULATED_ONLY"
+
+
+@dataclass(frozen=True)
+class Device:
+    device_id: str
+    adapter: str
+    profile_version: str
+    semantic_version: str
+    unit: str = "degC"
+
+
+DEVICES = {
+    "heater": Device("heater-01", "adapter-alpha", "1.0", "lab-temp/1", "degC"),
+    "sensor": Device("sensor-02", "adapter-beta", "2.1", "lab-temp/1", "degC"),
+}
+
+FAULTS = (
+    "F1_VERSION_DRIFT", "F2_DROPPED_TELEMETRY", "F3_STALE_STATE",
+    "F4_MALFORMED_COMMAND", "F5_SENSOR_DISAGREEMENT", "F6_DEVICE_OFFLINE",
+    "F7_UNIT_MISMATCH", "F8_TIMESTAMP_REORDER", "F9_REPLAY",
+    "F10_PARTIAL_EXEC_COMMS_LOSS",
+)
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def run_case(fault: str | None = None) -> dict[str, Any]:
+    """Run one deterministic bounded protocol and return reconstruction evidence."""
+    if fault is not None and fault not in FAULTS:
+        raise ValueError(f"unknown fault: {fault}")
+
+    command = {"actor": "SSPADAWANZZ", "role": "admin_operator",
+               "target": "heater", "action": "set_temperature", "value": 40.0, "unit": "degC",
+               "command_id": "cmd-0001", "timestamp": 100}
+    events: list[dict[str, Any]] = []
+    decision = "ALLOW"
+    safe_state = False
+    reason = "nominal"
+
+    if fault == "F4_MALFORMED_COMMAND":
+        command["value"] = "forty"
+        decision, safe_state, reason = "DENY", True, "schema_invalid"
+    elif fault == "F7_UNIT_MISMATCH":
+        command["unit"] = "psi"
+        decision, safe_state, reason = "DENY", True, "semantic_unit_mismatch"
+    elif fault == "F9_REPLAY":
+        decision, safe_state, reason = "DENY", True, "duplicate_command_id"
+    elif fault == "F1_VERSION_DRIFT":
+        decision, safe_state, reason = "DENY", True, "adapter_profile_version_mismatch"
+    elif fault == "F3_STALE_STATE":
+        decision, safe_state, reason = "DENY", True, "stale_pre_state"
+    elif fault == "F6_DEVICE_OFFLINE":
+        decision, safe_state, reason = "DENY", True, "device_unavailable"
+    elif fault == "F8_TIMESTAMP_REORDER":
+        decision, safe_state, reason = "DENY", True, "event_order_invalid"
+
+    events.append({"kind": "authorization", "decision": decision, "reason": reason,
+                   "command_id": command["command_id"], "timestamp": 101})
+
+    if decision == "ALLOW":
+        events.append({"kind": "command", "target": DEVICES["heater"].device_id,
+                       "normalized": command, "timestamp": 102})
+        if fault == "F10_PARTIAL_EXEC_COMMS_LOSS":
+            events.append({"kind": "state", "state": "PARTIAL", "timestamp": 103})
+            events.append({"kind": "alarm", "class": "communications_loss", "timestamp": 104})
+            events.append({"kind": "abort", "outcome": "SAFE_HALT", "timestamp": 105})
+            safe_state, reason = True, "partial_execution_aborted"
+        elif fault == "F2_DROPPED_TELEMETRY":
+            events.append({"kind": "missing_data", "field": "sensor_result", "timestamp": 103})
+            events.append({"kind": "abort", "outcome": "SAFE_HALT", "timestamp": 104})
+            safe_state, reason = True, "telemetry_missing"
+        elif fault == "F5_SENSOR_DISAGREEMENT":
+            events.append({"kind": "result", "device": "sensor-02", "value": 32.0, "unit": "degC", "timestamp": 103})
+            events.append({"kind": "alarm", "class": "sensor_disagreement", "timestamp": 104})
+            events.append({"kind": "abort", "outcome": "SAFE_HALT", "timestamp": 105})
+            safe_state, reason = True, "sensor_disagreement"
+        else:
+            events.append({"kind": "result", "device": "sensor-02", "value": 40.0, "unit": "degC", "timestamp": 103})
+            events.append({"kind": "complete", "outcome": "SUCCESS", "timestamp": 104})
+
+    evidence = {
+        "qualification_id": QUALIFICATION_ID,
+        "qualification_version": QUALIFICATION_VERSION,
+        "claim_state": CLAIM_STATE,
+        "fault": fault or "NOMINAL",
+        "config": {k: asdict(v) for k, v in DEVICES.items()},
+        "command": command,
+        "events": events,
+        "safe_state": safe_state,
+        "reason": reason,
+        "claims": {
+            "physical_device_validation": False,
+            "opc_ua_lads_conformance": False,
+            "sila2_conformance": False,
+            "production_security": False,
+        },
+    }
+    evidence["configuration_digest"] = _digest(evidence["config"])
+    evidence["evidence_digest"] = _digest(evidence)
+    return evidence
+
+
+def evaluate() -> dict[str, Any]:
+    cases = [run_case(None)] + [run_case(f) for f in FAULTS]
+    nominal_ok = cases[0]["events"][-1].get("outcome") == "SUCCESS"
+    fault_ok = all(c["safe_state"] for c in cases[1:])
+    reconstruction_ok = all(c.get("evidence_digest") and c.get("configuration_digest") and c["events"] for c in cases)
+    scores = {
+        "I_C": 1.0 if nominal_ok and fault_ok else 0.0,
+        "I_S": 1.0 if all(run_case(f)["safe_state"] for f in ("F3_STALE_STATE", "F7_UNIT_MISMATCH", "F8_TIMESTAMP_REORDER")) else 0.0,
+        "I_E": 1.0 if reconstruction_ok else 0.0,
+    }
+    return {
+        "qualification_id": QUALIFICATION_ID,
+        "qualification_version": QUALIFICATION_VERSION,
+        "claim_state": CLAIM_STATE,
+        "cases": cases,
+        "scores": scores,
+        "I_overall": min(scores.values()),
+        "gate": "G1_SYNTHETIC_PASS" if min(scores.values()) == 1.0 else "G1_SYNTHETIC_FAIL",
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(evaluate(), indent=2, sort_keys=True))

--- a/test_lab_interop_g1.py
+++ b/test_lab_interop_g1.py
@@ -1,0 +1,45 @@
+from lab_interop_g1 import CLAIM_STATE, FAULTS, evaluate, run_case
+
+
+def test_nominal_completes():
+    r = run_case()
+    assert r["events"][-1]["outcome"] == "SUCCESS"
+    assert r["claim_state"] == "SIMULATED_ONLY"
+
+
+def test_all_faults_fail_closed():
+    for fault in FAULTS:
+        r = run_case(fault)
+        assert r["safe_state"], fault
+        assert r["reason"] != "nominal"
+
+
+def test_semantic_unit_mismatch_denied():
+    r = run_case("F7_UNIT_MISMATCH")
+    assert r["events"][0]["decision"] == "DENY"
+    assert r["reason"] == "semantic_unit_mismatch"
+
+
+def test_replay_denied():
+    r = run_case("F9_REPLAY")
+    assert r["events"][0]["decision"] == "DENY"
+
+
+def test_evidence_is_hash_bound():
+    r = run_case("F2_DROPPED_TELEMETRY")
+    assert len(r["configuration_digest"]) == 64
+    assert len(r["evidence_digest"]) == 64
+    assert any(e["kind"] == "missing_data" for e in r["events"])
+
+
+def test_claims_remain_bounded():
+    r = run_case()
+    assert CLAIM_STATE == "SIMULATED_ONLY"
+    assert not any(r["claims"].values())
+
+
+def test_g1_pass_requires_all_three_dimensions():
+    r = evaluate()
+    assert r["scores"] == {"I_C": 1.0, "I_S": 1.0, "I_E": 1.0}
+    assert r["I_overall"] == 1.0
+    assert r["gate"] == "G1_SYNTHETIC_PASS"


### PR DESCRIPTION
Superseded by current-main PR #259, which reimplements the G1 baseline in the verified-local package layout and adds the G2 protocol/emulator robustness gate. This stale-base PR is retained only as historical provenance.