### PR TITLE
Add governed Worldshepherd recursive improvement protocol v0.1

### DIFF
--- a/.github/workflows/ws-recursive-improvement-v0-1.yml
+++ b/.github/workflows/ws-recursive-improvement-v0-1.yml
@@ -1,0 +1,61 @@
+name: WS Recursive Improvement v0.1 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-recursive-improvement-v0-1.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-recursive-improvement-v0-1.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  recursive-improvement:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and tests
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Compile recursive-improvement modules
+        run: |
+          python -m py_compile worldshepherd_sara/improvement_cycle.py
+          python -m py_compile worldshepherd_sara/improvement_routing.py
+
+      - name: Run recursive-improvement tests
+        run: |
+          python -m pytest tests/test_improvement_cycle.py tests/test_improvement_routing.py -q

--- a/.github/workflows/ws-recursive-improvement-v0-1.yml
+++ b/.github/workflows/ws-recursive-improvement-v0-1.yml
@@ -14,6 +14,7 @@ on:
       - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
       - 'deployments/sara_verified_local_v1/tests/test_evidence_improvement.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
+      - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_PRODUCER_BRIDGES_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
   push:
@@ -29,6 +30,7 @@ on:
       - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
       - 'deployments/sara_verified_local_v1/tests/test_evidence_improvement.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
+      - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_PRODUCER_BRIDGES_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
   workflow_dispatch:

--- a/.github/workflows/ws-recursive-improvement-v0-1.yml
+++ b/.github/workflows/ws-recursive-improvement-v0-1.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
@@ -16,10 +18,12 @@ on:
     paths:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
+      - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
@@ -55,7 +59,12 @@ jobs:
         run: |
           python -m py_compile worldshepherd_sara/improvement_cycle.py
           python -m py_compile worldshepherd_sara/improvement_routing.py
+          python -m py_compile worldshepherd_sara/pre_improvement.py
 
       - name: Run recursive-improvement tests
         run: |
-          python -m pytest tests/test_improvement_cycle.py tests/test_improvement_routing.py -q
+          python -m pytest \
+            tests/test_improvement_cycle.py \
+            tests/test_improvement_routing.py \
+            tests/test_pre_improvement.py \
+            -q

--- a/.github/workflows/ws-recursive-improvement-v0-1.yml
+++ b/.github/workflows/ws-recursive-improvement-v0-1.yml
@@ -6,11 +6,13 @@ on:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/evidence_improvement.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
       - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
+      - 'deployments/sara_verified_local_v1/tests/test_evidence_improvement.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
@@ -19,11 +21,13 @@ on:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/evidence_improvement.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
       - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
+      - 'deployments/sara_verified_local_v1/tests/test_evidence_improvement.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
@@ -60,6 +64,7 @@ jobs:
           python -m py_compile worldshepherd_sara/improvement_cycle.py
           python -m py_compile worldshepherd_sara/improvement_routing.py
           python -m py_compile worldshepherd_sara/pre_improvement.py
+          python -m py_compile worldshepherd_sara/evidence_improvement.py
 
       - name: Run recursive-improvement tests
         run: |
@@ -67,4 +72,5 @@ jobs:
             tests/test_improvement_cycle.py \
             tests/test_improvement_routing.py \
             tests/test_pre_improvement.py \
+            tests/test_evidence_improvement.py \
             -q

--- a/.github/workflows/ws-recursive-improvement-v0-1.yml
+++ b/.github/workflows/ws-recursive-improvement-v0-1.yml
@@ -7,14 +7,24 @@ on:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/evidence_improvement.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_checkpoint.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/echo_event_store.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/echo_checkpoint.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/echo_checkpoint_verify.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
       - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
       - 'deployments/sara_verified_local_v1/tests/test_evidence_improvement.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_ledger_checkpoint.py'
+      - 'deployments/sara_verified_local_v1/tests/test_operational_feedback.py'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
       - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_PRODUCER_BRIDGES_V0_1.md'
+      - 'deployments/sara_verified_local_v1/docs/WS_RI_CHECKPOINT_FEEDBACK_V0_1.md'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
   push:
@@ -23,15 +33,13 @@ on:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/evidence_improvement.py'
-      - 'deployments/sara_verified_local_v1/worldshepherd_sara/recursive_discovery.py'
-      - 'deployments/sara_verified_local_v1/worldshepherd_sara/config_custody.py'
-      - 'deployments/sara_verified_local_v1/tests/test_improvement_cycle.py'
-      - 'deployments/sara_verified_local_v1/tests/test_improvement_routing.py'
-      - 'deployments/sara_verified_local_v1/tests/test_pre_improvement.py'
-      - 'deployments/sara_verified_local_v1/tests/test_evidence_improvement.py'
-      - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md'
-      - 'deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_PRODUCER_BRIDGES_V0_1.md'
-      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_checkpoint.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_ledger_checkpoint.py'
+      - 'deployments/sara_verified_local_v1/tests/test_operational_feedback.py'
+      - 'deployments/sara_verified_local_v1/docs/WS_RI_CHECKPOINT_FEEDBACK_V0_1.md'
       - '.github/workflows/ws-recursive-improvement-v0-1.yml'
   workflow_dispatch:
 
@@ -45,7 +53,7 @@ defaults:
 jobs:
   recursive-improvement:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -67,6 +75,10 @@ jobs:
           python -m py_compile worldshepherd_sara/improvement_routing.py
           python -m py_compile worldshepherd_sara/pre_improvement.py
           python -m py_compile worldshepherd_sara/evidence_improvement.py
+          python -m py_compile worldshepherd_sara/operational_improvement.py
+          python -m py_compile worldshepherd_sara/improvement_ledger.py
+          python -m py_compile worldshepherd_sara/improvement_checkpoint.py
+          python -m py_compile worldshepherd_sara/improvement_feedback.py
 
       - name: Run recursive-improvement tests
         run: |
@@ -75,4 +87,6 @@ jobs:
             tests/test_improvement_routing.py \
             tests/test_pre_improvement.py \
             tests/test_evidence_improvement.py \
+            tests/test_improvement_ledger_checkpoint.py \
+            tests/test_operational_feedback.py \
             -q

--- a/.github/workflows/ws-ri-runtime-v0-1.yml
+++ b/.github/workflows/ws-ri-runtime-v0-1.yml
@@ -5,22 +5,28 @@ on:
     paths:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_handoff.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_handoff_export.py'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-ri-runtime-v0-1.yml'
   push:
     paths:
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_handoff.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py'
       - 'deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime.py'
       - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_handoff_export.py'
       - 'deployments/sara_verified_local_v1/pyproject.toml'
       - '.github/workflows/ws-ri-runtime-v0-1.yml'
   workflow_dispatch:
@@ -55,12 +61,15 @@ jobs:
         run: |
           python -m py_compile worldshepherd_sara/improvement_runtime.py
           python -m py_compile worldshepherd_sara/improvement_runtime_cli.py
+          python -m py_compile worldshepherd_sara/improvement_handoff.py
+          python -m py_compile worldshepherd_sara/improvement_evidence_export.py
 
       - name: Run runtime contract tests
         run: |
           python -m pytest \
             tests/test_improvement_runtime.py \
             tests/test_improvement_runtime_cli.py \
+            tests/test_improvement_handoff_export.py \
             -q
 
       - name: Verify CLI entry point

--- a/.github/workflows/ws-ri-runtime-v0-1.yml
+++ b/.github/workflows/ws-ri-runtime-v0-1.yml
@@ -1,0 +1,67 @@
+name: WS-RI Runtime v0.1 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-ri-runtime-v0-1.yml'
+  push:
+    paths:
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py'
+      - 'deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime.py'
+      - 'deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py'
+      - 'deployments/sara_verified_local_v1/pyproject.toml'
+      - '.github/workflows/ws-ri-runtime-v0-1.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: deployments/sara_verified_local_v1
+
+jobs:
+  runtime-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and tests
+        run: |
+          python -m pip install 'pip==26.2.1'
+          python -m pip install -c constraints-ci.txt -e '.[test]'
+          python -m pip check
+
+      - name: Compile runtime modules
+        run: |
+          python -m py_compile worldshepherd_sara/improvement_runtime.py
+          python -m py_compile worldshepherd_sara/improvement_runtime_cli.py
+
+      - name: Run runtime contract tests
+        run: |
+          python -m pytest \
+            tests/test_improvement_runtime.py \
+            tests/test_improvement_runtime_cli.py \
+            -q
+
+      - name: Verify CLI entry point
+        run: ws-ri-runtime --help >/dev/null

--- a/deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_PRODUCER_BRIDGES_V0_1.md
+++ b/deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_PRODUCER_BRIDGES_V0_1.md
@@ -1,0 +1,142 @@
+# Worldshepherd Recursive Improvement Producer Bridges v0.1
+
+## Purpose
+
+This document records the executable producer bridges that feed governed `ImprovementProposal` records into Worldshepherd Recursive Improvement (WS-RI).
+
+The producer bridges are translation and routing layers only. They do not merge code, append configuration snapshots, deploy releases, actuate hardware, contact external parties, spend funds, submit proposals, or elevate scientific/readiness claims.
+
+## Producer 1: WS-OMEGA -> WS-RI
+
+`omega_to_improvement()` translates a `DiscoveryNode` into an `ImprovementProposal`.
+
+Preserved lineage:
+
+- OMEGA node ID;
+- source references;
+- discovery kind;
+- discovery evidence state;
+- falsification tests;
+- downstream Worldshepherd routes.
+
+Conservative evidence mapping:
+
+| OMEGA evidence state | WS-RI baseline capability state |
+| --- | --- |
+| SOURCE_VERIFIED / CORROBORATED | SUPPORTED_BY_LITERATURE |
+| SINGLE_SOURCE / HYPOTHESIS | HYPOTHESIS |
+| SIMULATED | SIMULATED_ONLY |
+| SPECULATIVE | SPECULATIVE_EXTENSION |
+| CONFLICTING / UNVERIFIED | NOT_CURRENTLY_CLAIMED |
+
+The translation never assigns a target maturity level. It adds source/evidence and red-team gates, plus all OMEGA falsification tests.
+
+## Producer 2: PRE -> WS-RI
+
+`pre_to_improvement()` translates a `RequirementDeltaRecord` into an `ImprovementProposal`.
+
+Preserved lineage and context:
+
+- PRE requirement-delta ID;
+- source URL and topic reference;
+- demand class;
+- affected lanes;
+- current capability status;
+- missing capability;
+- required experiment/demonstration;
+- evidence targets;
+- partner needs;
+- PRE claims boundary.
+
+Demand class remains demand evidence only:
+
+- `CONFIRMED_DEMAND` does not prove Worldshepherd capability;
+- `EMERGING_DEMAND` does not prove future solicitation language;
+- `WORLDSHEPHERD_FORECAST` is explicitly a preparation signal and not evidence that an external customer requirement exists.
+
+A source that is not PRE capture-ready raises the improvement risk level and remains blocked from consequential use until source resolution.
+
+## Producer 3: Qualification Evidence / TEVV -> WS-RI
+
+`evidence_to_improvement()` translates a `QualificationEvidenceRecord` into feedback for Worldshepherd change control.
+
+Result handling:
+
+| Qualification result | WS-RI behavior |
+| --- | --- |
+| PASS | scoped test-result candidate; no maturity promotion |
+| FAIL | high-risk failure/remediation candidate |
+| INCONCLUSIVE | uncertainty-resolution candidate |
+
+The bridge preserves negative evidence and keeps the original qualification record unchanged. A failure adds a root-cause gate; an inconclusive result adds an uncertainty-resolution gate; all results receive evidence-review and regression gates.
+
+Passing evidence remains bounded to the recorded test scope, environment, configuration, inputs, uncertainty, and capability status.
+
+## Shared routing
+
+`route_improvement()` emits a deterministic routing envelope. Depending on trigger and lifecycle state, routes can include:
+
+- ECHO;
+- WS-OMEGA;
+- PRE;
+- PRIME-TEVV;
+- PRIME;
+- OVERWATCH;
+- RED-TEAM;
+- PARTNER-SCREENING;
+- CONFIG-CUSTODY.
+
+Every routing envelope records:
+
+```text
+deployment_authorized=false
+claim_promotion_performed=false
+external_execution_performed=false
+```
+
+`CONFIG-CUSTODY` is excluded until the improvement is already `PROMOTED` through qualification, identified-human review, and an authorization reference.
+
+## Configuration custody boundary
+
+`build_promoted_configuration_snapshot()` may stage a `ConfigurationSnapshot` only for a promoted improvement record with:
+
+- accepted human review;
+- qualification references;
+- authorization reference;
+- identified actor.
+
+The function returns a snapshot candidate. It does **not** append that snapshot to the custody ledger. Existing authorized change procedures remain responsible for any actual configuration transition.
+
+## Feedback topology
+
+```text
+OMEGA discovery --------+
+                        |
+PRE requirement --------+--> WS-RI proposal
+                        |       |
+QE / TEVV result -------+       v
+                         validation / red-team
+                                |
+                                v
+                         human + PRIME gate
+                                |
+                 +--------------+--------------+
+                 |                             |
+              reject /                     promote
+              quarantine                       |
+                                               v
+                                     custody/change candidate
+                                               |
+                                     authorized change path
+                                               |
+                                               v
+                               ECHO / PRE / OMEGA feedback
+```
+
+## Claims boundary
+
+Current code establishes producer translation, deterministic routing, validation-state gating, and configuration-snapshot staging as software candidates on the feature branch.
+
+It does not establish autonomous self-modification, continuous operation, physical validation, certification, partner validation, mission effectiveness, external authorization, or deployment.
+
+Exact-head protected CI remains the software evidence gate before any stronger implementation claim or merge.

--- a/deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md
+++ b/deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md
@@ -157,6 +157,68 @@ opportunity     -> PRE / partner screening / capture review
 security        -> containment / verification / authorized remediation
 ```
 
+## Executable OMEGA -> WS-RI bridge
+
+`improvement_routing.py` now provides the first executable bridge from recursive discovery into the improvement lifecycle.
+
+`omega_to_improvement()` translates a `DiscoveryNode` into an `ImprovementProposal` while preserving the OMEGA node ID and source references as lineage. It maps discovery type to an improvement trigger and maps discovery evidence state to a conservative baseline capability state. It deliberately does not assign a target maturity level.
+
+The conservative evidence mapping is:
+
+| OMEGA evidence state | WS-RI baseline capability state |
+| --- | --- |
+| SOURCE_VERIFIED / CORROBORATED | SUPPORTED_BY_LITERATURE |
+| SINGLE_SOURCE / HYPOTHESIS | HYPOTHESIS |
+| SIMULATED | SIMULATED_ONLY |
+| SPECULATIVE | SPECULATIVE_EXTENSION |
+| CONFLICTING / UNVERIFIED | NOT_CURRENTLY_CLAIMED |
+
+This mapping is intentionally non-promotional. A verified source can establish that external evidence exists; it cannot establish that Worldshepherd has physically demonstrated or internally proven the capability.
+
+Every OMEGA-derived proposal receives at least two qualification gates:
+
+- a source/evidence gate;
+- a red-team gate.
+
+Any OMEGA falsification tests and caller-specified additional tests are added to those required gates.
+
+`route_improvement()` returns a deterministic routing envelope only. It can route records toward ECHO, WS-OMEGA, PRE, PRIME-TEVV, PRIME, OVERWATCH, RED-TEAM, partner screening, and configuration custody according to trigger and lifecycle state. It explicitly records:
+
+- `deployment_authorized=false`;
+- `claim_promotion_performed=false`;
+- `external_execution_performed=false`.
+
+Configuration custody is excluded until the improvement record reaches `PROMOTED` through the existing validation and human/authorization gates.
+
+## Configuration-custody staging boundary
+
+`build_promoted_configuration_snapshot()` connects an accepted WS-RI record to the existing append-only configuration custody model.
+
+The function requires:
+
+- `state=PROMOTED`;
+- accepted identified-human review;
+- qualification references;
+- an authorization reference;
+- an identified actor.
+
+It then returns a `ConfigurationSnapshot` whose reason records the improvement ID, authorization reference, and qualification references.
+
+The function **does not append the snapshot to the ledger**. It therefore does not merge code, change the deployed configuration, deploy a release, actuate hardware, or perform an external action. Existing configuration-custody and authorized change paths remain the execution boundary.
+
+This separation creates the following traceable sequence:
+
+```text
+OMEGA DISCOVERY
+  -> WS-RI PROPOSAL
+  -> QUALIFICATION / RED-TEAM
+  -> HUMAN + PRIME AUTHORIZATION
+  -> PROMOTED RECORD
+  -> CONFIGURATION SNAPSHOT CANDIDATE
+  -> AUTHORIZED CUSTODY APPEND / CHANGE PROCESS
+  -> OBSERVATION / ECHO / OMEGA FEEDBACK
+```
+
 ## Initial standing doctrine encoded by WS-RI
 
 For every materially relevant new input, Worldshepherd should ask:
@@ -174,7 +236,9 @@ For every materially relevant new input, Worldshepherd should ask:
 
 ## Current implementation claim
 
-The v0.1 branch implements the **schema and deterministic validation-state logic** for the recursive improvement record, with unit tests for fail-closed boundaries, quarantine behavior, human-review gating, promotion-record requirements, rejection, and supersession.
+The v0.1 branch implements the **recursive improvement schema, deterministic validation-state logic, OMEGA-to-WS-RI translation, deterministic downstream routing, and promoted-record configuration-custody staging**.
+
+Unit tests cover fail-closed boundaries, quarantine behavior, human-review gating, promotion-record requirements, rejection, supersession, conservative evidence-state translation, non-inflation of capability maturity, routing gates, and configuration lineage staging.
 
 This does not establish:
 

--- a/deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md
+++ b/deployments/sara_verified_local_v1/docs/WS_RECURSIVE_IMPROVEMENT_V0_1.md
@@ -1,0 +1,189 @@
+# Worldshepherd Recursive Improvement Protocol v0.1
+
+## Purpose
+
+Worldshepherd Recursive Improvement (WS-RI) converts discoveries, failures, anomalies, requirement deltas, test results, research findings, partner feedback, security events, opportunities, and operator feedback into governed proposals for improving Worldshepherd itself.
+
+WS-RI is deliberately **not** a self-modifying execution engine. It is an auditable bridge between Worldshepherd's discovery/evidence systems and the existing human/PRIME authorization boundary.
+
+The governing sequence is:
+
+```text
+OBSERVE
+  -> CROSS-REFERENCE
+  -> DEFINE IMPROVEMENT DELTA
+  -> VALIDATE
+  -> HUMAN REVIEW / PRIME AUTHORIZATION
+  -> PROMOTE RECORD OR REJECT / QUARANTINE
+  -> IMPLEMENT THROUGH AN AUTHORIZED CHANGE PATH
+  -> MEASURE
+  -> FEED RESULTS BACK INTO ECHO / PRE / OMEGA
+```
+
+Promotion of an improvement record means the change is accepted as a governed improvement candidate/baseline decision. It does **not** itself deploy code, actuate hardware, contact a partner, submit a proposal, spend funds, or elevate a scientific or readiness claim.
+
+## Why this layer is needed
+
+Worldshepherd already contains complementary mechanisms:
+
+- **WS-OMEGA** recursively generates observations, hypotheses, contradictions, experiments, partner candidates, opportunities, standards gaps, prior-art checks, and risks while failing closed on claim promotion and external execution.
+- **PRE** records requirement deltas and keeps source status separate from capability maturity.
+- **Qualification Evidence** records test configuration, result, uncertainty, negative evidence, operator, review, and supersession state.
+- **ECHO** preserves provenance and evidence custody.
+- **PRIME SENTINEL** remains the authorization boundary for consequential execution.
+- **OVERWATCH / RED-TEAM / TEVV** provide monitoring, contradiction, risk, and verification routes.
+
+What was missing was a canonical record whose subject is explicitly: **"Worldshepherd should change in this way because of this evidence, with these risks and these validation gates."**
+
+WS-RI supplies that record without creating a parallel assurance system.
+
+## Canonical improvement record
+
+`ImprovementProposal` records:
+
+- stable improvement ID;
+- trigger kind;
+- source references;
+- affected Worldshepherd lanes;
+- baseline artifacts and capability state;
+- proposed change;
+- target capability status, if any;
+- expected benefit;
+- assumptions;
+- risks and risk level;
+- required validation tests;
+- success metrics;
+- retained negative evidence;
+- reversibility;
+- generator and creation timestamp;
+- lifecycle state;
+- identified-human review;
+- qualification references;
+- authorization reference.
+
+The object carries explicit false fields for self-authorized claim promotion and external execution. Setting either true fails validation.
+
+## Lifecycle
+
+```text
+PROPOSED
+   |
+   v
+VALIDATING ----------------------+
+   |                              |
+   | any required FAIL            | missing / inconclusive
+   v                              |
+QUARANTINED <---------------------+
+   |
+   | new evidence / revised proposal
+   v
+PROPOSED / VALIDATING
+
+VALIDATING
+   |
+   | all required tests PASS
+   v
+HUMAN_REVIEW_REQUIRED
+   |                    |
+   | reject             | accept + qualification refs
+   v                    | + authorization ref
+REJECTED                 v
+                       PROMOTED
+                          |
+                          | later stronger baseline
+                          v
+                      SUPERSEDED
+```
+
+No automated path leads directly from a generated proposal to `PROMOTED`.
+
+## Validation semantics
+
+`assess_improvement()` is fail-closed:
+
+1. Any required test `FAIL` -> `QUARANTINED`.
+2. Any required test missing or `INCONCLUSIVE` -> `VALIDATING`.
+3. Only complete PASS coverage -> `HUMAN_REVIEW_REQUIRED`.
+4. The assessment always records `claim_promotion_performed=false`.
+5. The assessment always records `external_execution_performed=false`.
+
+`record_human_decision()` can promote the record only when:
+
+- the record is already in `HUMAN_REVIEW_REQUIRED`;
+- an identified reviewer is present;
+- a review rationale is present;
+- qualification evidence references are present;
+- an authorization reference is present.
+
+The function records governance state only; execution remains outside this module.
+
+## Claims and evidence rules
+
+WS-RI inherits the strictest existing Worldshepherd claims boundary:
+
+- A prediction is preparation, not evidence of capability.
+- Software implementation is not evidence of physical performance.
+- Literature support is not internal validation.
+- Simulation is not physical validation.
+- Partner marketing material or outreach is not partner validation.
+- Administrative controls do not establish external certification, authorization, clearance, CMMC status, NIST 800-171 conformity, or operational readiness.
+- Failed, anomalous, contradictory, revoked, and superseded evidence must remain traceable.
+- Cross-domain reuse is a hypothesis until the reused capability passes the receiving lane's own validation gates.
+
+## Integration routes
+
+Recommended producer routes into WS-RI:
+
+| Producer | Improvement trigger examples |
+| --- | --- |
+| WS-OMEGA | contradiction, negative space, experiment, risk, cross-domain discovery |
+| PRE | requirement delta, recurring demand, standards gap |
+| TEVV / QE | pass, fail, uncertainty shift, regression |
+| ECHO | provenance conflict, stale evidence, custody anomaly |
+| PRIME | authorization-policy gap, denied action pattern |
+| OVERWATCH | operational anomaly, reliability degradation |
+| Partner screening | validated external feedback or integration constraint |
+| Security | vulnerability, configuration drift, control failure |
+| Human operator | correction, new objective, observed workflow deficiency |
+
+Recommended downstream routes from an accepted improvement record:
+
+```text
+software change -> branch / tests / CI / review / authorized merge
+model change    -> benchmark / ablation / TEVV / review
+physical design -> simulation / coupon or prototype test / independent measurement / review
+claims change   -> evidence graph / claims-boundary review / human approval
+opportunity     -> PRE / partner screening / capture review
+security        -> containment / verification / authorized remediation
+```
+
+## Initial standing doctrine encoded by WS-RI
+
+For every materially relevant new input, Worldshepherd should ask:
+
+1. What existing requirements, claims, designs, tests, partners, opportunities, and risks does this touch?
+2. Does it support, contradict, supersede, or leave prior evidence unchanged?
+3. Is there a reusable cross-domain capability here?
+4. What exact improvement is proposed?
+5. What assumptions could make that improvement wrong?
+6. What falsification or qualification tests are required?
+7. What negative evidence must be preserved?
+8. Is the proposed change reversible?
+9. What human/PRIME authorization is required before promotion or execution?
+10. After implementation, what measurement feeds the result back into the next cycle?
+
+## Current implementation claim
+
+The v0.1 branch implements the **schema and deterministic validation-state logic** for the recursive improvement record, with unit tests for fail-closed boundaries, quarantine behavior, human-review gating, promotion-record requirements, rejection, and supersession.
+
+This does not establish:
+
+- autonomous self-modification of a deployed Worldshepherd host;
+- continuous scheduler operation;
+- automatic merging or deployment;
+- physical validation of any technology;
+- autonomous external communication or action;
+- certification or government authorization;
+- improved mission performance until the affected lane is separately tested.
+
+Those remain separate evidence and authorization gates.

--- a/deployments/sara_verified_local_v1/docs/WS_RI_CHECKPOINT_FEEDBACK_V0_1.md
+++ b/deployments/sara_verified_local_v1/docs/WS_RI_CHECKPOINT_FEEDBACK_V0_1.md
@@ -1,0 +1,56 @@
+# WS-RI Checkpoint and Bounded Feedback Increment v0.1
+
+## Purpose
+
+This increment extends Worldshepherd Recursive Improvement in two bounded directions:
+
+1. checkpoint the WS-RI lifecycle ledger into ECHO provenance custody and verify later inclusion in an ECHO signed checkpoint;
+2. run finite, resumable ECHO-to-WS-RI feedback cycles without granting claim-promotion, deployment, external-execution, or physical-actuation authority.
+
+It reuses the existing WS-RI lifecycle, ECHO semantic event store, and ECHO signed checkpoint chain rather than creating a parallel trust system.
+
+## Ledger custody
+
+`ImprovementLedger` persists lifecycle records in SQLite. Each entry chains to the prior global record and the prior record for the same improvement ID. The ledger enforces allowed lifecycle transitions, deduplicates exact proposal replay, and recomputes proposal and record digests during chain verification.
+
+This is application-level custody evidence. It is not by itself evidence of immutable/WORM retention, external anchoring, third-party attestation, certification, or deployment authority.
+
+## Operational evidence bridge
+
+Ordinary ECHO traffic does not become an improvement proposal. An accepted audit event must carry an explicit `_ws_improvement_signal` object before `operational_improvement.py` will translate it.
+
+The adapter preserves ECHO event identity and semantic digest, defaults unspecified capability maturity to `NOT_CURRENTLY_CLAIMED`, leaves target maturity unset, and emits only `PROPOSED` records. An `OVERWATCH` source label remains a producer-contract label and is not proof of a separately validated runtime.
+
+## Ledger checkpoint into ECHO
+
+`build_ledger_checkpoint()` requires a non-empty, verifying WS-RI ledger and records the current record count, head sequence, head record digest, state counts, timestamp, claims boundary, and canonical checkpoint digest.
+
+`build_ledger_checkpoint_event()` wraps the checkpoint in an ECHO-valid audit event using the existing stable outbox ID and `AT_LEAST_ONCE` delivery contract. The event deliberately does not contain `_ws_improvement_signal`, preventing the custody checkpoint from becoming its own new improvement candidate.
+
+`ingest_ledger_checkpoint_into_echo()` establishes ECHO provenance custody only. `verify_signed_echo_membership()` first invokes the existing ECHO checkpoint verifier with a trusted key fingerprint and then requires exact event-ID and semantic-digest membership. Only that latter state is treated as locally signed ECHO inclusion.
+
+## Bounded feedback cycle
+
+`run_operational_feedback_cycle()` is a finite, resumable collector. Default bounds are 64 ECHO events scanned per cycle and 32 improvement proposals handled per cycle.
+
+The policy model fails closed if claim promotion, deployment, or external execution is enabled. Ordinary events advance the cursor without creating proposals. Explicit signals are translated to `PROPOSED` records and appended or deduplicated in the WS-RI ledger. If the proposal budget is reached, the cursor stops before the deferred signal so the next cycle can process it.
+
+The module is not a background daemon. Repeated execution requires an existing authorized scheduler or operator.
+
+## Claims boundary
+
+The resulting software path is:
+
+```text
+ECHO accepted events
+  -> bounded feedback cycle
+  -> explicit WS-RI proposal
+  -> lifecycle ledger
+  -> qualification / human + PRIME review
+  -> governed state transition
+  -> ledger checkpoint
+  -> ECHO provenance event
+  -> verified signed ECHO checkpoint
+```
+
+No step in this increment authorizes automatic claim elevation, merge, deployment, partner contact, purchasing, proposal submission, physical actuation, or other consequential external execution.

--- a/deployments/sara_verified_local_v1/pyproject.toml
+++ b/deployments/sara_verified_local_v1/pyproject.toml
@@ -53,6 +53,7 @@ ws-nsb-g13 = "worldshepherd_sara.nsb_g13_cli:main"
 ws-nsb-g14 = "worldshepherd_sara.nsb_g14_cli:main"
 ws-nsb-g15 = "worldshepherd_sara.nsb_g15_cli:main"
 ws-omega-recursion = "worldshepherd_sara.recursive_discovery_cli:main"
+ws-ri-runtime = "worldshepherd_sara.improvement_runtime_cli:main"
 
 [tool.setuptools]
 packages = ["worldshepherd_sara"]

--- a/deployments/sara_verified_local_v1/tests/test_evidence_improvement.py
+++ b/deployments/sara_verified_local_v1/tests/test_evidence_improvement.py
@@ -1,0 +1,109 @@
+from worldshepherd_sara.evidence_improvement import evidence_to_improvement
+from worldshepherd_sara.improvement_cycle import ImprovementRisk, ImprovementState, ImprovementTriggerKind
+from worldshepherd_sara.improvement_routing import ImprovementRoute, route_improvement
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    EvidenceScope,
+    QualificationEvidenceRecord,
+    ResultStatus,
+    ReviewRecord,
+    ReviewStatus,
+)
+
+
+def make_record(**overrides):
+    payload = {
+        "qualification_id": "WS-QE-2026-9100",
+        "requirement_id": "PRE-RD-2026-9001",
+        "test_id": "ddil-rejoin-qualification",
+        "evidence_scope": EvidenceScope.SOFTWARE,
+        "capability_status": CapabilityStatus.IMPLEMENTED_IN_SOFTWARE,
+        "environment_digest": "sha256:environment",
+        "configuration_digest": "sha256:configuration",
+        "inputs": [{"scenario": "partition-rejoin"}],
+        "outputs": [{"event_count": 10}],
+        "metrics": [{"integrity": 1.0}],
+        "uncertainty": [{"clock_skew_ms": 2.0}],
+        "result": ResultStatus.FAIL,
+        "rationale": "One required integrity assertion failed.",
+        "negative_evidence": [{"failed_assertion": "event-order-preserved"}],
+        "software_commit": "deadbeef",
+        "executed_utc": "2026-09-12T21:20:00Z",
+        "operator": "CI",
+        "physical_validation_performed": False,
+        "review": ReviewRecord(status=ReviewStatus.UNREVIEWED),
+    }
+    payload.update(overrides)
+    return QualificationEvidenceRecord(**payload)
+
+
+def test_failed_evidence_creates_high_risk_failure_candidate_and_preserves_negative_evidence():
+    record = make_record()
+    proposal = evidence_to_improvement(
+        record,
+        created_utc="2026-09-12T21:30:00Z",
+        affected_lanes=["DDIL"],
+    )
+
+    assert proposal.state == ImprovementState.PROPOSED
+    assert proposal.trigger_kind == ImprovementTriggerKind.FAILURE
+    assert proposal.risk_level == ImprovementRisk.HIGH
+    assert proposal.baseline_capability_status == [CapabilityStatus.IMPLEMENTED_IN_SOFTWARE]
+    assert proposal.target_capability_status is None
+    assert {"failed_assertion": "event-order-preserved"} in proposal.negative_evidence
+    assert f"{record.qualification_id}:root-cause-gate" in proposal.required_tests
+    assert not proposal.requested_claim_promotion
+    assert not proposal.requested_external_execution
+
+
+def test_inconclusive_evidence_requires_uncertainty_resolution_without_directional_claim():
+    record = make_record(result=ResultStatus.INCONCLUSIVE, negative_evidence=[])
+    proposal = evidence_to_improvement(
+        record,
+        created_utc="2026-09-12T21:30:00Z",
+    )
+
+    assert proposal.trigger_kind == ImprovementTriggerKind.TEST_RESULT
+    assert proposal.risk_level == ImprovementRisk.MODERATE
+    assert f"{record.qualification_id}:uncertainty-resolution-gate" in proposal.required_tests
+    assert any("no directional capability conclusion" in risk for risk in proposal.risks)
+
+
+def test_passing_evidence_remains_scoped_and_does_not_auto_promote_maturity():
+    record = make_record(
+        result=ResultStatus.PASS,
+        review=ReviewRecord(
+            status=ReviewStatus.ACCEPTED,
+            reviewer="CRE1AWS",
+            reviewed_utc="2026-09-12T21:25:00Z",
+        ),
+        negative_evidence=[],
+    )
+    proposal = evidence_to_improvement(
+        record,
+        created_utc="2026-09-12T21:30:00Z",
+    )
+
+    assert proposal.trigger_kind == ImprovementTriggerKind.TEST_RESULT
+    assert proposal.risk_level == ImprovementRisk.LOW
+    assert proposal.baseline_capability_status == [CapabilityStatus.IMPLEMENTED_IN_SOFTWARE]
+    assert proposal.target_capability_status is None
+    assert "passing qualification result" in proposal.proposed_change
+
+
+def test_failure_feedback_routes_to_assurance_and_monitoring_without_execution_authority():
+    proposal = evidence_to_improvement(
+        make_record(),
+        created_utc="2026-09-12T21:30:00Z",
+        affected_lanes=["DDIL"],
+    )
+    envelope = route_improvement(proposal)
+
+    assert ImprovementRoute.ECHO in envelope.routes
+    assert ImprovementRoute.PRIME_TEVV in envelope.routes
+    assert ImprovementRoute.PRIME in envelope.routes
+    assert ImprovementRoute.OVERWATCH in envelope.routes
+    assert ImprovementRoute.RED_TEAM in envelope.routes
+    assert ImprovementRoute.CONFIG_CUSTODY not in envelope.routes
+    assert not envelope.deployment_authorized
+    assert not envelope.external_execution_performed

--- a/deployments/sara_verified_local_v1/tests/test_improvement_cycle.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_cycle.py
@@ -160,3 +160,32 @@ def test_promoted_improvement_can_be_superseded_without_erasure():
     superseded = supersede_improvement(promoted, superseded_by="WS-IR-2026-0002")
     assert superseded.state == ImprovementState.SUPERSEDED
     assert {"superseded_by": "WS-IR-2026-0002"} in superseded.negative_evidence
+
+
+def test_public_transition_revalidates_existing_forbidden_execution_flag():
+    proposal = make_proposal()
+    invalid = proposal.model_copy(update={"requested_external_execution": True})
+    assessment = assess_improvement(
+        invalid,
+        {
+            "test_schema": ResultStatus.PASS,
+            "test_fail_closed": ResultStatus.FAIL,
+        },
+    )
+    with pytest.raises(ValidationError):
+        apply_assessment(invalid, assessment)
+
+
+def test_human_transition_revalidates_existing_forbidden_claim_flag():
+    proposal = make_proposal(state=ImprovementState.HUMAN_REVIEW_REQUIRED)
+    invalid = proposal.model_copy(update={"requested_claim_promotion": True})
+    with pytest.raises(ValidationError):
+        record_human_decision(
+            invalid,
+            accepted=True,
+            reviewer="CRE1AWS",
+            reviewed_utc="2026-09-12T19:40:00Z",
+            rationale="Evidence accepted.",
+            qualification_refs=["WS-QE-2026-0001"],
+            authorization_ref="PRIME-AUTH-1",
+        )

--- a/deployments/sara_verified_local_v1/tests/test_improvement_cycle.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_cycle.py
@@ -1,0 +1,162 @@
+import pytest
+from pydantic import ValidationError
+
+from worldshepherd_sara.improvement_cycle import (
+    ImprovementProposal,
+    ImprovementRisk,
+    ImprovementState,
+    ImprovementTriggerKind,
+    apply_assessment,
+    assess_improvement,
+    record_human_decision,
+    supersede_improvement,
+)
+from worldshepherd_sara.qualification import CapabilityStatus, ResultStatus, ReviewStatus
+
+
+def make_proposal(**overrides):
+    payload = {
+        "improvement_id": "WS-IR-2026-0001",
+        "trigger_kind": ImprovementTriggerKind.NEW_EVIDENCE,
+        "title": "Cross-lane evidence feedback",
+        "source_refs": ["WS-OMEGA-abcdef0123456789", "PRE-RD-2026-0001"],
+        "affected_lanes": ["PRE", "ECHO", "PRIME"],
+        "baseline_artifacts": ["worldshepherd_sara/recursive_discovery.py"],
+        "baseline_capability_status": [CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        "target_capability_status": CapabilityStatus.IMPLEMENTED_IN_SOFTWARE,
+        "proposed_change": "Route qualified discoveries into an auditable improvement record.",
+        "expected_benefit": "Convert discoveries into testable, reversible improvement proposals.",
+        "assumptions": ["Existing qualification and authorization controls remain authoritative."],
+        "risks": ["A weak source could produce a low-value proposal."],
+        "risk_level": ImprovementRisk.MODERATE,
+        "required_tests": ["test_schema", "test_fail_closed"],
+        "success_metrics": ["schema validates", "claim and execution boundaries fail closed"],
+        "reversible": True,
+        "generated_by": "SARA",
+        "created_utc": "2026-09-12T19:30:00Z",
+    }
+    payload.update(overrides)
+    return ImprovementProposal(**payload)
+
+
+def test_proposal_fails_closed_on_self_authorized_claim_promotion():
+    with pytest.raises(ValidationError):
+        make_proposal(requested_claim_promotion=True)
+
+
+def test_proposal_fails_closed_on_self_authorized_external_execution():
+    with pytest.raises(ValidationError):
+        make_proposal(requested_external_execution=True)
+
+
+def test_missing_or_inconclusive_tests_keep_proposal_validating():
+    proposal = make_proposal()
+    assessment = assess_improvement(
+        proposal,
+        {"test_schema": ResultStatus.INCONCLUSIVE},
+    )
+    assert assessment.disposition == ImprovementState.VALIDATING
+    assert assessment.inconclusive_tests == ["test_schema"]
+    assert assessment.missing_tests == ["test_fail_closed"]
+    assert not assessment.claim_promotion_performed
+    assert not assessment.external_execution_performed
+
+
+def test_failed_required_test_quarantines_proposal():
+    proposal = make_proposal()
+    assessment = assess_improvement(
+        proposal,
+        {
+            "test_schema": ResultStatus.PASS,
+            "test_fail_closed": ResultStatus.FAIL,
+        },
+    )
+    assert assessment.disposition == ImprovementState.QUARANTINED
+    updated = apply_assessment(proposal, assessment)
+    assert updated.state == ImprovementState.QUARANTINED
+
+
+def test_all_required_tests_only_advance_to_human_review():
+    proposal = make_proposal()
+    assessment = assess_improvement(
+        proposal,
+        {
+            "test_schema": ResultStatus.PASS,
+            "test_fail_closed": ResultStatus.PASS,
+        },
+    )
+    assert assessment.disposition == ImprovementState.HUMAN_REVIEW_REQUIRED
+    updated = apply_assessment(proposal, assessment)
+    assert updated.state == ImprovementState.HUMAN_REVIEW_REQUIRED
+    assert updated.review.status == ReviewStatus.UNREVIEWED
+
+
+def test_accepted_human_decision_requires_qualification_and_authorization():
+    proposal = make_proposal(state=ImprovementState.HUMAN_REVIEW_REQUIRED)
+    with pytest.raises(ValueError):
+        record_human_decision(
+            proposal,
+            accepted=True,
+            reviewer="CRE1AWS",
+            reviewed_utc="2026-09-12T19:40:00Z",
+            rationale="Validation complete.",
+            qualification_refs=[],
+            authorization_ref="PRIME-AUTH-1",
+        )
+    with pytest.raises(ValueError):
+        record_human_decision(
+            proposal,
+            accepted=True,
+            reviewer="CRE1AWS",
+            reviewed_utc="2026-09-12T19:40:00Z",
+            rationale="Validation complete.",
+            qualification_refs=["WS-QE-2026-0001"],
+            authorization_ref=None,
+        )
+
+
+def test_human_accepted_proposal_can_be_promoted_as_record_not_executed():
+    proposal = make_proposal(state=ImprovementState.HUMAN_REVIEW_REQUIRED)
+    promoted = record_human_decision(
+        proposal,
+        accepted=True,
+        reviewer="CRE1AWS",
+        reviewed_utc="2026-09-12T19:40:00Z",
+        rationale="Evidence and bounded authorization accepted.",
+        qualification_refs=["WS-QE-2026-0001"],
+        authorization_ref="PRIME-AUTH-1",
+    )
+    assert promoted.state == ImprovementState.PROMOTED
+    assert promoted.review.status == ReviewStatus.ACCEPTED
+    assert promoted.review.reviewer == "CRE1AWS"
+    assert not promoted.requested_external_execution
+
+
+def test_human_rejection_preserves_record():
+    proposal = make_proposal(state=ImprovementState.HUMAN_REVIEW_REQUIRED)
+    rejected = record_human_decision(
+        proposal,
+        accepted=False,
+        reviewer="CRE1AWS",
+        reviewed_utc="2026-09-12T19:40:00Z",
+        rationale="Benefit did not justify residual risk.",
+        qualification_refs=["WS-QE-2026-0001"],
+    )
+    assert rejected.state == ImprovementState.REJECTED
+    assert rejected.review.status == ReviewStatus.REJECTED
+
+
+def test_promoted_improvement_can_be_superseded_without_erasure():
+    proposal = make_proposal(state=ImprovementState.HUMAN_REVIEW_REQUIRED)
+    promoted = record_human_decision(
+        proposal,
+        accepted=True,
+        reviewer="CRE1AWS",
+        reviewed_utc="2026-09-12T19:40:00Z",
+        rationale="Evidence and bounded authorization accepted.",
+        qualification_refs=["WS-QE-2026-0001"],
+        authorization_ref="PRIME-AUTH-1",
+    )
+    superseded = supersede_improvement(promoted, superseded_by="WS-IR-2026-0002")
+    assert superseded.state == ImprovementState.SUPERSEDED
+    assert {"superseded_by": "WS-IR-2026-0002"} in superseded.negative_evidence

--- a/deployments/sara_verified_local_v1/tests/test_improvement_handoff_export.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_handoff_export.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from worldshepherd_sara.echo_event_store import EchoEventStore
+from worldshepherd_sara.improvement_evidence_export import (
+    build_evidence_manifest,
+    manifest_matches_runtime,
+    verify_evidence_manifest,
+)
+from worldshepherd_sara.improvement_feedback import ImprovementFeedbackPolicy
+from worldshepherd_sara.improvement_handoff import (
+    ImprovementSchedulerHandoff,
+    build_scheduler_handoff,
+    verify_scheduler_handoff,
+)
+from worldshepherd_sara.improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
+from worldshepherd_sara.models import AuditRecord
+
+
+def signal(event_id: str) -> AuditRecord:
+    return AuditRecord(
+        timestamp="2026-09-12T21:00:00+00:00",
+        event="wsri_operational_signal",
+        actor="OVERWATCH",
+        payload={
+            "_outbox_event_id": event_id,
+            "_delivery_semantics": "AT_LEAST_ONCE",
+            "_ws_improvement_signal": {
+                "source": "OVERWATCH",
+                "trigger_kind": "OPERATOR_FEEDBACK",
+                "statement": "evaluate bounded operational evidence",
+                "affected_lanes": ["OVERWATCH"],
+                "required_tests": ["source-gate"],
+                "success_metrics": ["required validation passes"],
+                "risk_level": "MODERATE",
+            },
+        },
+    )
+
+
+def seeded_runtime(tmp_path) -> ImprovementRuntime:
+    wsri = (tmp_path / "wsri").resolve()
+    echo_dir = (tmp_path / "echo").resolve()
+    echo_dir.mkdir(mode=0o700)
+    echo = EchoEventStore(echo_dir)
+    echo.ingest(signal("SARA-EVENT-handoff-0001"))
+    runtime = ImprovementRuntime(wsri, echo_data_dir=echo_dir)
+    runtime.run_feedback_once(actor="operator")
+    return runtime
+
+
+def test_scheduler_handoff_is_verifiable_and_never_self_authorizes(tmp_path):
+    runtime = seeded_runtime(tmp_path)
+    handoff = build_scheduler_handoff(
+        runtime,
+        requested_by="operator",
+        generated_utc="2026-09-12T21:05:00+00:00",
+        policy=ImprovementFeedbackPolicy(
+            max_echo_events_per_cycle=8,
+            max_new_proposals_per_cycle=4,
+        ),
+    )
+    assert verify_scheduler_handoff(handoff) is True
+    assert handoff.execution_disposition.value == "HUMAN_REVIEW_REQUIRED"
+    assert handoff.authorization_required is True
+    assert handoff.autonomous_execution_authorized is False
+    assert handoff.claim_promotion_authorized is False
+    assert handoff.deployment_authorized is False
+    assert handoff.external_execution_authorized is False
+
+
+def test_scheduler_handoff_rejects_authority_escalation(tmp_path):
+    runtime = seeded_runtime(tmp_path)
+    handoff = build_scheduler_handoff(
+        runtime,
+        requested_by="operator",
+        generated_utc="2026-09-12T21:05:00+00:00",
+    )
+    data = handoff.model_dump(mode="json")
+    data["deployment_authorized"] = True
+    try:
+        ImprovementSchedulerHandoff.model_validate(data)
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("handoff must reject deployment authority")
+
+
+def test_scheduler_handoff_requires_echo_source(tmp_path):
+    runtime = ImprovementRuntime((tmp_path / "wsri").resolve())
+    try:
+        build_scheduler_handoff(
+            runtime,
+            requested_by="operator",
+            generated_utc="2026-09-12T21:05:00+00:00",
+        )
+    except ImprovementRuntimeError as exc:
+        assert "ECHO source" in str(exc)
+    else:
+        raise AssertionError("feedback handoff must require ECHO source")
+
+
+def test_evidence_manifest_verifies_and_matches_runtime(tmp_path):
+    runtime = seeded_runtime(tmp_path)
+    manifest = build_evidence_manifest(
+        runtime,
+        generated_utc="2026-09-12T21:06:00+00:00",
+    )
+    assert verify_evidence_manifest(manifest) is True
+    assert manifest_matches_runtime(manifest, runtime) is True
+    assert manifest.record_count == 1
+    assert manifest.ledger_chain_verified is True
+    assert manifest.claim_promotion_performed is False
+    assert manifest.deployment_performed is False
+
+
+def test_manifest_detects_tampering_and_runtime_drift(tmp_path):
+    runtime = seeded_runtime(tmp_path)
+    manifest = build_evidence_manifest(
+        runtime,
+        generated_utc="2026-09-12T21:06:00+00:00",
+    )
+    tampered = manifest.model_copy(update={"record_count": 999})
+    assert verify_evidence_manifest(tampered) is False
+
+    echo = runtime.echo_store
+    assert echo is not None
+    echo.ingest(signal("SARA-EVENT-handoff-0002"))
+    runtime.run_feedback_once(actor="operator")
+    assert manifest_matches_runtime(manifest, runtime) is False
+
+
+def test_empty_runtime_can_emit_evidence_manifest(tmp_path):
+    runtime = ImprovementRuntime((tmp_path / "wsri").resolve())
+    manifest = build_evidence_manifest(
+        runtime,
+        generated_utc="2026-09-12T21:06:00+00:00",
+    )
+    assert manifest.record_count == 0
+    assert manifest.head_record_digest is None
+    assert verify_evidence_manifest(manifest) is True

--- a/deployments/sara_verified_local_v1/tests/test_improvement_handoff_export.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_handoff_export.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 
 from worldshepherd_sara.echo_event_store import EchoEventStore
 from worldshepherd_sara.improvement_evidence_export import (
+    ImprovementEvidenceManifest,
     build_evidence_manifest,
     manifest_matches_runtime,
     verify_evidence_manifest,
@@ -110,6 +111,7 @@ def test_evidence_manifest_verifies_and_matches_runtime(tmp_path):
     assert verify_evidence_manifest(manifest) is True
     assert manifest_matches_runtime(manifest, runtime) is True
     assert manifest.record_count == 1
+    assert manifest.record_sequences == [1]
     assert manifest.ledger_chain_verified is True
     assert manifest.claim_promotion_performed is False
     assert manifest.deployment_performed is False
@@ -131,6 +133,47 @@ def test_manifest_detects_tampering_and_runtime_drift(tmp_path):
     assert manifest_matches_runtime(manifest, runtime) is False
 
 
+def test_manifest_model_rejects_semantic_authority_escalation(tmp_path):
+    runtime = seeded_runtime(tmp_path)
+    manifest = build_evidence_manifest(
+        runtime,
+        generated_utc="2026-09-12T21:06:00+00:00",
+    )
+    data = manifest.model_dump(mode="json")
+    data["claim_promotion_performed"] = True
+    try:
+        ImprovementEvidenceManifest.model_validate(data)
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("manifest must reject claim-promotion assertions")
+
+
+def test_manifest_model_rejects_inconsistent_sequence_or_state_counts(tmp_path):
+    runtime = seeded_runtime(tmp_path)
+    manifest = build_evidence_manifest(
+        runtime,
+        generated_utc="2026-09-12T21:06:00+00:00",
+    )
+    bad_sequence = manifest.model_dump(mode="json")
+    bad_sequence["record_sequences"] = [5]
+    with_validation_error = False
+    try:
+        ImprovementEvidenceManifest.model_validate(bad_sequence)
+    except ValidationError:
+        with_validation_error = True
+    assert with_validation_error is True
+
+    bad_counts = manifest.model_dump(mode="json")
+    bad_counts["state_counts"] = {"PROPOSED": 2}
+    with_validation_error = False
+    try:
+        ImprovementEvidenceManifest.model_validate(bad_counts)
+    except ValidationError:
+        with_validation_error = True
+    assert with_validation_error is True
+
+
 def test_empty_runtime_can_emit_evidence_manifest(tmp_path):
     runtime = ImprovementRuntime((tmp_path / "wsri").resolve())
     manifest = build_evidence_manifest(
@@ -138,5 +181,6 @@ def test_empty_runtime_can_emit_evidence_manifest(tmp_path):
         generated_utc="2026-09-12T21:06:00+00:00",
     )
     assert manifest.record_count == 0
+    assert manifest.record_sequences == []
     assert manifest.head_record_digest is None
     assert verify_evidence_manifest(manifest) is True

--- a/deployments/sara_verified_local_v1/tests/test_improvement_ledger_checkpoint.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_ledger_checkpoint.py
@@ -1,0 +1,161 @@
+import sqlite3
+
+import pytest
+
+from worldshepherd_sara.echo_checkpoint import EchoCheckpointManager
+from worldshepherd_sara.echo_event_store import EchoEventStore
+from worldshepherd_sara.improvement_checkpoint import (
+    ImprovementCheckpointError,
+    build_ledger_checkpoint,
+    build_ledger_checkpoint_event,
+    ingest_ledger_checkpoint_into_echo,
+    verify_signed_echo_membership,
+    verify_stored_ledger_checkpoint,
+)
+from worldshepherd_sara.improvement_cycle import (
+    ImprovementProposal,
+    ImprovementRisk,
+    ImprovementState,
+    ImprovementTriggerKind,
+    apply_assessment,
+    assess_improvement,
+    record_human_decision,
+)
+from worldshepherd_sara.improvement_ledger import ImprovementLedger, ImprovementLedgerError
+from worldshepherd_sara.qualification import CapabilityStatus, ResultStatus
+
+
+def proposal(improvement_id="WS-IR-2026-9101"):
+    return ImprovementProposal(
+        improvement_id=improvement_id,
+        trigger_kind=ImprovementTriggerKind.NEW_EVIDENCE,
+        title="ledger candidate",
+        source_refs=["SRC-LEDGER"],
+        affected_lanes=["ECHO", "WS-RI"],
+        baseline_capability_status=[CapabilityStatus.NOT_CURRENTLY_CLAIMED],
+        proposed_change="Evaluate a bounded candidate.",
+        expected_benefit="Preserve lifecycle custody.",
+        risk_level=ImprovementRisk.MODERATE,
+        required_tests=["gate-a"],
+        success_metrics=["gate-a passes"],
+        generated_by="test",
+        created_utc="2026-09-12T20:00:00Z",
+    )
+
+
+def append(ledger, item, reason="seed"):
+    return ledger.append(
+        item,
+        actor="CRE1AWS",
+        recorded_utc="2026-09-12T20:01:00Z",
+        reason=reason,
+    )
+
+
+def test_ledger_records_valid_lifecycle_and_verifies_chain(tmp_path):
+    ledger = ImprovementLedger(tmp_path.resolve())
+    item = proposal()
+    append(ledger, item)
+    reviewable = apply_assessment(
+        item,
+        assess_improvement(item, {"gate-a": ResultStatus.PASS}),
+    )
+    append(ledger, reviewable, "qualification passed")
+    promoted = record_human_decision(
+        reviewable,
+        accepted=True,
+        reviewer="CRE1AWS",
+        reviewed_utc="2026-09-12T20:02:00Z",
+        rationale="Bounded qualification accepted.",
+        qualification_refs=["WS-QE-2026-9101"],
+        authorization_ref="PRIME-AUTH-9101",
+    )
+    append(ledger, promoted, "authorization recorded")
+    assert ledger.verify_chain()
+    assert ledger.latest(item.improvement_id).state == ImprovementState.PROMOTED.value
+
+
+def test_replay_deduplicates_and_same_state_rewrite_fails(tmp_path):
+    ledger = ImprovementLedger(tmp_path.resolve())
+    item = proposal()
+    first = append(ledger, item)
+    second = append(ledger, item)
+    assert second.outcome == "DEDUPLICATED"
+    assert first.record.record_digest == second.record.record_digest
+    changed = item.model_copy(update={"expected_benefit": "changed content"})
+    with pytest.raises(ImprovementLedgerError):
+        append(ledger, changed)
+
+
+def test_tampering_breaks_ledger_verification(tmp_path):
+    ledger = ImprovementLedger(tmp_path.resolve())
+    append(ledger, proposal())
+    connection = sqlite3.connect(ledger.db_path)
+    try:
+        connection.execute("UPDATE wsri_records SET reason='tampered' WHERE sequence=1")
+        connection.commit()
+    finally:
+        connection.close()
+    assert not ledger.verify_chain()
+
+
+def test_checkpoint_requires_nonempty_valid_ledger(tmp_path):
+    ledger = ImprovementLedger(tmp_path.resolve())
+    with pytest.raises(ImprovementCheckpointError):
+        build_ledger_checkpoint(ledger, created_utc="2026-09-12T20:03:00Z")
+    append(ledger, proposal())
+    checkpoint = build_ledger_checkpoint(
+        ledger, created_utc="2026-09-12T20:03:00Z"
+    )
+    assert checkpoint.record_count == 1
+    assert checkpoint.state_counts == {"PROPOSED": 1}
+
+
+def test_checkpoint_event_is_not_a_feedback_signal(tmp_path):
+    ledger = ImprovementLedger(tmp_path.resolve())
+    append(ledger, proposal())
+    record, checkpoint = build_ledger_checkpoint_event(
+        ledger,
+        event_id="SARA-EVENT-wsri-ledger-anchor-1",
+        actor="SARA",
+        timestamp="2026-09-12T20:04:00+00:00",
+    )
+    assert "_ws_improvement_signal" not in record.payload
+    assert (
+        record.payload["_ws_ri_ledger_checkpoint"]["checkpoint_digest"]
+        == checkpoint.checkpoint_digest
+    )
+
+
+def test_echo_ingest_and_signed_membership_verification(
+    tmp_path, echo_checkpoint_key
+):
+    key, _path = echo_checkpoint_key
+    ledger_root = tmp_path / "ledger"
+    ledger = ImprovementLedger(ledger_root.resolve())
+    append(ledger, proposal())
+    echo_root = tmp_path / "echo"
+    echo_root.mkdir(mode=0o700)
+    store = EchoEventStore(echo_root.resolve())
+    result, checkpoint = ingest_ledger_checkpoint_into_echo(
+        store,
+        ledger,
+        event_id="SARA-EVENT-wsri-ledger-anchor-2",
+        actor="SARA",
+        timestamp="2026-09-12T20:05:00+00:00",
+    )
+    assert verify_stored_ledger_checkpoint(result.record, checkpoint)
+    manager = EchoCheckpointManager(
+        store,
+        private_key=key,
+        key_id="WS-RI-CHECKPOINT-TEST-V1",
+    )
+    bundle = manager.create_checkpoint()
+    summary = verify_signed_echo_membership(
+        bundle,
+        trusted_fingerprint_sha256=manager.fingerprint_sha256,
+        event_id=result.record.event_id,
+        semantic_digest=result.record.semantic_sha256,
+    )
+    assert summary["status"] == "PASS"
+    assert summary["echo_checkpoint_id"] == bundle["manifest"]["checkpoint_id"]

--- a/deployments/sara_verified_local_v1/tests/test_improvement_routing.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_routing.py
@@ -1,0 +1,177 @@
+import pytest
+
+from worldshepherd_sara.config_custody import ConfigurationCustodyLedger, create_snapshot
+from worldshepherd_sara.improvement_cycle import (
+    ImprovementState,
+    apply_assessment,
+    assess_improvement,
+    record_human_decision,
+)
+from worldshepherd_sara.improvement_routing import (
+    ImprovementRoute,
+    build_promoted_configuration_snapshot,
+    omega_to_improvement,
+    route_improvement,
+)
+from worldshepherd_sara.qualification import CapabilityStatus, ResultStatus
+from worldshepherd_sara.recursive_discovery import (
+    DiscoveryEvidenceState,
+    DiscoveryKind,
+    make_seed,
+)
+
+
+def make_node(**overrides):
+    payload = {
+        "kind": DiscoveryKind.CONTRADICTION,
+        "domain": "APNT",
+        "statement": "A new source conflicts with the current integration assumption.",
+        "source_refs": ["source:official:example"],
+        "confidence": 0.82,
+        "evidence_state": DiscoveryEvidenceState.CORROBORATED,
+        "cross_domain_tags": ["DDIL", "sensor-fusion"],
+        "falsification_tests": ["reproduce-conflict", "compare-baseline"],
+    }
+    payload.update(overrides)
+    return make_seed(**payload)
+
+
+def promote(proposal):
+    assessment = assess_improvement(
+        proposal,
+        {test_id: ResultStatus.PASS for test_id in proposal.required_tests},
+    )
+    ready = apply_assessment(proposal, assessment)
+    assert ready.state == ImprovementState.HUMAN_REVIEW_REQUIRED
+    return record_human_decision(
+        ready,
+        accepted=True,
+        reviewer="CRE1AWS",
+        reviewed_utc="2026-09-12T20:20:00Z",
+        rationale="Required validation passed and bounded configuration staging is authorized.",
+        qualification_refs=["WS-QE-2026-9001"],
+        authorization_ref="PRIME-AUTH-WSRI-9001",
+    )
+
+
+def test_omega_translation_is_deterministic_and_preserves_lineage():
+    node = make_node()
+    first = omega_to_improvement(node, created_utc="2026-09-12T20:00:00Z")
+    second = omega_to_improvement(node, created_utc="2026-09-12T21:00:00Z")
+
+    assert first.improvement_id == second.improvement_id
+    assert first.source_refs[0] == node.node_id
+    assert "source:official:example" in first.source_refs
+    assert first.generated_by == "WS-OMEGA->WS-RI"
+    assert not first.requested_claim_promotion
+    assert not first.requested_external_execution
+
+
+def test_translation_does_not_inflate_capability_maturity():
+    unverified = make_node(evidence_state=DiscoveryEvidenceState.UNVERIFIED)
+    simulated = make_node(evidence_state=DiscoveryEvidenceState.SIMULATED)
+
+    unverified_proposal = omega_to_improvement(
+        unverified, created_utc="2026-09-12T20:00:00Z"
+    )
+    simulated_proposal = omega_to_improvement(
+        simulated, created_utc="2026-09-12T20:00:00Z"
+    )
+
+    assert unverified_proposal.baseline_capability_status == [
+        CapabilityStatus.NOT_CURRENTLY_CLAIMED
+    ]
+    assert simulated_proposal.baseline_capability_status == [
+        CapabilityStatus.SIMULATED_ONLY
+    ]
+    assert unverified_proposal.target_capability_status is None
+    assert simulated_proposal.target_capability_status is None
+
+
+def test_translation_requires_evidence_and_red_team_gates():
+    node = make_node(falsification_tests=[])
+    proposal = omega_to_improvement(node, created_utc="2026-09-12T20:00:00Z")
+
+    assert f"{node.node_id}:source-evidence-gate" in proposal.required_tests
+    assert f"{node.node_id}:red-team-gate" in proposal.required_tests
+
+
+def test_pre_promotion_routing_excludes_configuration_custody():
+    proposal = omega_to_improvement(
+        make_node(), created_utc="2026-09-12T20:00:00Z"
+    )
+    envelope = route_improvement(proposal)
+
+    assert ImprovementRoute.ECHO in envelope.routes
+    assert ImprovementRoute.OMEGA in envelope.routes
+    assert ImprovementRoute.PRIME_TEVV in envelope.routes
+    assert ImprovementRoute.PRIME in envelope.routes
+    assert ImprovementRoute.OVERWATCH in envelope.routes
+    assert ImprovementRoute.RED_TEAM in envelope.routes
+    assert ImprovementRoute.CONFIG_CUSTODY not in envelope.routes
+    assert not envelope.custody_eligible
+    assert not envelope.deployment_authorized
+    assert not envelope.external_execution_performed
+
+
+def test_promoted_routing_becomes_custody_eligible_but_not_deployment_authorized():
+    proposal = omega_to_improvement(
+        make_node(), created_utc="2026-09-12T20:00:00Z"
+    )
+    promoted = promote(proposal)
+    envelope = route_improvement(promoted)
+
+    assert ImprovementRoute.CONFIG_CUSTODY in envelope.routes
+    assert envelope.custody_eligible
+    assert not envelope.deployment_authorized
+    assert "WS-QE-2026-9001" in envelope.lineage_refs
+
+
+def test_configuration_snapshot_rejects_unpromoted_improvement():
+    proposal = omega_to_improvement(
+        make_node(), created_utc="2026-09-12T20:00:00Z"
+    )
+    with pytest.raises(ValueError):
+        build_promoted_configuration_snapshot(
+            proposal,
+            candidate_payload={"version": 2},
+            snapshot_id="cfg-2",
+            created_utc="2026-09-12T20:30:00Z",
+            actor="CRE1AWS",
+            parent_digest=None,
+        )
+
+
+def test_promoted_improvement_stages_appendable_configuration_lineage():
+    proposal = omega_to_improvement(
+        make_node(), created_utc="2026-09-12T20:00:00Z"
+    )
+    promoted = promote(proposal)
+
+    ledger = ConfigurationCustodyLedger()
+    baseline = create_snapshot(
+        snapshot_id="cfg-1",
+        payload={"version": 1, "mode": "baseline"},
+        created_utc="2026-09-12T19:00:00Z",
+        actor="CRE1AWS",
+        reason="test baseline",
+    )
+    ledger.append(baseline)
+
+    candidate = build_promoted_configuration_snapshot(
+        promoted,
+        candidate_payload={"version": 2, "mode": "candidate"},
+        snapshot_id="cfg-2",
+        created_utc="2026-09-12T20:30:00Z",
+        actor="CRE1AWS",
+        parent_digest=baseline.digest,
+    )
+
+    assert candidate.parent_digest == baseline.digest
+    assert promoted.improvement_id in candidate.reason
+    assert "PRIME-AUTH-WSRI-9001" in candidate.reason
+    assert "WS-QE-2026-9001" in candidate.reason
+
+    ledger.append(candidate)
+    assert ledger.head() == candidate
+    assert ledger.verify_chain()

--- a/deployments/sara_verified_local_v1/tests/test_improvement_runtime.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_runtime.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from worldshepherd_sara.echo_event_store import EchoEventStore
+from worldshepherd_sara.improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
+from worldshepherd_sara.models import AuditRecord
+
+
+def operational_signal(event_id: str) -> AuditRecord:
+    return AuditRecord(
+        timestamp="2026-09-12T20:00:00+00:00",
+        event="wsri_operational_signal",
+        actor="OVERWATCH",
+        payload={
+            "_outbox_event_id": event_id,
+            "_delivery_semantics": "AT_LEAST_ONCE",
+            "_ws_improvement_signal": {
+                "trigger_kind": "OPERATOR_FEEDBACK",
+                "title": "Operational improvement input",
+                "affected_lanes": ["OVERWATCH", "WS-RI"],
+                "proposed_change": "evaluate the recorded operational improvement input",
+                "expected_benefit": "improve the affected workflow after validation",
+                "required_tests": ["source-gate"],
+                "success_metrics": ["required validation passes"],
+                "risk_level": "MODERATE",
+                "source_refs": [event_id],
+            },
+        },
+    )
+
+
+def test_runtime_cursor_survives_restart(tmp_path):
+    wsri = (tmp_path / "wsri").resolve()
+    echo_dir = (tmp_path / "echo").resolve()
+    echo_dir.mkdir(mode=0o700)
+    echo = EchoEventStore(echo_dir)
+    echo.ingest(operational_signal("SARA-EVENT-runtime-0001"))
+
+    runtime = ImprovementRuntime(wsri, echo_data_dir=echo_dir)
+    report = runtime.run_feedback_once(actor="admin")
+    assert report.proposals_stored == 1
+    assert report.claim_promotion_performed is False
+    assert report.deployment_performed is False
+
+    cursor = runtime.load_cursor()
+    restarted = ImprovementRuntime(wsri, echo_data_dir=echo_dir)
+    assert restarted.load_cursor() == cursor
+    assert restarted.status()["ledger_chain_verified"] is True
+    assert restarted.status()["record_count"] == 1
+
+
+def test_runtime_checkpoint_payload_preserves_claims_boundary(tmp_path):
+    wsri = (tmp_path / "wsri").resolve()
+    echo_dir = (tmp_path / "echo").resolve()
+    echo_dir.mkdir(mode=0o700)
+    echo = EchoEventStore(echo_dir)
+    echo.ingest(operational_signal("SARA-EVENT-runtime-0002"))
+    runtime = ImprovementRuntime(wsri, echo_data_dir=echo_dir)
+    runtime.run_feedback_once(actor="admin")
+
+    payload = runtime.checkpoint_outbox_payload(created_utc="2026-09-12T20:05:00+00:00")
+    assert payload["anchor_schema"] == "WS-RI-LEDGER-ECHO-ANCHOR-V1"
+    assert "signed inclusion require" in payload["claims_boundary"]
+    records = runtime.export_records(limit=1)
+    assert records[0]["state"] == "PROPOSED"
+
+
+def test_runtime_requires_echo_source_for_feedback(tmp_path):
+    runtime = ImprovementRuntime((tmp_path / "wsri").resolve())
+    try:
+        runtime.run_feedback_once(actor="admin")
+    except ImprovementRuntimeError as exc:
+        assert "ECHO source" in str(exc)
+    else:
+        raise AssertionError("feedback must require configured ECHO source")

--- a/deployments/sara_verified_local_v1/tests/test_improvement_runtime.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from worldshepherd_sara.echo_event_store import EchoEventStore
 from worldshepherd_sara.improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
 from worldshepherd_sara.models import AuditRecord
@@ -14,15 +16,13 @@ def operational_signal(event_id: str) -> AuditRecord:
             "_outbox_event_id": event_id,
             "_delivery_semantics": "AT_LEAST_ONCE",
             "_ws_improvement_signal": {
+                "source": "OVERWATCH",
                 "trigger_kind": "OPERATOR_FEEDBACK",
-                "title": "Operational improvement input",
+                "statement": "evaluate the recorded operational improvement input",
                 "affected_lanes": ["OVERWATCH", "WS-RI"],
-                "proposed_change": "evaluate the recorded operational improvement input",
-                "expected_benefit": "improve the affected workflow after validation",
                 "required_tests": ["source-gate"],
                 "success_metrics": ["required validation passes"],
                 "risk_level": "MODERATE",
-                "source_refs": [event_id],
             },
         },
     )
@@ -46,6 +46,7 @@ def test_runtime_cursor_survives_restart(tmp_path):
     assert restarted.load_cursor() == cursor
     assert restarted.status()["ledger_chain_verified"] is True
     assert restarted.status()["record_count"] == 1
+    assert restarted.status()["feedback_cursor_digest"]
 
 
 def test_runtime_checkpoint_payload_preserves_claims_boundary(tmp_path):
@@ -72,3 +73,24 @@ def test_runtime_requires_echo_source_for_feedback(tmp_path):
         assert "ECHO source" in str(exc)
     else:
         raise AssertionError("feedback must require configured ECHO source")
+
+
+def test_runtime_rejects_tampered_cursor_state(tmp_path):
+    wsri = (tmp_path / "wsri").resolve()
+    echo_dir = (tmp_path / "echo").resolve()
+    echo_dir.mkdir(mode=0o700)
+    echo = EchoEventStore(echo_dir)
+    echo.ingest(operational_signal("SARA-EVENT-runtime-0003"))
+    runtime = ImprovementRuntime(wsri, echo_data_dir=echo_dir)
+    runtime.run_feedback_once(actor="admin")
+
+    state = json.loads(runtime.state_path.read_text(encoding="utf-8"))
+    state["feedback_cursor"]["cycle_index"] += 1
+    runtime.state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    try:
+        runtime.load_cursor()
+    except ImprovementRuntimeError as exc:
+        assert "digest mismatch" in str(exc)
+    else:
+        raise AssertionError("tampered cursor state must be rejected")

--- a/deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py
@@ -26,3 +26,49 @@ def test_runtime_cli_records_is_bounded_local_export(tmp_path, monkeypatch, caps
     body = json.loads(capsys.readouterr().out)
     assert body["records"] == []
     assert body["claims_boundary"] == "bounded local custody export only"
+
+
+def test_runtime_cli_evidence_manifest_is_verifiable_shape(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("WSRI_DATA_DIR", str((tmp_path / "wsri").resolve()))
+    monkeypatch.delenv("WSRI_ECHO_DATA_DIR", raising=False)
+
+    assert main([
+        "evidence-manifest",
+        "--generated-utc",
+        "2026-09-12T21:10:00+00:00",
+    ]) == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["schema"] == "ws-ri-evidence-manifest-1"
+    assert body["record_count"] == 0
+    assert body["ledger_chain_verified"] is True
+    assert body["claim_promotion_performed"] is False
+    assert body["deployment_performed"] is False
+    assert body["manifest_digest"]
+
+
+def test_runtime_cli_handoff_requires_authorized_scheduler_or_human(tmp_path, monkeypatch, capsys):
+    wsri = (tmp_path / "wsri").resolve()
+    echo = (tmp_path / "echo").resolve()
+    echo.mkdir(mode=0o700)
+    monkeypatch.setenv("WSRI_DATA_DIR", str(wsri))
+    monkeypatch.setenv("WSRI_ECHO_DATA_DIR", str(echo))
+
+    assert main([
+        "handoff",
+        "--requested-by",
+        "operator",
+        "--generated-utc",
+        "2026-09-12T21:11:00+00:00",
+        "--max-events",
+        "8",
+        "--max-proposals",
+        "4",
+    ]) == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["schema"] == "ws-ri-scheduler-handoff-1"
+    assert body["execution_disposition"] == "HUMAN_REVIEW_REQUIRED"
+    assert body["authorization_required"] is True
+    assert body["autonomous_execution_authorized"] is False
+    assert body["claim_promotion_authorized"] is False
+    assert body["deployment_authorized"] is False
+    assert body["external_execution_authorized"] is False

--- a/deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py
+++ b/deployments/sara_verified_local_v1/tests/test_improvement_runtime_cli.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+
+from worldshepherd_sara.improvement_runtime_cli import main
+
+
+def test_runtime_cli_status_uses_configured_local_store(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("WSRI_DATA_DIR", str((tmp_path / "wsri").resolve()))
+    monkeypatch.delenv("WSRI_ECHO_DATA_DIR", raising=False)
+
+    assert main(["status"]) == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["record_count"] == 0
+    assert body["ledger_chain_verified"] is True
+    assert body["autonomous_scheduler_active"] is False
+    assert body["claim_promotion_performed"] is False
+    assert body["deployment_performed"] is False
+
+
+def test_runtime_cli_records_is_bounded_local_export(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("WSRI_DATA_DIR", str((tmp_path / "wsri").resolve()))
+    monkeypatch.delenv("WSRI_ECHO_DATA_DIR", raising=False)
+
+    assert main(["records", "--limit", "10"]) == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["records"] == []
+    assert body["claims_boundary"] == "bounded local custody export only"

--- a/deployments/sara_verified_local_v1/tests/test_operational_feedback.py
+++ b/deployments/sara_verified_local_v1/tests/test_operational_feedback.py
@@ -1,0 +1,167 @@
+import pytest
+from pydantic import ValidationError
+
+from worldshepherd_sara.echo_event_store import EchoEventStore
+from worldshepherd_sara.improvement_cycle import ImprovementRisk, ImprovementTriggerKind
+from worldshepherd_sara.improvement_feedback import (
+    ImprovementFeedbackCursor,
+    ImprovementFeedbackPolicy,
+    run_operational_feedback_cycle,
+)
+from worldshepherd_sara.improvement_ledger import ImprovementLedger
+from worldshepherd_sara.models import AuditRecord
+from worldshepherd_sara.operational_improvement import (
+    OperationalImprovementSignalError,
+    audit_event_to_improvement,
+    stored_echo_event_to_improvement,
+)
+from worldshepherd_sara.qualification import CapabilityStatus
+
+
+def signal_event(event_id: str, *, source="ECHO", trigger="ANOMALY") -> AuditRecord:
+    return AuditRecord(
+        timestamp="2026-09-12T20:00:00+00:00",
+        event="operational_signal",
+        actor="SARA",
+        payload={
+            "_outbox_event_id": event_id,
+            "_delivery_semantics": "AT_LEAST_ONCE",
+            "_ws_improvement_signal": {
+                "source": source,
+                "trigger_kind": trigger,
+                "statement": "Observed delta exceeded the qualified envelope.",
+                "affected_lanes": ["PRIME"],
+                "risk_level": "HIGH",
+                "required_tests": ["regression-gate"],
+                "success_metrics": ["qualified envelope restored"],
+                "negative_evidence": [{"metric": "delta", "result": "outside-envelope"}],
+            },
+        },
+    )
+
+
+def ordinary_event(event_id: str) -> AuditRecord:
+    return AuditRecord(
+        timestamp="2026-09-12T20:00:00+00:00",
+        event="ordinary_audit",
+        actor="SARA",
+        payload={
+            "_outbox_event_id": event_id,
+            "_delivery_semantics": "AT_LEAST_ONCE",
+        },
+    )
+
+
+def echo_store(tmp_path):
+    root = tmp_path / "echo"
+    root.mkdir(mode=0o700)
+    return EchoEventStore(root.resolve())
+
+
+def test_explicit_event_translation_does_not_inflate_maturity():
+    item = audit_event_to_improvement(
+        signal_event("SARA-EVENT-wsri-operational-1"),
+        created_utc="2026-09-12T20:01:00Z",
+    )
+    assert item.trigger_kind == ImprovementTriggerKind.ANOMALY
+    assert item.risk_level == ImprovementRisk.HIGH
+    assert item.baseline_capability_status == [CapabilityStatus.NOT_CURRENTLY_CLAIMED]
+    assert item.target_capability_status is None
+    assert not item.requested_claim_promotion
+    assert not item.requested_external_execution
+
+
+def test_missing_signal_is_rejected():
+    with pytest.raises(OperationalImprovementSignalError):
+        audit_event_to_improvement(
+            ordinary_event("SARA-EVENT-wsri-ordinary"),
+            created_utc="2026-09-12T20:01:00Z",
+        )
+
+
+def test_event_id_is_stable_across_reprocessing():
+    record = signal_event("SARA-EVENT-wsri-stable")
+    first = audit_event_to_improvement(record, created_utc="2026-09-12T20:01:00Z")
+    second = audit_event_to_improvement(record, created_utc="2026-09-13T20:01:00Z")
+    assert first.improvement_id == second.improvement_id
+
+
+def test_stored_echo_event_round_trip(tmp_path):
+    store = echo_store(tmp_path)
+    result = store.ingest(signal_event("SARA-EVENT-wsri-roundtrip"))
+    item = stored_echo_event_to_improvement(
+        result.record,
+        created_utc=result.record.first_ingested_at,
+    )
+    assert result.record.event_id in item.source_refs
+    assert any(ref.startswith("ECHO-SEMANTIC-SHA256:") for ref in item.source_refs)
+
+
+def test_feedback_policy_fails_closed():
+    with pytest.raises(ValidationError):
+        ImprovementFeedbackPolicy(allow_claim_promotion=True)
+    with pytest.raises(ValidationError):
+        ImprovementFeedbackPolicy(allow_deployment=True)
+    with pytest.raises(ValidationError):
+        ImprovementFeedbackPolicy(allow_external_execution=True)
+
+
+def test_feedback_cycle_ignores_ordinary_and_stores_signal(tmp_path):
+    store = echo_store(tmp_path)
+    store.ingest(ordinary_event("SARA-EVENT-wsri-feedback-ordinary"))
+    store.ingest(signal_event("SARA-EVENT-wsri-feedback-signal"))
+    ledger = ImprovementLedger((tmp_path / "ledger").resolve())
+    cursor, report = run_operational_feedback_cycle(
+        store,
+        ledger,
+        ImprovementFeedbackCursor(),
+    )
+    assert report.scanned_events == 2
+    assert report.ordinary_events_ignored == 1
+    assert report.proposals_stored == 1
+    assert not report.claim_promotion_performed
+    assert not report.deployment_performed
+    assert not report.external_execution_performed
+    assert cursor.last_event_id == "SARA-EVENT-wsri-feedback-signal"
+    assert ledger.verify_chain()
+
+
+def test_feedback_reprocessing_deduplicates(tmp_path):
+    store = echo_store(tmp_path)
+    store.ingest(signal_event("SARA-EVENT-wsri-feedback-dedupe"))
+    ledger = ImprovementLedger((tmp_path / "ledger").resolve())
+    _, first = run_operational_feedback_cycle(store, ledger, ImprovementFeedbackCursor())
+    _, second = run_operational_feedback_cycle(store, ledger, ImprovementFeedbackCursor())
+    assert first.proposals_stored == 1
+    assert second.proposals_deduplicated == 1
+    assert len(ledger.records()) == 1
+
+
+def test_feedback_budget_defers_without_skipping(tmp_path):
+    store = echo_store(tmp_path)
+    store.ingest(signal_event("SARA-EVENT-wsri-feedback-s1"))
+    store.ingest(signal_event("SARA-EVENT-wsri-feedback-s2"))
+    ledger = ImprovementLedger((tmp_path / "ledger").resolve())
+    policy = ImprovementFeedbackPolicy(max_new_proposals_per_cycle=1)
+    cursor, first = run_operational_feedback_cycle(
+        store, ledger, ImprovementFeedbackCursor(), policy=policy
+    )
+    assert first.deferred_signal_event_ids == ["SARA-EVENT-wsri-feedback-s2"]
+    assert cursor.last_event_id == "SARA-EVENT-wsri-feedback-s1"
+    cursor, second = run_operational_feedback_cycle(store, ledger, cursor, policy=policy)
+    assert second.proposals_stored == 1
+    assert cursor.last_event_id == "SARA-EVENT-wsri-feedback-s2"
+
+
+def test_invalid_explicit_signal_is_reported(tmp_path):
+    store = echo_store(tmp_path)
+    bad = signal_event("SARA-EVENT-wsri-feedback-bad")
+    bad.payload["_ws_improvement_signal"]["trigger_kind"] = "OPPORTUNITY"
+    store.ingest(bad)
+    ledger = ImprovementLedger((tmp_path / "ledger").resolve())
+    cursor, report = run_operational_feedback_cycle(
+        store, ledger, ImprovementFeedbackCursor()
+    )
+    assert report.invalid_signal_event_ids == ["SARA-EVENT-wsri-feedback-bad"]
+    assert cursor.last_event_id == "SARA-EVENT-wsri-feedback-bad"
+    assert len(ledger.records()) == 0

--- a/deployments/sara_verified_local_v1/tests/test_pre_improvement.py
+++ b/deployments/sara_verified_local_v1/tests/test_pre_improvement.py
@@ -1,0 +1,110 @@
+from worldshepherd_sara.improvement_cycle import ImprovementRisk, ImprovementState
+from worldshepherd_sara.improvement_routing import ImprovementRoute, route_improvement
+from worldshepherd_sara.pre_improvement import pre_to_improvement
+from worldshepherd_sara.qualification import (
+    CapabilityStatus,
+    DemandClass,
+    ForecastHorizon,
+    RequirementDeltaRecord,
+    SourceRecord,
+    SourceStatus,
+)
+
+
+def make_requirement(**overrides):
+    payload = {
+        "requirement_delta_id": "PRE-RD-2026-9001",
+        "demand_class": DemandClass.CONFIRMED_DEMAND,
+        "source": SourceRecord(
+            title="Official requirement source",
+            agency="Example Agency",
+            url="https://example.gov/requirement",
+            solicitation_or_topic="TOPIC-9001",
+            source_status=SourceStatus.OFFICIAL_SOURCE_VERIFIED,
+            retrieved_utc="2026-09-12T20:40:00Z",
+        ),
+        "statement": "System must preserve traceable state across degraded connectivity.",
+        "recurrence": "Repeated across current and prior requirement sets.",
+        "forecast_horizon": ForecastHorizon.D0_90,
+        "affected_lanes": ["DDIL", "ECHO"],
+        "existing_capability": ["DDIL reconcile", "event provenance"],
+        "capability_status": [CapabilityStatus.IMPLEMENTED_IN_SOFTWARE],
+        "missing_capability": ["receiving-lane qualification under representative disruption"],
+        "experiment_or_demonstration_needed": ["representative DDIL partition/rejoin qualification"],
+        "partner_needed": [],
+        "evidence_target": ["rejoin integrity PASS", "provenance chain preserved"],
+        "likely_future_programs": ["example future program"],
+        "claims_boundary": ["No field-performance claim without representative external validation."],
+    }
+    payload.update(overrides)
+    return RequirementDeltaRecord(**payload)
+
+
+def test_pre_translation_preserves_requirement_lineage_without_maturity_promotion():
+    requirement = make_requirement()
+    proposal = pre_to_improvement(
+        requirement, created_utc="2026-09-12T21:00:00Z"
+    )
+
+    assert proposal.state == ImprovementState.PROPOSED
+    assert proposal.source_refs[0] == requirement.requirement_delta_id
+    assert requirement.source.url in proposal.source_refs
+    assert proposal.baseline_capability_status == [CapabilityStatus.IMPLEMENTED_IN_SOFTWARE]
+    assert proposal.target_capability_status is None
+    assert proposal.generated_by == "PRE->WS-RI"
+    assert not proposal.requested_claim_promotion
+    assert not proposal.requested_external_execution
+
+
+def test_pre_translation_turns_missing_capability_and_evidence_targets_into_gates():
+    requirement = make_requirement()
+    proposal = pre_to_improvement(
+        requirement, created_utc="2026-09-12T21:00:00Z"
+    )
+
+    assert "receiving-lane qualification" in proposal.proposed_change
+    assert "representative DDIL partition/rejoin qualification" in proposal.required_tests
+    assert f"{requirement.requirement_delta_id}:source-evidence-gate" in proposal.required_tests
+    assert f"{requirement.requirement_delta_id}:claims-boundary-gate" in proposal.required_tests
+    assert proposal.success_metrics == ["rejoin integrity PASS", "provenance chain preserved"]
+
+
+def test_forecast_or_unverified_pre_source_is_high_risk_preparation_not_evidence():
+    source = SourceRecord(
+        title="Discovery-only source",
+        agency="External discovery",
+        url="https://example.com/discovery",
+        solicitation_or_topic=None,
+        source_status=SourceStatus.THIRD_PARTY_DISCOVERY_ONLY,
+        retrieved_utc="2026-09-12T20:40:00Z",
+    )
+    requirement = make_requirement(
+        demand_class=DemandClass.WORLDSHEPHERD_FORECAST,
+        source=source,
+        capability_status=[],
+        partner_needed=["representative integration partner"],
+    )
+    proposal = pre_to_improvement(
+        requirement, created_utc="2026-09-12T21:00:00Z"
+    )
+
+    assert proposal.baseline_capability_status == [CapabilityStatus.NOT_CURRENTLY_CLAIMED]
+    assert proposal.risk_level == ImprovementRisk.HIGH
+    assert any("preparation signal only" in risk for risk in proposal.risks)
+    assert any("not capture-ready" in risk for risk in proposal.risks)
+    assert any("Partner need is unresolved" in risk for risk in proposal.risks)
+
+
+def test_requirement_delta_routes_back_to_pre_without_execution_authority():
+    proposal = pre_to_improvement(
+        make_requirement(), created_utc="2026-09-12T21:00:00Z"
+    )
+    envelope = route_improvement(proposal)
+
+    assert ImprovementRoute.PRE in envelope.routes
+    assert ImprovementRoute.ECHO in envelope.routes
+    assert ImprovementRoute.OMEGA in envelope.routes
+    assert ImprovementRoute.PRIME_TEVV in envelope.routes
+    assert ImprovementRoute.CONFIG_CUSTODY not in envelope.routes
+    assert not envelope.deployment_authorized
+    assert not envelope.external_execution_performed

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_improvement.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/evidence_improvement.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .improvement_cycle import (
+    ImprovementProposal,
+    ImprovementRisk,
+    ImprovementState,
+    ImprovementTriggerKind,
+)
+from .qualification import (
+    QualificationEvidenceRecord,
+    ResultStatus,
+    ReviewStatus,
+    canonical_digest,
+)
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _stable_evidence_improvement_id(
+    record: QualificationEvidenceRecord,
+    created_utc: str,
+) -> str:
+    year = created_utc[:4]
+    if len(year) != 4 or not year.isdigit():
+        raise ValueError("created_utc must begin with a four-digit year")
+    material = {
+        "qualification_id": record.qualification_id,
+        "requirement_id": record.requirement_id,
+        "result": record.result.value,
+        "created_year": year,
+    }
+    digest_hex = canonical_digest(material).split(":", 1)[1]
+    numeric_suffix = str(int(digest_hex[:12], 16))
+    return f"WS-IR-{year}-{numeric_suffix}"
+
+
+def evidence_to_improvement(
+    record: QualificationEvidenceRecord,
+    *,
+    created_utc: str,
+    affected_lanes: Iterable[str] = (),
+    baseline_artifacts: Iterable[str] = (),
+    additional_required_tests: Iterable[str] = (),
+) -> ImprovementProposal:
+    """Translate qualification/TEVV evidence into a governed WS-RI proposal.
+
+    A PASS remains evidence for the tested scope only. A FAIL or INCONCLUSIVE
+    result creates a remediation/uncertainty candidate but does not authorize a
+    fix, invalidate unrelated evidence, or promote any capability claim.
+    """
+
+    if record.result == ResultStatus.FAIL:
+        trigger = ImprovementTriggerKind.FAILURE
+        risk_level = ImprovementRisk.HIGH
+        action_text = (
+            "Investigate and remediate the failed qualification result through a reversible, "
+            "re-tested change path."
+        )
+    elif record.result == ResultStatus.INCONCLUSIVE:
+        trigger = ImprovementTriggerKind.TEST_RESULT
+        risk_level = ImprovementRisk.MODERATE
+        action_text = (
+            "Resolve the inconclusive qualification result by reducing uncertainty and repeating "
+            "the required test under a controlled configuration."
+        )
+    else:
+        trigger = ImprovementTriggerKind.TEST_RESULT
+        risk_level = ImprovementRisk.LOW
+        action_text = (
+            "Evaluate whether the passing qualification result warrants any bounded baseline update, "
+            "while preserving the exact tested scope and configuration."
+        )
+
+    lanes = _dedupe([*affected_lanes, "PRIME-TEVV", "ECHO", "WS-RI"])
+    sources = _dedupe(
+        [
+            record.qualification_id,
+            record.requirement_id,
+            record.test_id,
+            record.software_commit or "",
+        ]
+    )
+
+    required_tests = [
+        f"{record.qualification_id}:evidence-review-gate",
+        f"{record.qualification_id}:regression-gate",
+    ]
+    if record.result == ResultStatus.FAIL:
+        required_tests.append(f"{record.qualification_id}:root-cause-gate")
+    elif record.result == ResultStatus.INCONCLUSIVE:
+        required_tests.append(f"{record.qualification_id}:uncertainty-resolution-gate")
+    required_tests = _dedupe([*required_tests, *additional_required_tests])
+
+    risks = [
+        "Qualification evidence applies only to the recorded test scope, configuration, environment, inputs, and uncertainty.",
+        "This translation does not establish broader readiness, certification, partner validation, or physical performance beyond the evidence record.",
+    ]
+    if record.review.status == ReviewStatus.UNREVIEWED:
+        risks.append("Qualification evidence has not yet received recorded human review.")
+    if record.result == ResultStatus.FAIL:
+        risks.append("A failed required test may indicate a regression, invalid assumption, configuration defect, or unmodeled condition.")
+    if record.result == ResultStatus.INCONCLUSIVE:
+        risks.append("Uncertainty is unresolved; no directional capability conclusion should be drawn from the result.")
+
+    success_metrics = [
+        "Required remediation or uncertainty-resolution gates return PASS.",
+        "The original qualification record remains traceable and unmodified.",
+        "No unrelated capability state or claim is promoted from the result.",
+        "Any resulting configuration change is separately authorized and regression-tested.",
+    ]
+
+    return ImprovementProposal(
+        improvement_id=_stable_evidence_improvement_id(record, created_utc),
+        trigger_kind=trigger,
+        title=f"Qualification feedback: {record.qualification_id}",
+        source_refs=sources,
+        affected_lanes=lanes,
+        baseline_artifacts=_dedupe(baseline_artifacts),
+        baseline_capability_status=[record.capability_status],
+        target_capability_status=None,
+        proposed_change=(
+            f"{action_text} Requirement={record.requirement_id}; test={record.test_id}; "
+            f"result={record.result.value}."
+        ),
+        expected_benefit=(
+            "Feed measured qualification results back into Worldshepherd change control without erasing failures, expanding scope, or inflating maturity."
+        ),
+        assumptions=[
+            "The qualification record digest inputs accurately identify the tested environment and configuration.",
+            "Existing evidence lifecycle, ECHO custody, PRIME authorization, and configuration custody remain authoritative.",
+        ],
+        risks=risks,
+        risk_level=risk_level,
+        required_tests=required_tests,
+        success_metrics=success_metrics,
+        negative_evidence=[dict(item) for item in record.negative_evidence],
+        reversible=True,
+        generated_by="QE/TEVV->WS-RI",
+        created_utc=created_utc,
+        state=ImprovementState.PROPOSED,
+        requested_claim_promotion=False,
+        requested_external_execution=False,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_checkpoint.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_checkpoint.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+from pydantic import BaseModel, Field
+
+from .echo_checkpoint_verify import verify_bundle
+from .echo_event_store import EchoEventStore, EchoIngestResult, EchoStoredEvent, semantic_sha256
+from .improvement_ledger import ImprovementLedger
+from .models import AuditRecord
+from .qualification import canonical_digest
+
+LEDGER_CHECKPOINT_SCHEMA = "WS-RI-LEDGER-CHECKPOINT-V1"
+LEDGER_ECHO_EVENT_SCHEMA = "WS-RI-LEDGER-ECHO-ANCHOR-V1"
+_LEDGER_PAYLOAD_KEY = "_ws_ri_ledger_checkpoint"
+
+class ImprovementCheckpointError(RuntimeError):
+    pass
+
+class ImprovementLedgerCheckpoint(BaseModel):
+    schema: str = LEDGER_CHECKPOINT_SCHEMA
+    record_count: int = Field(ge=1)
+    head_sequence: int = Field(ge=1)
+    head_record_digest: str = Field(min_length=1)
+    state_counts: dict[str, int]
+    created_utc: str = Field(min_length=1)
+    claims_boundary: str = Field(min_length=1)
+    checkpoint_digest: str = Field(min_length=1)
+
+def _payload(record_count: int, head_sequence: int, head_record_digest: str, state_counts: dict[str, int], created_utc: str) -> dict[str, Any]:
+    return {
+        "schema": LEDGER_CHECKPOINT_SCHEMA,
+        "record_count": record_count,
+        "head_sequence": head_sequence,
+        "head_record_digest": head_record_digest,
+        "state_counts": dict(sorted(state_counts.items())),
+        "created_utc": created_utc,
+        "claims_boundary": "local WS-RI custody digest only; stronger retention or deployment claims require separate evidence",
+    }
+
+def build_ledger_checkpoint(ledger: ImprovementLedger, *, created_utc: str) -> ImprovementLedgerCheckpoint:
+    if not created_utc.strip():
+        raise ImprovementCheckpointError("created_utc is required")
+    if not ledger.verify_chain():
+        raise ImprovementCheckpointError("WS-RI ledger chain verification failed")
+    records = ledger.records()
+    if not records:
+        raise ImprovementCheckpointError("cannot checkpoint an empty WS-RI ledger")
+    head = records[-1]
+    material = _payload(len(records), head.sequence, head.record_digest, dict(Counter(r.state for r in records)), created_utc.strip())
+    return ImprovementLedgerCheckpoint(**material, checkpoint_digest=canonical_digest(material))
+
+def build_ledger_checkpoint_event(ledger: ImprovementLedger, *, event_id: str, actor: str, timestamp: str) -> tuple[AuditRecord, ImprovementLedgerCheckpoint]:
+    if not event_id.strip() or not actor.strip() or not timestamp.strip():
+        raise ImprovementCheckpointError("event_id, actor, and timestamp are required")
+    checkpoint = build_ledger_checkpoint(ledger, created_utc=timestamp)
+    record = AuditRecord(
+        timestamp=timestamp,
+        event="ws_ri_ledger_checkpoint",
+        actor=actor,
+        payload={
+            "_outbox_event_id": event_id,
+            "_delivery_semantics": "AT_LEAST_ONCE",
+            _LEDGER_PAYLOAD_KEY: checkpoint.model_dump(mode="json"),
+            "anchor_schema": LEDGER_ECHO_EVENT_SCHEMA,
+        },
+    )
+    semantic_sha256(record)
+    return record, checkpoint
+
+def ingest_ledger_checkpoint_into_echo(store: EchoEventStore, ledger: ImprovementLedger, *, event_id: str, actor: str, timestamp: str) -> tuple[EchoIngestResult, ImprovementLedgerCheckpoint]:
+    record, checkpoint = build_ledger_checkpoint_event(ledger, event_id=event_id, actor=actor, timestamp=timestamp)
+    return store.ingest(record), checkpoint
+
+def verify_stored_ledger_checkpoint(stored: EchoStoredEvent, expected: ImprovementLedgerCheckpoint) -> bool:
+    try:
+        record = AuditRecord(timestamp=stored.first_audit_timestamp, event=stored.event, actor=stored.actor, payload=stored.payload())
+        if semantic_sha256(record) != stored.semantic_sha256:
+            return False
+        raw = record.payload.get(_LEDGER_PAYLOAD_KEY)
+        if not isinstance(raw, dict):
+            return False
+        observed = ImprovementLedgerCheckpoint.model_validate(raw)
+        if observed != expected:
+            return False
+        material = observed.model_dump(mode="json")
+        digest = material.pop("checkpoint_digest")
+        return digest == canonical_digest(material)
+    except Exception:
+        return False
+
+def verify_signed_echo_membership(bundle: dict[str, Any], *, trusted_fingerprint_sha256: str, event_id: str, semantic_digest: str) -> dict[str, Any]:
+    summary = verify_bundle(bundle, trusted_fingerprint_sha256)
+    manifest = bundle.get("manifest")
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("events"), list):
+        raise ImprovementCheckpointError("verified ECHO bundle has no membership list")
+    matches = [item for item in manifest["events"] if isinstance(item, dict) and item.get("event_id") == event_id and item.get("semantic_sha256") == semantic_digest]
+    if len(matches) != 1:
+        raise ImprovementCheckpointError("WS-RI ledger anchor is not uniquely present in the verified ECHO checkpoint")
+    return {
+        "status": "PASS",
+        "event_id": event_id,
+        "semantic_sha256": semantic_digest,
+        "echo_checkpoint_id": manifest.get("checkpoint_id"),
+        "echo_checkpoint_sha256": bundle.get("checkpoint_sha256"),
+        "echo_verification": summary,
+    }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py
@@ -126,6 +126,23 @@ def proposal_digest(proposal: ImprovementProposal) -> str:
     return canonical_digest(proposal.model_dump(mode="json"))
 
 
+def _validated_update(
+    proposal: ImprovementProposal,
+    **updates: Any,
+) -> ImprovementProposal:
+    """Reconstruct a proposal so every transition re-runs model validators.
+
+    Pydantic's model_copy(update=...) does not guarantee update revalidation.
+    Governance transitions therefore reconstruct from the complete payload and
+    fail closed if either the existing object or the update violates WS-RI
+    invariants.
+    """
+
+    payload = proposal.model_dump(mode="python")
+    payload.update(updates)
+    return ImprovementProposal.model_validate(payload)
+
+
 def assess_improvement(
     proposal: ImprovementProposal,
     test_results: dict[str, ResultStatus],
@@ -208,7 +225,7 @@ def apply_assessment(
         ImprovementState.QUARANTINED,
     }:
         raise ValueError("assessment disposition is not an automated validation state")
-    return proposal.model_copy(update={"state": assessment.disposition})
+    return _validated_update(proposal, state=assessment.disposition)
 
 
 def record_human_decision(
@@ -249,7 +266,7 @@ def record_human_decision(
         qualification_refs=list(dict.fromkeys(qualification_refs)),
         authorization_ref=authorization_ref,
     )
-    return proposal.model_copy(update={"state": state, "review": review})
+    return _validated_update(proposal, state=state, review=review)
 
 
 def supersede_improvement(
@@ -263,9 +280,8 @@ def supersede_improvement(
         raise ValueError("superseding improvement reference is required")
     negative = list(proposal.negative_evidence)
     negative.append({"superseded_by": superseded_by})
-    return proposal.model_copy(
-        update={
-            "state": ImprovementState.SUPERSEDED,
-            "negative_evidence": negative,
-        }
+    return _validated_update(
+        proposal,
+        state=ImprovementState.SUPERSEDED,
+        negative_evidence=negative,
     )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_cycle.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .qualification import (
+    CapabilityStatus,
+    ResultStatus,
+    ReviewStatus,
+    canonical_digest,
+)
+
+
+class ImprovementTriggerKind(str, Enum):
+    NEW_EVIDENCE = "NEW_EVIDENCE"
+    TEST_RESULT = "TEST_RESULT"
+    FAILURE = "FAILURE"
+    ANOMALY = "ANOMALY"
+    CONTRADICTION = "CONTRADICTION"
+    REQUIREMENT_DELTA = "REQUIREMENT_DELTA"
+    PARTNER_FEEDBACK = "PARTNER_FEEDBACK"
+    RESEARCH = "RESEARCH"
+    SECURITY_EVENT = "SECURITY_EVENT"
+    OPPORTUNITY = "OPPORTUNITY"
+    OPERATOR_FEEDBACK = "OPERATOR_FEEDBACK"
+
+
+class ImprovementRisk(str, Enum):
+    LOW = "LOW"
+    MODERATE = "MODERATE"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class ImprovementState(str, Enum):
+    PROPOSED = "PROPOSED"
+    VALIDATING = "VALIDATING"
+    HUMAN_REVIEW_REQUIRED = "HUMAN_REVIEW_REQUIRED"
+    PROMOTED = "PROMOTED"
+    REJECTED = "REJECTED"
+    QUARANTINED = "QUARANTINED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class ImprovementReview(BaseModel):
+    status: ReviewStatus = ReviewStatus.UNREVIEWED
+    reviewer: str | None = None
+    reviewed_utc: str | None = None
+    rationale: str | None = None
+    qualification_refs: list[str] = Field(default_factory=list)
+    authorization_ref: str | None = None
+
+
+class ImprovementProposal(BaseModel):
+    """Governed proposal to improve Worldshepherd itself or one of its lanes.
+
+    The record is intentionally a proposal/evidence object, not an execution
+    primitive. Claim promotion and consequential external execution remain
+    outside this module and behind existing human/PRIME authorization.
+    """
+
+    schema: str = "ws-recursive-improvement-1"
+    improvement_id: str = Field(pattern=r"^WS-IR-[0-9]{4}-[0-9]{4,}$")
+    trigger_kind: ImprovementTriggerKind
+    title: str = Field(min_length=1)
+    source_refs: list[str] = Field(min_length=1)
+    affected_lanes: list[str] = Field(min_length=1)
+    baseline_artifacts: list[str] = Field(default_factory=list)
+    baseline_capability_status: list[CapabilityStatus] = Field(default_factory=list)
+    target_capability_status: CapabilityStatus | None = None
+    proposed_change: str = Field(min_length=1)
+    expected_benefit: str = Field(min_length=1)
+    assumptions: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
+    risk_level: ImprovementRisk = ImprovementRisk.MODERATE
+    required_tests: list[str] = Field(min_length=1)
+    success_metrics: list[str] = Field(min_length=1)
+    negative_evidence: list[dict[str, Any]] = Field(default_factory=list)
+    reversible: bool = True
+    generated_by: str = Field(min_length=1)
+    created_utc: str = Field(min_length=1)
+    state: ImprovementState = ImprovementState.PROPOSED
+    review: ImprovementReview = Field(default_factory=ImprovementReview)
+    requested_claim_promotion: bool = False
+    requested_external_execution: bool = False
+
+    @model_validator(mode="after")
+    def enforce_fail_closed_boundaries(self) -> "ImprovementProposal":
+        if self.requested_claim_promotion:
+            raise ValueError(
+                "recursive improvement may not self-authorize claim promotion"
+            )
+        if self.requested_external_execution:
+            raise ValueError(
+                "recursive improvement may not self-authorize external execution"
+            )
+        if self.state == ImprovementState.PROMOTED:
+            if self.review.status != ReviewStatus.ACCEPTED:
+                raise ValueError("PROMOTED state requires accepted human review")
+            if not self.review.reviewer:
+                raise ValueError("PROMOTED state requires an identified reviewer")
+            if not self.review.qualification_refs:
+                raise ValueError("PROMOTED state requires qualification evidence")
+            if not self.review.authorization_ref:
+                raise ValueError("PROMOTED state requires authorization reference")
+        return self
+
+
+class ImprovementAssessment(BaseModel):
+    schema: str = "ws-recursive-improvement-assessment-1"
+    improvement_id: str
+    disposition: ImprovementState
+    passed_tests: list[str] = Field(default_factory=list)
+    failed_tests: list[str] = Field(default_factory=list)
+    inconclusive_tests: list[str] = Field(default_factory=list)
+    missing_tests: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+    claim_promotion_performed: bool = False
+    external_execution_performed: bool = False
+    assessment_digest: str = ""
+
+
+def proposal_digest(proposal: ImprovementProposal) -> str:
+    return canonical_digest(proposal.model_dump(mode="json"))
+
+
+def assess_improvement(
+    proposal: ImprovementProposal,
+    test_results: dict[str, ResultStatus],
+) -> ImprovementAssessment:
+    """Evaluate validation completeness without performing the improvement.
+
+    Any required test failure quarantines the proposal. Missing or
+    inconclusive tests keep it in validation. Only complete PASS coverage can
+    advance the record to human review; this function never promotes it.
+    """
+
+    required = list(dict.fromkeys(proposal.required_tests))
+    passed: list[str] = []
+    failed: list[str] = []
+    inconclusive: list[str] = []
+    missing: list[str] = []
+
+    for test_id in required:
+        result = test_results.get(test_id)
+        if result is None:
+            missing.append(test_id)
+        elif result == ResultStatus.PASS:
+            passed.append(test_id)
+        elif result == ResultStatus.FAIL:
+            failed.append(test_id)
+        else:
+            inconclusive.append(test_id)
+
+    reasons: list[str] = []
+    if failed:
+        disposition = ImprovementState.QUARANTINED
+        reasons.append("one or more required validation tests failed")
+    elif missing or inconclusive:
+        disposition = ImprovementState.VALIDATING
+        if missing:
+            reasons.append("required validation tests are missing")
+        if inconclusive:
+            reasons.append("one or more required validation tests are inconclusive")
+    else:
+        disposition = ImprovementState.HUMAN_REVIEW_REQUIRED
+        reasons.append(
+            "all required validation tests passed; human review and authorization remain required"
+        )
+
+    payload = {
+        "schema": "ws-recursive-improvement-assessment-1",
+        "improvement_id": proposal.improvement_id,
+        "disposition": disposition.value,
+        "passed_tests": passed,
+        "failed_tests": failed,
+        "inconclusive_tests": inconclusive,
+        "missing_tests": missing,
+        "reasons": reasons,
+        "claim_promotion_performed": False,
+        "external_execution_performed": False,
+    }
+    return ImprovementAssessment(
+        improvement_id=proposal.improvement_id,
+        disposition=disposition,
+        passed_tests=passed,
+        failed_tests=failed,
+        inconclusive_tests=inconclusive,
+        missing_tests=missing,
+        reasons=reasons,
+        claim_promotion_performed=False,
+        external_execution_performed=False,
+        assessment_digest=canonical_digest(payload),
+    )
+
+
+def apply_assessment(
+    proposal: ImprovementProposal,
+    assessment: ImprovementAssessment,
+) -> ImprovementProposal:
+    if proposal.improvement_id != assessment.improvement_id:
+        raise ValueError("assessment does not belong to proposal")
+    if assessment.disposition not in {
+        ImprovementState.VALIDATING,
+        ImprovementState.HUMAN_REVIEW_REQUIRED,
+        ImprovementState.QUARANTINED,
+    }:
+        raise ValueError("assessment disposition is not an automated validation state")
+    return proposal.model_copy(update={"state": assessment.disposition})
+
+
+def record_human_decision(
+    proposal: ImprovementProposal,
+    *,
+    accepted: bool,
+    reviewer: str,
+    reviewed_utc: str,
+    rationale: str,
+    qualification_refs: list[str],
+    authorization_ref: str | None = None,
+) -> ImprovementProposal:
+    """Record the governance decision; this does not deploy or execute change."""
+
+    if proposal.state != ImprovementState.HUMAN_REVIEW_REQUIRED:
+        raise ValueError("proposal is not ready for human review")
+    if not reviewer.strip():
+        raise ValueError("identified reviewer is required")
+    if not rationale.strip():
+        raise ValueError("review rationale is required")
+
+    if accepted:
+        if not qualification_refs:
+            raise ValueError("accepted improvement requires qualification evidence")
+        if not authorization_ref:
+            raise ValueError("accepted improvement requires authorization reference")
+        state = ImprovementState.PROMOTED
+        review_status = ReviewStatus.ACCEPTED
+    else:
+        state = ImprovementState.REJECTED
+        review_status = ReviewStatus.REJECTED
+
+    review = ImprovementReview(
+        status=review_status,
+        reviewer=reviewer,
+        reviewed_utc=reviewed_utc,
+        rationale=rationale,
+        qualification_refs=list(dict.fromkeys(qualification_refs)),
+        authorization_ref=authorization_ref,
+    )
+    return proposal.model_copy(update={"state": state, "review": review})
+
+
+def supersede_improvement(
+    proposal: ImprovementProposal,
+    *,
+    superseded_by: str,
+) -> ImprovementProposal:
+    if proposal.state != ImprovementState.PROMOTED:
+        raise ValueError("only a promoted improvement may be superseded")
+    if not superseded_by.strip():
+        raise ValueError("superseding improvement reference is required")
+    negative = list(proposal.negative_evidence)
+    negative.append({"superseded_by": superseded_by})
+    return proposal.model_copy(
+        update={
+            "state": ImprovementState.SUPERSEDED,
+            "negative_evidence": negative,
+        }
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .improvement_feedback import feedback_cursor_digest
+from .improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
+from .qualification import canonical_digest
+
+
+EVIDENCE_MANIFEST_SCHEMA = "ws-ri-evidence-manifest-1"
+
+
+class ImprovementEvidenceManifest(BaseModel):
+    schema: str = EVIDENCE_MANIFEST_SCHEMA
+    generated_utc: str = Field(min_length=1)
+    record_count: int = Field(ge=0)
+    head_sequence: int | None = None
+    head_record_digest: str | None = None
+    state_counts: dict[str, int]
+    record_digests: list[str]
+    records_digest: str = Field(min_length=1)
+    feedback_cursor: dict[str, Any]
+    feedback_cursor_digest: str = Field(min_length=1)
+    ledger_chain_verified: bool
+    claim_promotion_performed: bool = False
+    deployment_performed: bool = False
+    external_execution_performed: bool = False
+    claims_boundary: str = Field(min_length=1)
+    manifest_digest: str = Field(min_length=1)
+
+
+def _manifest_material(runtime: ImprovementRuntime, *, generated_utc: str) -> dict[str, object]:
+    if not generated_utc.strip():
+        raise ImprovementRuntimeError("generated_utc is required")
+    if not runtime.ledger.verify_chain():
+        raise ImprovementRuntimeError("WS-RI ledger chain verification failed")
+    records = runtime.ledger.records()
+    cursor = runtime.load_cursor()
+    record_digests = [record.record_digest for record in records]
+    return {
+        "schema": EVIDENCE_MANIFEST_SCHEMA,
+        "generated_utc": generated_utc.strip(),
+        "record_count": len(records),
+        "head_sequence": None if not records else records[-1].sequence,
+        "head_record_digest": None if not records else records[-1].record_digest,
+        "state_counts": dict(sorted(Counter(record.state for record in records).items())),
+        "record_digests": record_digests,
+        "records_digest": canonical_digest({"record_digests": record_digests}),
+        "feedback_cursor": cursor.model_dump(mode="json"),
+        "feedback_cursor_digest": feedback_cursor_digest(cursor),
+        "ledger_chain_verified": True,
+        "claim_promotion_performed": False,
+        "deployment_performed": False,
+        "external_execution_performed": False,
+        "claims_boundary": (
+            "deterministic local evidence manifest only; it does not establish external retention, "
+            "qualification, deployment authorization, certification, or signed ECHO inclusion"
+        ),
+    }
+
+
+def build_evidence_manifest(
+    runtime: ImprovementRuntime,
+    *,
+    generated_utc: str,
+) -> ImprovementEvidenceManifest:
+    material = _manifest_material(runtime, generated_utc=generated_utc)
+    return ImprovementEvidenceManifest(
+        **material,
+        manifest_digest=canonical_digest(material),
+    )
+
+
+def verify_evidence_manifest(manifest: ImprovementEvidenceManifest) -> bool:
+    material = manifest.model_dump(mode="json")
+    observed = str(material.pop("manifest_digest"))
+    if observed != canonical_digest(material):
+        return False
+    record_digests = material.get("record_digests")
+    if not isinstance(record_digests, list):
+        return False
+    if material.get("records_digest") != canonical_digest({"record_digests": record_digests}):
+        return False
+    cursor = material.get("feedback_cursor")
+    if not isinstance(cursor, dict):
+        return False
+    try:
+        from .improvement_feedback import ImprovementFeedbackCursor
+
+        parsed = ImprovementFeedbackCursor.model_validate(cursor)
+    except ValueError:
+        return False
+    return material.get("feedback_cursor_digest") == feedback_cursor_digest(parsed)
+
+
+def manifest_matches_runtime(
+    manifest: ImprovementEvidenceManifest,
+    runtime: ImprovementRuntime,
+) -> bool:
+    if not verify_evidence_manifest(manifest):
+        return False
+    records = runtime.ledger.records()
+    cursor = runtime.load_cursor()
+    if not runtime.ledger.verify_chain():
+        return False
+    return (
+        manifest.record_count == len(records)
+        and manifest.head_sequence == (None if not records else records[-1].sequence)
+        and manifest.head_record_digest == (None if not records else records[-1].record_digest)
+        and manifest.record_digests == [record.record_digest for record in records]
+        and manifest.feedback_cursor_digest == feedback_cursor_digest(cursor)
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py
@@ -20,6 +20,7 @@ class ImprovementEvidenceManifest(BaseModel):
     head_sequence: int | None = None
     head_record_digest: str | None = None
     state_counts: dict[str, int]
+    record_sequences: list[int]
     record_digests: list[str]
     records_digest: str = Field(min_length=1)
     feedback_cursor: dict[str, Any]
@@ -45,19 +46,37 @@ class ImprovementEvidenceManifest(BaseModel):
             raise ValueError("evidence manifest cannot claim promotion, deployment, or execution")
         if self.record_count != len(self.record_digests):
             raise ValueError("record_count must match record_digests")
+        if self.record_count != len(self.record_sequences):
+            raise ValueError("record_count must match record_sequences")
         if sum(self.state_counts.values()) != self.record_count:
             raise ValueError("state_counts must sum to record_count")
         if any(value < 0 for value in self.state_counts.values()):
             raise ValueError("state_counts may not contain negative values")
+        if any(sequence < 1 for sequence in self.record_sequences):
+            raise ValueError("record sequences must be positive")
+        if any(
+            later <= earlier
+            for earlier, later in zip(self.record_sequences, self.record_sequences[1:])
+        ):
+            raise ValueError("record sequences must be strictly increasing")
         if self.record_count == 0:
             if self.head_sequence is not None or self.head_record_digest is not None:
                 raise ValueError("empty manifest may not declare a ledger head")
         else:
-            if self.head_sequence != self.record_count:
-                raise ValueError("head_sequence must equal record_count for contiguous ledger export")
+            if self.head_sequence != self.record_sequences[-1]:
+                raise ValueError("head_sequence must match final record sequence")
             if self.head_record_digest != self.record_digests[-1]:
                 raise ValueError("head_record_digest must match final record digest")
         return self
+
+
+def _records_material(sequences: list[int], digests: list[str]) -> dict[str, object]:
+    return {
+        "records": [
+            {"sequence": sequence, "record_digest": digest}
+            for sequence, digest in zip(sequences, digests)
+        ]
+    }
 
 
 def _manifest_material(runtime: ImprovementRuntime, *, generated_utc: str) -> dict[str, object]:
@@ -67,6 +86,7 @@ def _manifest_material(runtime: ImprovementRuntime, *, generated_utc: str) -> di
         raise ImprovementRuntimeError("WS-RI ledger chain verification failed")
     records = runtime.ledger.records()
     cursor = runtime.load_cursor()
+    record_sequences = [record.sequence for record in records]
     record_digests = [record.record_digest for record in records]
     return {
         "schema": EVIDENCE_MANIFEST_SCHEMA,
@@ -75,8 +95,9 @@ def _manifest_material(runtime: ImprovementRuntime, *, generated_utc: str) -> di
         "head_sequence": None if not records else records[-1].sequence,
         "head_record_digest": None if not records else records[-1].record_digest,
         "state_counts": dict(sorted(Counter(record.state for record in records).items())),
+        "record_sequences": record_sequences,
         "record_digests": record_digests,
-        "records_digest": canonical_digest({"record_digests": record_digests}),
+        "records_digest": canonical_digest(_records_material(record_sequences, record_digests)),
         "feedback_cursor": cursor.model_dump(mode="json"),
         "feedback_cursor_digest": feedback_cursor_digest(cursor),
         "ledger_chain_verified": True,
@@ -108,11 +129,23 @@ def verify_evidence_manifest(manifest: ImprovementEvidenceManifest) -> bool:
     if observed != canonical_digest(material):
         return False
     record_digests = material.get("record_digests")
+    record_sequences = material.get("record_sequences")
     state_counts = material.get("state_counts")
-    if not isinstance(record_digests, list) or not isinstance(state_counts, dict):
+    if not isinstance(record_digests, list) or not isinstance(record_sequences, list):
+        return False
+    if not isinstance(state_counts, dict):
         return False
     record_count = material.get("record_count")
-    if not isinstance(record_count, int) or record_count != len(record_digests):
+    if not isinstance(record_count, int):
+        return False
+    if record_count != len(record_digests) or record_count != len(record_sequences):
+        return False
+    if any(not isinstance(sequence, int) or sequence < 1 for sequence in record_sequences):
+        return False
+    if any(
+        later <= earlier
+        for earlier, later in zip(record_sequences, record_sequences[1:])
+    ):
         return False
     if any(not isinstance(value, int) or value < 0 for value in state_counts.values()):
         return False
@@ -133,11 +166,11 @@ def verify_evidence_manifest(manifest: ImprovementEvidenceManifest) -> bool:
         if material.get("head_sequence") is not None or material.get("head_record_digest") is not None:
             return False
     else:
-        if material.get("head_sequence") != record_count:
+        if material.get("head_sequence") != record_sequences[-1]:
             return False
         if material.get("head_record_digest") != record_digests[-1]:
             return False
-    if material.get("records_digest") != canonical_digest({"record_digests": record_digests}):
+    if material.get("records_digest") != canonical_digest(_records_material(record_sequences, record_digests)):
         return False
     cursor = material.get("feedback_cursor")
     if not isinstance(cursor, dict):
@@ -165,6 +198,7 @@ def manifest_matches_runtime(
         and manifest.head_sequence == (None if not records else records[-1].sequence)
         and manifest.head_record_digest == (None if not records else records[-1].record_digest)
         and manifest.state_counts == expected_counts
+        and manifest.record_sequences == [record.sequence for record in records]
         and manifest.record_digests == [record.record_digest for record in records]
         and manifest.feedback_cursor == cursor.model_dump(mode="json")
         and manifest.feedback_cursor_digest == feedback_cursor_digest(cursor)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_evidence_export.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
-from .improvement_feedback import feedback_cursor_digest
+from .improvement_feedback import ImprovementFeedbackCursor, feedback_cursor_digest
 from .improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
 from .qualification import canonical_digest
 
@@ -30,6 +30,34 @@ class ImprovementEvidenceManifest(BaseModel):
     external_execution_performed: bool = False
     claims_boundary: str = Field(min_length=1)
     manifest_digest: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def fail_closed_and_consistent(self) -> "ImprovementEvidenceManifest":
+        if not self.ledger_chain_verified:
+            raise ValueError("evidence manifest requires a verified WS-RI ledger chain")
+        if any(
+            (
+                self.claim_promotion_performed,
+                self.deployment_performed,
+                self.external_execution_performed,
+            )
+        ):
+            raise ValueError("evidence manifest cannot claim promotion, deployment, or execution")
+        if self.record_count != len(self.record_digests):
+            raise ValueError("record_count must match record_digests")
+        if sum(self.state_counts.values()) != self.record_count:
+            raise ValueError("state_counts must sum to record_count")
+        if any(value < 0 for value in self.state_counts.values()):
+            raise ValueError("state_counts may not contain negative values")
+        if self.record_count == 0:
+            if self.head_sequence is not None or self.head_record_digest is not None:
+                raise ValueError("empty manifest may not declare a ledger head")
+        else:
+            if self.head_sequence != self.record_count:
+                raise ValueError("head_sequence must equal record_count for contiguous ledger export")
+            if self.head_record_digest != self.record_digests[-1]:
+                raise ValueError("head_record_digest must match final record digest")
+        return self
 
 
 def _manifest_material(runtime: ImprovementRuntime, *, generated_utc: str) -> dict[str, object]:
@@ -80,16 +108,41 @@ def verify_evidence_manifest(manifest: ImprovementEvidenceManifest) -> bool:
     if observed != canonical_digest(material):
         return False
     record_digests = material.get("record_digests")
-    if not isinstance(record_digests, list):
+    state_counts = material.get("state_counts")
+    if not isinstance(record_digests, list) or not isinstance(state_counts, dict):
         return False
+    record_count = material.get("record_count")
+    if not isinstance(record_count, int) or record_count != len(record_digests):
+        return False
+    if any(not isinstance(value, int) or value < 0 for value in state_counts.values()):
+        return False
+    if sum(state_counts.values()) != record_count:
+        return False
+    if not material.get("ledger_chain_verified"):
+        return False
+    if any(
+        bool(material.get(key))
+        for key in (
+            "claim_promotion_performed",
+            "deployment_performed",
+            "external_execution_performed",
+        )
+    ):
+        return False
+    if record_count == 0:
+        if material.get("head_sequence") is not None or material.get("head_record_digest") is not None:
+            return False
+    else:
+        if material.get("head_sequence") != record_count:
+            return False
+        if material.get("head_record_digest") != record_digests[-1]:
+            return False
     if material.get("records_digest") != canonical_digest({"record_digests": record_digests}):
         return False
     cursor = material.get("feedback_cursor")
     if not isinstance(cursor, dict):
         return False
     try:
-        from .improvement_feedback import ImprovementFeedbackCursor
-
         parsed = ImprovementFeedbackCursor.model_validate(cursor)
     except ValueError:
         return False
@@ -106,10 +159,13 @@ def manifest_matches_runtime(
     cursor = runtime.load_cursor()
     if not runtime.ledger.verify_chain():
         return False
+    expected_counts = dict(sorted(Counter(record.state for record in records).items()))
     return (
         manifest.record_count == len(records)
         and manifest.head_sequence == (None if not records else records[-1].sequence)
         and manifest.head_record_digest == (None if not records else records[-1].record_digest)
+        and manifest.state_counts == expected_counts
         and manifest.record_digests == [record.record_digest for record in records]
+        and manifest.feedback_cursor == cursor.model_dump(mode="json")
         and manifest.feedback_cursor_digest == feedback_cursor_digest(cursor)
     )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_feedback.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+from .echo_event_store import EchoEventStore, EchoStoredEvent
+from .improvement_cycle import ImprovementState
+from .improvement_ledger import ImprovementLedger, ImprovementLedgerError
+from .operational_improvement import OperationalImprovementSignalError, stored_echo_event_to_improvement
+from .qualification import canonical_digest
+
+_SIGNAL_KEY = "_ws_improvement_signal"
+
+
+class ImprovementFeedbackPolicy(BaseModel):
+    max_echo_events_per_cycle: int = Field(default=64, ge=1, le=4096)
+    max_new_proposals_per_cycle: int = Field(default=32, ge=1, le=1024)
+    allow_claim_promotion: bool = False
+    allow_deployment: bool = False
+    allow_external_execution: bool = False
+
+    @model_validator(mode="after")
+    def fail_closed(self) -> "ImprovementFeedbackPolicy":
+        if self.allow_claim_promotion:
+            raise ValueError("feedback cycle may not authorize claim promotion")
+        if self.allow_deployment:
+            raise ValueError("feedback cycle may not authorize deployment")
+        if self.allow_external_execution:
+            raise ValueError("feedback cycle may not authorize external execution")
+        return self
+
+
+class ImprovementFeedbackCursor(BaseModel):
+    schema: str = "ws-ri-feedback-cursor-1"
+    cycle_index: int = Field(default=0, ge=0)
+    last_first_ingested_at: str | None = None
+    last_event_id: str | None = None
+    prior_state_digest: str | None = None
+
+
+class ImprovementFeedbackReport(BaseModel):
+    schema: str = "ws-ri-feedback-report-1"
+    cycle_index: int
+    scanned_events: int
+    ordinary_events_ignored: int
+    explicit_signals_seen: int
+    proposals_stored: int
+    proposals_deduplicated: int
+    invalid_signal_event_ids: list[str] = Field(default_factory=list)
+    deferred_signal_event_ids: list[str] = Field(default_factory=list)
+    cursor_event_id: str | None = None
+    claim_promotion_performed: bool = False
+    deployment_performed: bool = False
+    external_execution_performed: bool = False
+    report_digest: str = ""
+
+
+def feedback_cursor_digest(cursor: ImprovementFeedbackCursor) -> str:
+    return canonical_digest(cursor.model_dump(mode="json"))
+
+
+def _sort_key(item: EchoStoredEvent) -> tuple[str, str]:
+    return item.first_ingested_at, item.event_id
+
+
+def _after_cursor(item: EchoStoredEvent, cursor: ImprovementFeedbackCursor) -> bool:
+    if cursor.last_first_ingested_at is None or cursor.last_event_id is None:
+        return True
+    return _sort_key(item) > (cursor.last_first_ingested_at, cursor.last_event_id)
+
+
+def run_operational_feedback_cycle(
+    store: EchoEventStore,
+    ledger: ImprovementLedger,
+    cursor: ImprovementFeedbackCursor,
+    *,
+    policy: ImprovementFeedbackPolicy | None = None,
+    actor: str = "SARA",
+) -> tuple[ImprovementFeedbackCursor, ImprovementFeedbackReport]:
+    active = policy or ImprovementFeedbackPolicy()
+    if not actor.strip():
+        raise ValueError("identified ledger actor is required")
+    pending = [item for item in store.all_records() if _after_cursor(item, cursor)]
+    pending.sort(key=_sort_key)
+    window = pending[: active.max_echo_events_per_cycle]
+    scanned = ordinary = explicit = stored_count = dedupe_count = 0
+    invalid: list[str] = []
+    deferred: list[str] = []
+    last_consumed: EchoStoredEvent | None = None
+    for item in window:
+        scanned += 1
+        try:
+            payload = item.payload()
+        except Exception:
+            invalid.append(item.event_id)
+            break
+        if _SIGNAL_KEY not in payload:
+            ordinary += 1
+            last_consumed = item
+            continue
+        explicit += 1
+        if stored_count + dedupe_count >= active.max_new_proposals_per_cycle:
+            deferred.append(item.event_id)
+            break
+        try:
+            proposal = stored_echo_event_to_improvement(item, created_utc=item.first_ingested_at)
+            if proposal.state != ImprovementState.PROPOSED:
+                raise ImprovementLedgerError("feedback producer emitted a non-PROPOSED improvement")
+            result = ledger.append(
+                proposal,
+                actor=actor.strip(),
+                recorded_utc=item.first_ingested_at,
+                reason=f"bounded ECHO feedback ingestion from {item.event_id}",
+            )
+        except (OperationalImprovementSignalError, ImprovementLedgerError, ValueError):
+            invalid.append(item.event_id)
+            last_consumed = item
+            continue
+        if result.outcome == "STORED":
+            stored_count += 1
+        elif result.outcome == "DEDUPLICATED":
+            dedupe_count += 1
+        else:
+            raise ImprovementLedgerError("unexpected WS-RI ledger append outcome")
+        last_consumed = item
+    before_digest = feedback_cursor_digest(cursor)
+    next_cursor = ImprovementFeedbackCursor(
+        cycle_index=cursor.cycle_index + 1,
+        last_first_ingested_at=cursor.last_first_ingested_at if last_consumed is None else last_consumed.first_ingested_at,
+        last_event_id=cursor.last_event_id if last_consumed is None else last_consumed.event_id,
+        prior_state_digest=before_digest,
+    )
+    payload = {
+        "schema": "ws-ri-feedback-report-1",
+        "cycle_index": next_cursor.cycle_index,
+        "scanned_events": scanned,
+        "ordinary_events_ignored": ordinary,
+        "explicit_signals_seen": explicit,
+        "proposals_stored": stored_count,
+        "proposals_deduplicated": dedupe_count,
+        "invalid_signal_event_ids": invalid,
+        "deferred_signal_event_ids": deferred,
+        "cursor_event_id": next_cursor.last_event_id,
+        "claim_promotion_performed": False,
+        "deployment_performed": False,
+        "external_execution_performed": False,
+    }
+    return next_cursor, ImprovementFeedbackReport(**payload, report_digest=canonical_digest(payload))

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_handoff.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_handoff.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+from .autonomy_policy import ExecutionDisposition
+from .improvement_feedback import ImprovementFeedbackPolicy
+from .improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
+from .qualification import canonical_digest
+
+
+HANDOFF_SCHEMA = "ws-ri-scheduler-handoff-1"
+
+
+class ImprovementHandoffAction(StrEnum):
+    RUN_ONE_BOUNDED_FEEDBACK_CYCLE = "RUN_ONE_BOUNDED_FEEDBACK_CYCLE"
+
+
+class ImprovementSchedulerHandoff(BaseModel):
+    schema: str = HANDOFF_SCHEMA
+    handoff_id: str = Field(pattern=r"^WS-RI-HANDOFF-[A-F0-9]{16}$")
+    action: ImprovementHandoffAction
+    requested_by: str = Field(min_length=1)
+    generated_utc: str = Field(min_length=1)
+    ledger_head_digest: str | None = None
+    feedback_cursor_digest: str = Field(min_length=1)
+    max_echo_events: int = Field(ge=1, le=4096)
+    max_new_proposals: int = Field(ge=1, le=1024)
+    execution_disposition: ExecutionDisposition = ExecutionDisposition.HUMAN_REVIEW_REQUIRED
+    authorization_required: bool = True
+    autonomous_execution_authorized: bool = False
+    claim_promotion_authorized: bool = False
+    deployment_authorized: bool = False
+    external_execution_authorized: bool = False
+    claims_boundary: str = Field(min_length=1)
+    handoff_digest: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def fail_closed(self) -> "ImprovementSchedulerHandoff":
+        if self.execution_disposition != ExecutionDisposition.HUMAN_REVIEW_REQUIRED:
+            raise ValueError("WS-RI handoff must remain human/authorized-scheduler gated")
+        if not self.authorization_required:
+            raise ValueError("WS-RI handoff must require authorization")
+        if any(
+            (
+                self.autonomous_execution_authorized,
+                self.claim_promotion_authorized,
+                self.deployment_authorized,
+                self.external_execution_authorized,
+            )
+        ):
+            raise ValueError("WS-RI handoff cannot grant execution, promotion, or deployment authority")
+        return self
+
+
+def _handoff_payload(
+    runtime: ImprovementRuntime,
+    *,
+    requested_by: str,
+    generated_utc: str,
+    policy: ImprovementFeedbackPolicy,
+) -> dict[str, object]:
+    if not requested_by.strip() or not generated_utc.strip():
+        raise ImprovementRuntimeError("requested_by and generated_utc are required")
+    status = runtime.status()
+    if not status["ledger_chain_verified"]:
+        raise ImprovementRuntimeError("WS-RI ledger chain must verify before scheduler handoff")
+    if not status["echo_source_configured"]:
+        raise ImprovementRuntimeError("WS-RI ECHO source is required for feedback handoff")
+    return {
+        "schema": HANDOFF_SCHEMA,
+        "action": ImprovementHandoffAction.RUN_ONE_BOUNDED_FEEDBACK_CYCLE.value,
+        "requested_by": requested_by.strip(),
+        "generated_utc": generated_utc.strip(),
+        "ledger_head_digest": status["head_record_digest"],
+        "feedback_cursor_digest": status["feedback_cursor_digest"],
+        "max_echo_events": policy.max_echo_events_per_cycle,
+        "max_new_proposals": policy.max_new_proposals_per_cycle,
+        "execution_disposition": ExecutionDisposition.HUMAN_REVIEW_REQUIRED.value,
+        "authorization_required": True,
+        "autonomous_execution_authorized": False,
+        "claim_promotion_authorized": False,
+        "deployment_authorized": False,
+        "external_execution_authorized": False,
+        "claims_boundary": (
+            "handoff artifact only; an identified operator or separately authorized scheduler "
+            "must invoke one bounded feedback cycle; no claim promotion or deployment authority"
+        ),
+    }
+
+
+def build_scheduler_handoff(
+    runtime: ImprovementRuntime,
+    *,
+    requested_by: str,
+    generated_utc: str,
+    policy: ImprovementFeedbackPolicy | None = None,
+) -> ImprovementSchedulerHandoff:
+    active = policy or ImprovementFeedbackPolicy()
+    payload = _handoff_payload(
+        runtime,
+        requested_by=requested_by,
+        generated_utc=generated_utc,
+        policy=active,
+    )
+    digest = canonical_digest(payload)
+    raw = digest.split(":", 1)[-1].upper()
+    return ImprovementSchedulerHandoff(
+        **payload,
+        handoff_id=f"WS-RI-HANDOFF-{raw[:16]}",
+        handoff_digest=digest,
+    )
+
+
+def verify_scheduler_handoff(handoff: ImprovementSchedulerHandoff) -> bool:
+    material = handoff.model_dump(mode="json")
+    observed_digest = str(material.pop("handoff_digest"))
+    handoff_id = str(material.pop("handoff_id"))
+    expected_digest = canonical_digest(material)
+    expected_id = f"WS-RI-HANDOFF-{expected_digest.split(':', 1)[-1].upper()[:16]}"
+    return observed_digest == expected_digest and handoff_id == expected_id

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_ledger.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .improvement_cycle import ImprovementProposal, ImprovementState, proposal_digest
+from .qualification import canonical_digest
+
+LEDGER_SCHEMA = "WS-RI-LEDGER-V1"
+MAX_LEDGER_RECORDS = 16384
+
+class ImprovementLedgerError(RuntimeError):
+    pass
+
+@dataclass(frozen=True)
+class ImprovementLedgerRecord:
+    sequence: int
+    improvement_id: str
+    state: str
+    proposal_digest: str
+    proposal_json: str
+    previous_record_digest: str | None
+    prior_improvement_digest: str | None
+    actor: str
+    recorded_utc: str
+    reason: str
+    record_digest: str
+
+    def proposal(self) -> ImprovementProposal:
+        value = json.loads(self.proposal_json)
+        if not isinstance(value, dict):
+            raise ImprovementLedgerError("stored proposal is not a JSON object")
+        return ImprovementProposal.model_validate(value)
+
+@dataclass(frozen=True)
+class ImprovementLedgerAppendResult:
+    outcome: str
+    record: ImprovementLedgerRecord
+
+_ALLOWED_TRANSITIONS = {
+    ImprovementState.PROPOSED: {ImprovementState.VALIDATING, ImprovementState.HUMAN_REVIEW_REQUIRED, ImprovementState.QUARANTINED},
+    ImprovementState.VALIDATING: {ImprovementState.HUMAN_REVIEW_REQUIRED, ImprovementState.QUARANTINED},
+    ImprovementState.QUARANTINED: {ImprovementState.PROPOSED, ImprovementState.VALIDATING},
+    ImprovementState.HUMAN_REVIEW_REQUIRED: {ImprovementState.PROMOTED, ImprovementState.REJECTED},
+    ImprovementState.PROMOTED: {ImprovementState.SUPERSEDED},
+    ImprovementState.REJECTED: set(),
+    ImprovementState.SUPERSEDED: set(),
+}
+
+def _transition_allowed(previous: ImprovementState | None, current: ImprovementState) -> bool:
+    return current == ImprovementState.PROPOSED if previous is None else current in _ALLOWED_TRANSITIONS[previous]
+
+def _row_to_record(row: sqlite3.Row) -> ImprovementLedgerRecord:
+    return ImprovementLedgerRecord(
+        sequence=int(row["sequence"]), improvement_id=str(row["improvement_id"]), state=str(row["state"]),
+        proposal_digest=str(row["proposal_digest"]), proposal_json=str(row["proposal_json"]),
+        previous_record_digest=row["previous_record_digest"], prior_improvement_digest=row["prior_improvement_digest"],
+        actor=str(row["actor"]), recorded_utc=str(row["recorded_utc"]), reason=str(row["reason"]), record_digest=str(row["record_digest"]),
+    )
+
+def _record_material(record: ImprovementLedgerRecord | None = None, **values) -> dict:
+    if record is not None:
+        values = {
+            "improvement_id": record.improvement_id,
+            "state": record.state,
+            "proposal_digest": record.proposal_digest,
+            "previous_record_digest": record.previous_record_digest,
+            "prior_improvement_digest": record.prior_improvement_digest,
+            "actor": record.actor,
+            "recorded_utc": record.recorded_utc,
+            "reason": record.reason,
+        }
+    return {"schema": LEDGER_SCHEMA, **values}
+
+class ImprovementLedger:
+    """Persistent, application-enforced WS-RI lifecycle custody chain."""
+
+    def __init__(self, data_dir: str | Path) -> None:
+        self.data_dir = Path(data_dir)
+        if not self.data_dir.is_absolute():
+            raise ImprovementLedgerError("WS-RI ledger data directory must be absolute")
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.data_dir / "ws-ri-ledger.db"
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path, timeout=5.0, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA synchronous = FULL")
+        connection.execute("PRAGMA busy_timeout = 5000")
+        return connection
+
+    def _initialize(self) -> None:
+        connection = self._connect()
+        try:
+            connection.executescript("""
+                CREATE TABLE IF NOT EXISTS wsri_metadata (name TEXT PRIMARY KEY, value TEXT NOT NULL);
+                CREATE TABLE IF NOT EXISTS wsri_records (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    improvement_id TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    proposal_digest TEXT NOT NULL,
+                    proposal_json TEXT NOT NULL,
+                    previous_record_digest TEXT,
+                    prior_improvement_digest TEXT,
+                    actor TEXT NOT NULL,
+                    recorded_utc TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    record_digest TEXT NOT NULL UNIQUE,
+                    UNIQUE(improvement_id, proposal_digest)
+                );
+                CREATE INDEX IF NOT EXISTS idx_wsri_records_improvement ON wsri_records(improvement_id, sequence);
+            """)
+            connection.execute("INSERT OR IGNORE INTO wsri_metadata(name,value) VALUES('schema',?)", (LEDGER_SCHEMA,))
+            row = connection.execute("SELECT value FROM wsri_metadata WHERE name='schema'").fetchone()
+            if row is None or row["value"] != LEDGER_SCHEMA:
+                raise ImprovementLedgerError("WS-RI ledger schema mismatch")
+        finally:
+            connection.close()
+
+    def append(self, proposal: ImprovementProposal, *, actor: str, recorded_utc: str, reason: str) -> ImprovementLedgerAppendResult:
+        if not actor.strip() or not recorded_utc.strip() or not reason.strip():
+            raise ImprovementLedgerError("actor, recorded_utc, and reason are required")
+        pdigest = proposal_digest(proposal)
+        pjson = json.dumps(proposal.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            duplicate = connection.execute("SELECT * FROM wsri_records WHERE improvement_id=? AND proposal_digest=?", (proposal.improvement_id, pdigest)).fetchone()
+            if duplicate is not None:
+                connection.commit()
+                return ImprovementLedgerAppendResult("DEDUPLICATED", _row_to_record(duplicate))
+            count = connection.execute("SELECT COUNT(*) FROM wsri_records").fetchone()[0]
+            if count >= MAX_LEDGER_RECORDS:
+                raise ImprovementLedgerError("WS-RI ledger capacity reached")
+            global_prior = connection.execute("SELECT * FROM wsri_records ORDER BY sequence DESC LIMIT 1").fetchone()
+            item_prior = connection.execute("SELECT * FROM wsri_records WHERE improvement_id=? ORDER BY sequence DESC LIMIT 1", (proposal.improvement_id,)).fetchone()
+            prior_state = None if item_prior is None else ImprovementState(item_prior["state"])
+            if not _transition_allowed(prior_state, proposal.state):
+                before = "NONE" if prior_state is None else prior_state.value
+                raise ImprovementLedgerError(f"invalid WS-RI transition {before}->{proposal.state.value}")
+            previous_digest = None if global_prior is None else global_prior["record_digest"]
+            item_digest = None if item_prior is None else item_prior["record_digest"]
+            material = _record_material(
+                improvement_id=proposal.improvement_id, state=proposal.state.value, proposal_digest=pdigest,
+                previous_record_digest=previous_digest, prior_improvement_digest=item_digest,
+                actor=actor.strip(), recorded_utc=recorded_utc.strip(), reason=reason.strip(),
+            )
+            rdigest = canonical_digest(material)
+            connection.execute("""
+                INSERT INTO wsri_records(improvement_id,state,proposal_digest,proposal_json,previous_record_digest,prior_improvement_digest,actor,recorded_utc,reason,record_digest)
+                VALUES(?,?,?,?,?,?,?,?,?,?)
+            """, (proposal.improvement_id, proposal.state.value, pdigest, pjson, previous_digest, item_digest, actor.strip(), recorded_utc.strip(), reason.strip(), rdigest))
+            row = connection.execute("SELECT * FROM wsri_records WHERE record_digest=?", (rdigest,)).fetchone()
+            connection.commit()
+            assert row is not None
+            return ImprovementLedgerAppendResult("STORED", _row_to_record(row))
+        except Exception:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def records(self) -> list[ImprovementLedgerRecord]:
+        connection = self._connect()
+        try:
+            return [_row_to_record(row) for row in connection.execute("SELECT * FROM wsri_records ORDER BY sequence").fetchall()]
+        finally:
+            connection.close()
+
+    def latest(self, improvement_id: str) -> ImprovementLedgerRecord | None:
+        connection = self._connect()
+        try:
+            row = connection.execute("SELECT * FROM wsri_records WHERE improvement_id=? ORDER BY sequence DESC LIMIT 1", (improvement_id,)).fetchone()
+            return None if row is None else _row_to_record(row)
+        finally:
+            connection.close()
+
+    def verify_chain(self) -> bool:
+        previous = None
+        prior_by_id: dict[str, ImprovementLedgerRecord] = {}
+        for record in self.records():
+            prior = prior_by_id.get(record.improvement_id)
+            if record.previous_record_digest != previous:
+                return False
+            if record.prior_improvement_digest != (None if prior is None else prior.record_digest):
+                return False
+            try:
+                proposal = record.proposal()
+            except Exception:
+                return False
+            if proposal.improvement_id != record.improvement_id or proposal.state.value != record.state:
+                return False
+            prior_state = None if prior is None else ImprovementState(prior.state)
+            if not _transition_allowed(prior_state, proposal.state):
+                return False
+            if proposal_digest(proposal) != record.proposal_digest:
+                return False
+            if canonical_digest(_record_material(record)) != record.record_digest:
+                return False
+            previous = record.record_digest
+            prior_by_id[record.improvement_id] = record
+        return True

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_routing.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Iterable
+
+from pydantic import BaseModel, Field
+
+from .config_custody import ConfigurationSnapshot, create_snapshot
+from .improvement_cycle import (
+    ImprovementProposal,
+    ImprovementRisk,
+    ImprovementState,
+    ImprovementTriggerKind,
+)
+from .qualification import CapabilityStatus, ReviewStatus, canonical_digest
+from .recursive_discovery import (
+    DiscoveryEvidenceState,
+    DiscoveryKind,
+    DiscoveryNode,
+    route_node,
+)
+
+
+class ImprovementRoute(str, Enum):
+    ECHO = "ECHO"
+    PRE = "PRE"
+    PRIME = "PRIME"
+    PRIME_TEVV = "PRIME-TEVV"
+    OVERWATCH = "OVERWATCH"
+    RED_TEAM = "RED-TEAM"
+    PARTNER_SCREENING = "PARTNER-SCREENING"
+    CONFIG_CUSTODY = "CONFIG-CUSTODY"
+    OMEGA = "WS-OMEGA"
+
+
+class ImprovementRoutingEnvelope(BaseModel):
+    schema: str = "ws-recursive-improvement-routing-1"
+    improvement_id: str
+    routes: list[ImprovementRoute] = Field(min_length=1)
+    lineage_refs: list[str] = Field(min_length=1)
+    custody_eligible: bool = False
+    deployment_authorized: bool = False
+    claim_promotion_performed: bool = False
+    external_execution_performed: bool = False
+    envelope_digest: str = ""
+
+
+_TRIGGER_BY_DISCOVERY_KIND = {
+    DiscoveryKind.DOMAIN: ImprovementTriggerKind.RESEARCH,
+    DiscoveryKind.OBSERVATION: ImprovementTriggerKind.NEW_EVIDENCE,
+    DiscoveryKind.HYPOTHESIS: ImprovementTriggerKind.RESEARCH,
+    DiscoveryKind.CONTRADICTION: ImprovementTriggerKind.CONTRADICTION,
+    DiscoveryKind.NEGATIVE_SPACE: ImprovementTriggerKind.RESEARCH,
+    DiscoveryKind.EXPERIMENT: ImprovementTriggerKind.TEST_RESULT,
+    DiscoveryKind.PARTNER: ImprovementTriggerKind.PARTNER_FEEDBACK,
+    DiscoveryKind.OPPORTUNITY: ImprovementTriggerKind.OPPORTUNITY,
+    DiscoveryKind.STANDARD: ImprovementTriggerKind.REQUIREMENT_DELTA,
+    DiscoveryKind.PRIOR_ART: ImprovementTriggerKind.RESEARCH,
+    DiscoveryKind.RISK: ImprovementTriggerKind.ANOMALY,
+}
+
+_CAPABILITY_BY_EVIDENCE_STATE = {
+    DiscoveryEvidenceState.SOURCE_VERIFIED: CapabilityStatus.SUPPORTED_BY_LITERATURE,
+    DiscoveryEvidenceState.CORROBORATED: CapabilityStatus.SUPPORTED_BY_LITERATURE,
+    DiscoveryEvidenceState.SINGLE_SOURCE: CapabilityStatus.HYPOTHESIS,
+    DiscoveryEvidenceState.SIMULATED: CapabilityStatus.SIMULATED_ONLY,
+    DiscoveryEvidenceState.HYPOTHESIS: CapabilityStatus.HYPOTHESIS,
+    DiscoveryEvidenceState.SPECULATIVE: CapabilityStatus.SPECULATIVE_EXTENSION,
+    DiscoveryEvidenceState.CONFLICTING: CapabilityStatus.NOT_CURRENTLY_CLAIMED,
+    DiscoveryEvidenceState.UNVERIFIED: CapabilityStatus.NOT_CURRENTLY_CLAIMED,
+}
+
+_RISK_BY_DISCOVERY_KIND = {
+    DiscoveryKind.DOMAIN: ImprovementRisk.LOW,
+    DiscoveryKind.OBSERVATION: ImprovementRisk.MODERATE,
+    DiscoveryKind.HYPOTHESIS: ImprovementRisk.MODERATE,
+    DiscoveryKind.CONTRADICTION: ImprovementRisk.HIGH,
+    DiscoveryKind.NEGATIVE_SPACE: ImprovementRisk.MODERATE,
+    DiscoveryKind.EXPERIMENT: ImprovementRisk.MODERATE,
+    DiscoveryKind.PARTNER: ImprovementRisk.MODERATE,
+    DiscoveryKind.OPPORTUNITY: ImprovementRisk.MODERATE,
+    DiscoveryKind.STANDARD: ImprovementRisk.MODERATE,
+    DiscoveryKind.PRIOR_ART: ImprovementRisk.HIGH,
+    DiscoveryKind.RISK: ImprovementRisk.HIGH,
+}
+
+
+def _stable_improvement_id(node: DiscoveryNode, created_utc: str) -> str:
+    year = created_utc[:4]
+    if len(year) != 4 or not year.isdigit():
+        raise ValueError("created_utc must begin with a four-digit year")
+    material = {
+        "node_id": node.node_id,
+        "statement": node.statement,
+        "source_refs": sorted(set(node.source_refs)),
+        "created_year": year,
+    }
+    digest_hex = canonical_digest(material).split(":", 1)[1]
+    numeric_suffix = str(int(digest_hex[:12], 16))
+    return f"WS-IR-{year}-{numeric_suffix}"
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def omega_to_improvement(
+    node: DiscoveryNode,
+    *,
+    created_utc: str,
+    baseline_artifacts: Iterable[str] = (),
+    additional_required_tests: Iterable[str] = (),
+) -> ImprovementProposal:
+    """Translate an OMEGA discovery into a governed WS-RI proposal.
+
+    Translation preserves lineage and evidence state but does not elevate
+    capability maturity, perform claim promotion, authorize external execution,
+    or deploy any change.
+    """
+
+    trigger = _TRIGGER_BY_DISCOVERY_KIND[node.kind]
+    baseline_status = _CAPABILITY_BY_EVIDENCE_STATE[node.evidence_state]
+    lanes = _dedupe([*(node.downstream_routes or route_node(node.kind)), "WS-RI"])
+    sources = _dedupe([node.node_id, *node.source_refs])
+
+    required_tests = _dedupe(
+        [
+            f"{node.node_id}:source-evidence-gate",
+            f"{node.node_id}:red-team-gate",
+            *node.falsification_tests,
+            *additional_required_tests,
+        ]
+    )
+
+    risks = [
+        "Discovery relevance or source interpretation may not transfer cleanly into the affected Worldshepherd lanes.",
+        "No capability, readiness, partner-validation, certification, or physical-performance claim may be elevated from this translation alone.",
+    ]
+    if node.evidence_state in {
+        DiscoveryEvidenceState.SINGLE_SOURCE,
+        DiscoveryEvidenceState.HYPOTHESIS,
+        DiscoveryEvidenceState.SPECULATIVE,
+        DiscoveryEvidenceState.CONFLICTING,
+        DiscoveryEvidenceState.UNVERIFIED,
+    }:
+        risks.append("Evidence is incomplete, conflicting, or not independently corroborated.")
+    if node.cross_domain_tags:
+        risks.append("Cross-domain applicability remains a hypothesis until receiving-lane qualification succeeds.")
+
+    return ImprovementProposal(
+        improvement_id=_stable_improvement_id(node, created_utc),
+        trigger_kind=trigger,
+        title=f"OMEGA improvement candidate: {node.domain}",
+        source_refs=sources,
+        affected_lanes=lanes,
+        baseline_artifacts=_dedupe(baseline_artifacts),
+        baseline_capability_status=[baseline_status],
+        target_capability_status=None,
+        proposed_change=(
+            "Evaluate and, only if qualification succeeds, incorporate the following "
+            f"OMEGA discovery into the affected Worldshepherd lanes: {node.statement}"
+        ),
+        expected_benefit=(
+            "Close the traceable gap between recursive discovery and governed Worldshepherd change control while preserving evidence and claims boundaries."
+        ),
+        assumptions=[
+            "The OMEGA node accurately represents its current evidence state and provenance references.",
+            "Existing PRE, ECHO, TEVV, PRIME, and configuration-custody controls remain authoritative.",
+        ],
+        risks=risks,
+        risk_level=_RISK_BY_DISCOVERY_KIND[node.kind],
+        required_tests=required_tests,
+        success_metrics=[
+            "All required validation tests return PASS.",
+            "No claims-boundary violation is introduced.",
+            "No unauthorized external execution occurs.",
+            "Affected-lane evidence and configuration lineage remain traceable.",
+        ],
+        negative_evidence=[],
+        reversible=True,
+        generated_by="WS-OMEGA->WS-RI",
+        created_utc=created_utc,
+        state=ImprovementState.PROPOSED,
+        requested_claim_promotion=False,
+        requested_external_execution=False,
+    )
+
+
+def route_improvement(proposal: ImprovementProposal) -> ImprovementRoutingEnvelope:
+    """Produce deterministic downstream routes without executing any route."""
+
+    routes: list[ImprovementRoute] = [
+        ImprovementRoute.ECHO,
+        ImprovementRoute.OMEGA,
+        ImprovementRoute.PRIME_TEVV,
+    ]
+
+    if proposal.trigger_kind in {
+        ImprovementTriggerKind.REQUIREMENT_DELTA,
+        ImprovementTriggerKind.OPPORTUNITY,
+        ImprovementTriggerKind.PARTNER_FEEDBACK,
+        ImprovementTriggerKind.RESEARCH,
+        ImprovementTriggerKind.NEW_EVIDENCE,
+    }:
+        routes.append(ImprovementRoute.PRE)
+
+    if proposal.trigger_kind in {
+        ImprovementTriggerKind.FAILURE,
+        ImprovementTriggerKind.ANOMALY,
+        ImprovementTriggerKind.CONTRADICTION,
+        ImprovementTriggerKind.SECURITY_EVENT,
+        ImprovementTriggerKind.TEST_RESULT,
+    }:
+        routes.extend([ImprovementRoute.PRIME, ImprovementRoute.OVERWATCH, ImprovementRoute.RED_TEAM])
+
+    if proposal.trigger_kind in {
+        ImprovementTriggerKind.PARTNER_FEEDBACK,
+        ImprovementTriggerKind.OPPORTUNITY,
+    }:
+        routes.append(ImprovementRoute.PARTNER_SCREENING)
+
+    custody_eligible = proposal.state == ImprovementState.PROMOTED
+    if custody_eligible:
+        routes.append(ImprovementRoute.CONFIG_CUSTODY)
+
+    unique_routes = list(dict.fromkeys(routes))
+    lineage = _dedupe([proposal.improvement_id, *proposal.source_refs, *proposal.review.qualification_refs])
+    payload = {
+        "schema": "ws-recursive-improvement-routing-1",
+        "improvement_id": proposal.improvement_id,
+        "routes": [route.value for route in unique_routes],
+        "lineage_refs": lineage,
+        "custody_eligible": custody_eligible,
+        "deployment_authorized": False,
+        "claim_promotion_performed": False,
+        "external_execution_performed": False,
+    }
+    return ImprovementRoutingEnvelope(
+        improvement_id=proposal.improvement_id,
+        routes=unique_routes,
+        lineage_refs=lineage,
+        custody_eligible=custody_eligible,
+        deployment_authorized=False,
+        claim_promotion_performed=False,
+        external_execution_performed=False,
+        envelope_digest=canonical_digest(payload),
+    )
+
+
+def build_promoted_configuration_snapshot(
+    proposal: ImprovementProposal,
+    *,
+    candidate_payload: dict,
+    snapshot_id: str,
+    created_utc: str,
+    actor: str,
+    parent_digest: str | None,
+) -> ConfigurationSnapshot:
+    """Stage a configuration-custody snapshot for a promoted improvement.
+
+    This returns a snapshot only. It does not append to a custody ledger,
+    merge code, deploy a release, actuate hardware, or execute any external
+    action. The caller must still use the existing authorized custody/change
+    path.
+    """
+
+    if proposal.state != ImprovementState.PROMOTED:
+        raise ValueError("configuration custody requires a PROMOTED improvement record")
+    if proposal.review.status != ReviewStatus.ACCEPTED:
+        raise ValueError("configuration custody requires accepted human review")
+    if not proposal.review.authorization_ref:
+        raise ValueError("configuration custody requires an authorization reference")
+    if not proposal.review.qualification_refs:
+        raise ValueError("configuration custody requires qualification evidence")
+    if not actor.strip():
+        raise ValueError("configuration custody requires an identified actor")
+
+    reason = (
+        f"Stage promoted Worldshepherd improvement {proposal.improvement_id}; "
+        f"authorization={proposal.review.authorization_ref}; "
+        f"qualification={','.join(proposal.review.qualification_refs)}"
+    )
+    return create_snapshot(
+        snapshot_id=snapshot_id,
+        payload=dict(candidate_payload),
+        created_utc=created_utc,
+        actor=actor,
+        reason=reason,
+        parent_digest=parent_digest,
+    )

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+from .echo_event_store import EchoEventStore
+from .improvement_checkpoint import LEDGER_ECHO_EVENT_SCHEMA, build_ledger_checkpoint
+from .improvement_feedback import (
+    ImprovementFeedbackCursor,
+    ImprovementFeedbackPolicy,
+    ImprovementFeedbackReport,
+    run_operational_feedback_cycle,
+)
+from .improvement_ledger import ImprovementLedger
+
+
+RUNTIME_STATE_SCHEMA = "WS-RI-RUNTIME-STATE-V1"
+RUNTIME_STATE_FILENAME = "ws-ri-runtime-state.json"
+
+
+class ImprovementRuntimeError(RuntimeError):
+    pass
+
+
+class ImprovementRuntime:
+    """Operator-invoked WS-RI runtime with persistent bounded-feedback cursor.
+
+    The runtime does not schedule itself. Repeated execution requires an
+    existing authorized scheduler or a human/operator call.
+    """
+
+    def __init__(
+        self,
+        wsri_data_dir: str | Path,
+        *,
+        echo_data_dir: str | Path | None = None,
+    ) -> None:
+        root = Path(wsri_data_dir)
+        if not root.is_absolute():
+            raise ImprovementRuntimeError("WS-RI data directory must be absolute")
+        root.mkdir(parents=True, exist_ok=True)
+        self.root = root
+        self.ledger = ImprovementLedger(root)
+        self.echo_store = None
+        if echo_data_dir is not None:
+            echo_root = Path(echo_data_dir)
+            if not echo_root.is_absolute():
+                raise ImprovementRuntimeError("WS-RI ECHO data directory must be absolute")
+            self.echo_store = EchoEventStore(echo_root)
+        self.state_path = root / RUNTIME_STATE_FILENAME
+
+    @classmethod
+    def from_environment(cls) -> "ImprovementRuntime | None":
+        wsri = os.getenv("WSRI_DATA_DIR", "").strip()
+        if not wsri:
+            return None
+        echo = os.getenv("WSRI_ECHO_DATA_DIR", "").strip() or None
+        return cls(wsri, echo_data_dir=echo)
+
+    def load_cursor(self) -> ImprovementFeedbackCursor:
+        if not self.state_path.exists():
+            return ImprovementFeedbackCursor()
+        try:
+            value = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ImprovementRuntimeError("unable to read WS-RI runtime state") from exc
+        if not isinstance(value, dict) or value.get("schema") != RUNTIME_STATE_SCHEMA:
+            raise ImprovementRuntimeError("WS-RI runtime state schema mismatch")
+        raw = value.get("feedback_cursor")
+        if not isinstance(raw, dict):
+            raise ImprovementRuntimeError("WS-RI runtime feedback cursor is malformed")
+        return ImprovementFeedbackCursor.model_validate(raw)
+
+    def _save_cursor(self, cursor: ImprovementFeedbackCursor) -> None:
+        payload = {
+            "schema": RUNTIME_STATE_SCHEMA,
+            "feedback_cursor": cursor.model_dump(mode="json"),
+            "claims_boundary": (
+                "operational cursor state only; not qualification evidence, "
+                "authorization, claim promotion, or deployment evidence"
+            ),
+        }
+        temp = self.state_path.with_suffix(".tmp")
+        data = json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+        try:
+            with temp.open("w", encoding="utf-8") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp, self.state_path)
+            descriptor = os.open(self.root, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        except OSError as exc:
+            try:
+                temp.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise ImprovementRuntimeError("unable to persist WS-RI runtime state") from exc
+
+    def status(self) -> dict[str, object]:
+        records = self.ledger.records()
+        head = records[-1] if records else None
+        counts = dict(sorted(Counter(record.state for record in records).items()))
+        cursor = self.load_cursor()
+        return {
+            "configured": True,
+            "echo_source_configured": self.echo_store is not None,
+            "ledger_chain_verified": self.ledger.verify_chain(),
+            "record_count": len(records),
+            "head_sequence": None if head is None else head.sequence,
+            "head_record_digest": None if head is None else head.record_digest,
+            "state_counts": counts,
+            "feedback_cursor": cursor.model_dump(mode="json"),
+            "autonomous_scheduler_active": False,
+            "claim_promotion_performed": False,
+            "deployment_performed": False,
+            "external_execution_performed": False,
+        }
+
+    def export_records(
+        self,
+        *,
+        limit: int = 50,
+        improvement_id: str | None = None,
+    ) -> list[dict[str, object]]:
+        if limit < 1 or limit > 500:
+            raise ImprovementRuntimeError("record export limit must be between 1 and 500")
+        records = self.ledger.records()
+        if improvement_id is not None:
+            records = [record for record in records if record.improvement_id == improvement_id]
+        selected = records[-limit:]
+        return [
+            {
+                "sequence": record.sequence,
+                "improvement_id": record.improvement_id,
+                "state": record.state,
+                "proposal_digest": record.proposal_digest,
+                "previous_record_digest": record.previous_record_digest,
+                "prior_improvement_digest": record.prior_improvement_digest,
+                "actor": record.actor,
+                "recorded_utc": record.recorded_utc,
+                "reason": record.reason,
+                "record_digest": record.record_digest,
+                "proposal": record.proposal().model_dump(mode="json"),
+            }
+            for record in selected
+        ]
+
+    def run_feedback_once(
+        self,
+        *,
+        actor: str,
+        policy: ImprovementFeedbackPolicy | None = None,
+    ) -> ImprovementFeedbackReport:
+        if self.echo_store is None:
+            raise ImprovementRuntimeError("WS-RI ECHO source is not configured")
+        cursor = self.load_cursor()
+        next_cursor, report = run_operational_feedback_cycle(
+            self.echo_store,
+            self.ledger,
+            cursor,
+            policy=policy,
+            actor=actor,
+        )
+        self._save_cursor(next_cursor)
+        return report
+
+    def checkpoint_outbox_payload(self, *, created_utc: str) -> dict[str, object]:
+        checkpoint = build_ledger_checkpoint(self.ledger, created_utc=created_utc)
+        return {
+            "_ws_ri_ledger_checkpoint": checkpoint.model_dump(mode="json"),
+            "anchor_schema": LEDGER_ECHO_EVENT_SCHEMA,
+            "claims_boundary": (
+                "SARA outbox staging only; ECHO custody and signed inclusion require "
+                "separate successful ECHO ingestion/checkpoint verification"
+            ),
+        }

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime.py
@@ -11,6 +11,7 @@ from .improvement_feedback import (
     ImprovementFeedbackCursor,
     ImprovementFeedbackPolicy,
     ImprovementFeedbackReport,
+    feedback_cursor_digest,
     run_operational_feedback_cycle,
 )
 from .improvement_ledger import ImprovementLedger
@@ -62,6 +63,8 @@ class ImprovementRuntime:
     def load_cursor(self) -> ImprovementFeedbackCursor:
         if not self.state_path.exists():
             return ImprovementFeedbackCursor()
+        if self.state_path.is_symlink():
+            raise ImprovementRuntimeError("WS-RI runtime state must not be a symbolic link")
         try:
             value = json.loads(self.state_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -71,12 +74,22 @@ class ImprovementRuntime:
         raw = value.get("feedback_cursor")
         if not isinstance(raw, dict):
             raise ImprovementRuntimeError("WS-RI runtime feedback cursor is malformed")
-        return ImprovementFeedbackCursor.model_validate(raw)
+        try:
+            cursor = ImprovementFeedbackCursor.model_validate(raw)
+        except ValueError as exc:
+            raise ImprovementRuntimeError("WS-RI runtime feedback cursor is invalid") from exc
+        stored_digest = value.get("feedback_cursor_digest")
+        if not isinstance(stored_digest, str):
+            raise ImprovementRuntimeError("WS-RI runtime cursor digest is missing")
+        if stored_digest != feedback_cursor_digest(cursor):
+            raise ImprovementRuntimeError("WS-RI runtime cursor digest mismatch")
+        return cursor
 
     def _save_cursor(self, cursor: ImprovementFeedbackCursor) -> None:
         payload = {
             "schema": RUNTIME_STATE_SCHEMA,
             "feedback_cursor": cursor.model_dump(mode="json"),
+            "feedback_cursor_digest": feedback_cursor_digest(cursor),
             "claims_boundary": (
                 "operational cursor state only; not qualification evidence, "
                 "authorization, claim promotion, or deployment evidence"
@@ -116,6 +129,7 @@ class ImprovementRuntime:
             "head_record_digest": None if head is None else head.record_digest,
             "state_counts": counts,
             "feedback_cursor": cursor.model_dump(mode="json"),
+            "feedback_cursor_digest": feedback_cursor_digest(cursor),
             "autonomous_scheduler_active": False,
             "claim_promotion_performed": False,
             "deployment_performed": False,

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from typing import Sequence
+
+from .improvement_feedback import ImprovementFeedbackPolicy
+from .improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
+
+
+def _json(value: object) -> None:
+    print(json.dumps(value, sort_keys=True, indent=2))
+
+
+def _runtime() -> ImprovementRuntime:
+    runtime = ImprovementRuntime.from_environment()
+    if runtime is None:
+        raise ImprovementRuntimeError("WSRI_DATA_DIR is required")
+    return runtime
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ws-ri-runtime",
+        description="Operator-invoked Worldshepherd recursive-improvement runtime",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="show ledger and feedback-cursor status")
+
+    records = sub.add_parser("records", help="export bounded WS-RI custody records")
+    records.add_argument("--limit", type=int, default=50)
+    records.add_argument("--improvement-id")
+
+    feedback = sub.add_parser("feedback-run", help="run one bounded ECHO feedback cycle")
+    feedback.add_argument("--actor", required=True)
+    feedback.add_argument("--max-events", type=int, default=64)
+    feedback.add_argument("--max-proposals", type=int, default=32)
+
+    checkpoint = sub.add_parser(
+        "checkpoint-payload",
+        help="emit a ledger checkpoint payload for the governed SARA/ECHO provenance path",
+    )
+    checkpoint.add_argument("--created-utc")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        runtime = _runtime()
+        if args.command == "status":
+            _json(runtime.status())
+            return 0
+        if args.command == "records":
+            _json(
+                {
+                    "records": runtime.export_records(
+                        limit=args.limit,
+                        improvement_id=args.improvement_id,
+                    ),
+                    "claims_boundary": "bounded local custody export only",
+                }
+            )
+            return 0
+        if args.command == "feedback-run":
+            policy = ImprovementFeedbackPolicy(
+                max_echo_events_per_cycle=args.max_events,
+                max_new_proposals_per_cycle=args.max_proposals,
+            )
+            report = runtime.run_feedback_once(actor=args.actor, policy=policy)
+            _json(
+                {
+                    "report": report.model_dump(mode="json"),
+                    "scheduler_mode": "OPERATOR_INVOKED_SINGLE_BOUNDED_CYCLE",
+                }
+            )
+            return 0
+        if args.command == "checkpoint-payload":
+            created = args.created_utc or datetime.now(timezone.utc).isoformat()
+            _json(runtime.checkpoint_outbox_payload(created_utc=created))
+            return 0
+    except (ImprovementRuntimeError, OSError, ValueError) as exc:
+        parser = build_parser()
+        parser.error(str(exc))
+    raise AssertionError("unreachable command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/improvement_runtime_cli.py
@@ -5,7 +5,9 @@ import json
 from datetime import datetime, timezone
 from typing import Sequence
 
+from .improvement_evidence_export import build_evidence_manifest
 from .improvement_feedback import ImprovementFeedbackPolicy
+from .improvement_handoff import build_scheduler_handoff
 from .improvement_runtime import ImprovementRuntime, ImprovementRuntimeError
 
 
@@ -18,6 +20,10 @@ def _runtime() -> ImprovementRuntime:
     if runtime is None:
         raise ImprovementRuntimeError("WSRI_DATA_DIR is required")
     return runtime
+
+
+def _utc(value: str | None) -> str:
+    return value or datetime.now(timezone.utc).isoformat()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -43,6 +49,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="emit a ledger checkpoint payload for the governed SARA/ECHO provenance path",
     )
     checkpoint.add_argument("--created-utc")
+
+    handoff = sub.add_parser(
+        "handoff",
+        help="emit a human/authorized-scheduler-gated one-cycle feedback handoff",
+    )
+    handoff.add_argument("--requested-by", required=True)
+    handoff.add_argument("--generated-utc")
+    handoff.add_argument("--max-events", type=int, default=64)
+    handoff.add_argument("--max-proposals", type=int, default=32)
+
+    manifest = sub.add_parser(
+        "evidence-manifest",
+        help="emit a deterministic manifest of current WS-RI custody and cursor state",
+    )
+    manifest.add_argument("--generated-utc")
     return parser
 
 
@@ -78,8 +99,27 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         if args.command == "checkpoint-payload":
-            created = args.created_utc or datetime.now(timezone.utc).isoformat()
-            _json(runtime.checkpoint_outbox_payload(created_utc=created))
+            _json(runtime.checkpoint_outbox_payload(created_utc=_utc(args.created_utc)))
+            return 0
+        if args.command == "handoff":
+            policy = ImprovementFeedbackPolicy(
+                max_echo_events_per_cycle=args.max_events,
+                max_new_proposals_per_cycle=args.max_proposals,
+            )
+            handoff = build_scheduler_handoff(
+                runtime,
+                requested_by=args.requested_by,
+                generated_utc=_utc(args.generated_utc),
+                policy=policy,
+            )
+            _json(handoff.model_dump(mode="json"))
+            return 0
+        if args.command == "evidence-manifest":
+            manifest = build_evidence_manifest(
+                runtime,
+                generated_utc=_utc(args.generated_utc),
+            )
+            _json(manifest.model_dump(mode="json"))
             return 0
     except (ImprovementRuntimeError, OSError, ValueError) as exc:
         parser = build_parser()

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/operational_improvement.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+from pydantic import BaseModel, Field, model_validator
+
+from .echo_event_store import EchoStoredEvent, semantic_sha256
+from .improvement_cycle import ImprovementProposal, ImprovementRisk, ImprovementState, ImprovementTriggerKind
+from .models import AuditRecord
+from .qualification import CapabilityStatus, canonical_digest
+
+_SIGNAL_KEY = "_ws_improvement_signal"
+_ALLOWED = {
+    ImprovementTriggerKind.NEW_EVIDENCE,
+    ImprovementTriggerKind.TEST_RESULT,
+    ImprovementTriggerKind.FAILURE,
+    ImprovementTriggerKind.ANOMALY,
+    ImprovementTriggerKind.CONTRADICTION,
+    ImprovementTriggerKind.SECURITY_EVENT,
+    ImprovementTriggerKind.OPERATOR_FEEDBACK,
+}
+
+class OperationalImprovementSignalError(ValueError):
+    pass
+
+class OperationalImprovementSignal(BaseModel):
+    source: str = Field(min_length=1)
+    trigger_kind: ImprovementTriggerKind
+    statement: str = Field(min_length=1)
+    affected_lanes: list[str] = Field(min_length=1)
+    risk_level: ImprovementRisk = ImprovementRisk.MODERATE
+    baseline_capability_status: list[CapabilityStatus] = Field(default_factory=list)
+    baseline_artifacts: list[str] = Field(default_factory=list)
+    required_tests: list[str] = Field(default_factory=list)
+    success_metrics: list[str] = Field(default_factory=list)
+    negative_evidence: list[dict[str, Any]] = Field(default_factory=list)
+    reversible: bool = True
+
+    @model_validator(mode="after")
+    def validate_signal(self):
+        if self.source not in {"ECHO", "OVERWATCH"}:
+            raise ValueError("unsupported operational source")
+        if self.trigger_kind not in _ALLOWED:
+            raise ValueError("unsupported operational trigger")
+        return self
+
+def _stable_id(record: AuditRecord) -> str:
+    event_id = record.payload.get("_outbox_event_id")
+    if not isinstance(event_id, str):
+        raise OperationalImprovementSignalError("valid ECHO event id required")
+    year = record.timestamp[:4]
+    digest = canonical_digest({"event_id": event_id}).split(":", 1)[1]
+    return f"WS-IR-{year}-{int(digest[:12], 16)}"
+
+def _signal(record: AuditRecord) -> OperationalImprovementSignal:
+    raw = record.payload.get(_SIGNAL_KEY)
+    if not isinstance(raw, dict):
+        raise OperationalImprovementSignalError("explicit WS-RI signal required")
+    try:
+        return OperationalImprovementSignal.model_validate(raw)
+    except ValueError as exc:
+        raise OperationalImprovementSignalError("invalid WS-RI signal") from exc
+
+def audit_event_to_improvement(record: AuditRecord, *, created_utc: str) -> ImprovementProposal:
+    digest = semantic_sha256(record)
+    signal = _signal(record)
+    event_id = str(record.payload["_outbox_event_id"])
+    baseline = list(dict.fromkeys(signal.baseline_capability_status)) or [CapabilityStatus.NOT_CURRENTLY_CLAIMED]
+    tests = list(dict.fromkeys([
+        f"{event_id}:echo-semantic-integrity",
+        f"{event_id}:observation-gate",
+        *signal.required_tests,
+    ]))
+    metrics = list(dict.fromkeys(signal.success_metrics)) or ["all required validation tests pass"]
+    risks = ["observation does not promote capability maturity"]
+    if signal.source == "OVERWATCH":
+        risks.append("producer label does not establish runtime validation")
+    return ImprovementProposal(
+        improvement_id=_stable_id(record),
+        trigger_kind=signal.trigger_kind,
+        title=f"{signal.source} improvement candidate: {record.event}",
+        source_refs=[event_id, f"ECHO-SEMANTIC-SHA256:{digest}"],
+        affected_lanes=list(dict.fromkeys([signal.source, *signal.affected_lanes, "WS-RI"])),
+        baseline_artifacts=list(dict.fromkeys(signal.baseline_artifacts)),
+        baseline_capability_status=baseline,
+        target_capability_status=None,
+        proposed_change="Evaluate this operational signal through existing qualification and authorization gates: " + signal.statement,
+        expected_benefit="Create a traceable improvement candidate from explicit operational evidence.",
+        assumptions=["ECHO semantic validation remains authoritative."],
+        risks=risks,
+        risk_level=signal.risk_level,
+        required_tests=tests,
+        success_metrics=metrics,
+        negative_evidence=list(signal.negative_evidence),
+        reversible=signal.reversible,
+        generated_by=f"{signal.source}->ECHO->WS-RI",
+        created_utc=created_utc,
+        state=ImprovementState.PROPOSED,
+        requested_claim_promotion=False,
+        requested_external_execution=False,
+    )
+
+def stored_echo_event_to_improvement(stored: EchoStoredEvent, *, created_utc: str) -> ImprovementProposal:
+    record = AuditRecord(timestamp=stored.first_audit_timestamp, event=stored.event, actor=stored.actor, payload=stored.payload())
+    if semantic_sha256(record) != stored.semantic_sha256:
+        raise OperationalImprovementSignalError("stored ECHO event failed semantic verification")
+    return audit_event_to_improvement(record, created_utc=created_utc)

--- a/deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py
+++ b/deployments/sara_verified_local_v1/worldshepherd_sara/pre_improvement.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .improvement_cycle import (
+    ImprovementProposal,
+    ImprovementRisk,
+    ImprovementState,
+    ImprovementTriggerKind,
+)
+from .qualification import (
+    CapabilityStatus,
+    DemandClass,
+    RequirementDeltaRecord,
+    canonical_digest,
+)
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _stable_requirement_improvement_id(
+    requirement: RequirementDeltaRecord,
+    created_utc: str,
+) -> str:
+    year = created_utc[:4]
+    if len(year) != 4 or not year.isdigit():
+        raise ValueError("created_utc must begin with a four-digit year")
+    material = {
+        "requirement_delta_id": requirement.requirement_delta_id,
+        "statement": requirement.statement,
+        "source_url": requirement.source.url,
+        "created_year": year,
+    }
+    digest_hex = canonical_digest(material).split(":", 1)[1]
+    numeric_suffix = str(int(digest_hex[:12], 16))
+    return f"WS-IR-{year}-{numeric_suffix}"
+
+
+def pre_to_improvement(
+    requirement: RequirementDeltaRecord,
+    *,
+    created_utc: str,
+    baseline_artifacts: Iterable[str] = (),
+    additional_required_tests: Iterable[str] = (),
+) -> ImprovementProposal:
+    """Translate a PRE requirement delta into a governed WS-RI proposal.
+
+    PRE demand classification is preserved as context only. Confirmed demand,
+    emerging demand, and Worldshepherd forecasts do not themselves promote
+    capability maturity or authorize implementation.
+    """
+
+    baseline_status = list(dict.fromkeys(requirement.capability_status))
+    if not baseline_status:
+        baseline_status = [CapabilityStatus.NOT_CURRENTLY_CLAIMED]
+
+    lanes = _dedupe([*requirement.affected_lanes, "PRE", "WS-RI"])
+    sources = _dedupe(
+        [
+            requirement.requirement_delta_id,
+            requirement.source.url,
+            requirement.source.solicitation_or_topic or "",
+        ]
+    )
+    required_tests = _dedupe(
+        [
+            f"{requirement.requirement_delta_id}:source-evidence-gate",
+            f"{requirement.requirement_delta_id}:claims-boundary-gate",
+            *requirement.experiment_or_demonstration_needed,
+            *additional_required_tests,
+        ]
+    )
+
+    risks = [
+        "Demand evidence does not establish Worldshepherd capability, readiness, certification, or physical performance.",
+        "A requirement may change, be superseded, or apply differently to a specific program or integration context.",
+    ]
+    risk_level = ImprovementRisk.MODERATE
+
+    if not requirement.capture_ready():
+        risks.append(
+            "The PRE source is not capture-ready and requires source resolution before consequential use."
+        )
+        risk_level = ImprovementRisk.HIGH
+
+    if requirement.demand_class == DemandClass.WORLDSHEPHERD_FORECAST:
+        risks.append(
+            "Worldshepherd forecast is a preparation signal only and is not evidence that an external customer requirement exists."
+        )
+
+    if requirement.partner_needed:
+        risks.append(
+            "Partner need is unresolved; partner interest, validation, eligibility, and performance are not established by this record."
+        )
+
+    gap_text = "; ".join(requirement.missing_capability)
+    if gap_text:
+        proposed_change = (
+            "Evaluate and close the following PRE capability gaps only through qualified, authorized changes: "
+            f"{gap_text}. Requirement context: {requirement.statement}"
+        )
+    else:
+        proposed_change = (
+            "Evaluate the PRE requirement delta and define any evidence-backed Worldshepherd change needed to address it: "
+            f"{requirement.statement}"
+        )
+
+    success_metrics = _dedupe(requirement.evidence_target)
+    if not success_metrics:
+        success_metrics = [
+            "All required validation tests return PASS.",
+            "The requirement remains traceable to its source and PRE record.",
+            "No claims-boundary violation or unauthorized external execution occurs.",
+        ]
+
+    assumptions = [
+        f"PRE demand class remains {requirement.demand_class.value} unless superseded by a newer requirement record.",
+        "Source status and capability status remain separate evidence dimensions.",
+        "Existing ECHO, TEVV, PRIME, and configuration-custody controls remain authoritative.",
+    ]
+    if requirement.claims_boundary:
+        assumptions.append(
+            "The PRE claims boundary remains binding: "
+            + " | ".join(requirement.claims_boundary)
+        )
+
+    return ImprovementProposal(
+        improvement_id=_stable_requirement_improvement_id(requirement, created_utc),
+        trigger_kind=ImprovementTriggerKind.REQUIREMENT_DELTA,
+        title=f"PRE improvement candidate: {requirement.requirement_delta_id}",
+        source_refs=sources,
+        affected_lanes=lanes,
+        baseline_artifacts=_dedupe(baseline_artifacts),
+        baseline_capability_status=baseline_status,
+        target_capability_status=None,
+        proposed_change=proposed_change,
+        expected_benefit=(
+            "Convert a PRE requirement gap into a traceable, testable improvement path without confusing demand evidence with capability evidence."
+        ),
+        assumptions=assumptions,
+        risks=risks,
+        risk_level=risk_level,
+        required_tests=required_tests,
+        success_metrics=success_metrics,
+        negative_evidence=[],
+        reversible=True,
+        generated_by="PRE->WS-RI",
+        created_utc=created_utc,
+        state=ImprovementState.PROPOSED,
+        requested_claim_promotion=False,
+        requested_external_execution=False,
+    )


### PR DESCRIPTION
## Summary

Adds a governed recursive-improvement layer for Worldshepherd and extends it through persistent lifecycle custody, operational evidence ingestion, bounded feedback, ECHO checkpoint linkage, a local operator runtime/CLI, and verifiable scheduler-handoff/evidence-export artifacts.

### CI-validated baseline
Exact head `68c0152836d57fea520c9d6ba0eede59cc73aa8c` completed **all registered workflows successfully**, including WS-RI Runtime, WS Recursive Improvement, Required Test and Build, ECHO Anchor, full SARA, recovery/resilience, rollback, TLS, NIST, commit-closure, and the complete NSB matrix.

Classification for that exact head:

`IMPLEMENTED IN SOFTWARE — CI VALIDATED`

### Core governed lifecycle
- `improvement_cycle.py`: fail-closed proposal lifecycle with full model revalidation on public transitions
- `improvement_routing.py`: OMEGA translation and downstream routing
- `pre_improvement.py`: PRE requirement-delta bridge
- `evidence_improvement.py`: qualification/TEVV feedback bridge
- `operational_improvement.py`: explicit ECHO/OVERWATCH-compatible operational signal bridge

### Persistent custody/runtime
- `improvement_ledger.py`: append-only application custody over SQLite with global/per-improvement digest chains, replay dedupe, transition enforcement, verification
- `improvement_feedback.py`: finite resumable ECHO feedback cycles with bounded event/proposal budgets
- `improvement_checkpoint.py`: ledger-head checkpoint digest and ECHO signed-membership verification
- `improvement_runtime.py`: persistent digest-verified cursor, restart-safe bounded feedback, status/export, checkpoint staging
- `improvement_runtime_cli.py`: local operator CLI (`ws-ri-runtime`)

### Governed scheduler handoff
- `improvement_handoff.py`
  - one-cycle feedback handoff artifact only
  - binds ledger head + cursor digest + requestor + generation time + bounded budgets
  - requires `HUMAN_REVIEW_REQUIRED`
  - requires separate authorization
  - structurally forbids autonomous execution, claim promotion, deployment, and external-execution authority
- CLI: `ws-ri-runtime handoff`

### Deterministic evidence manifest
- `improvement_evidence_export.py`
  - binds explicit ordered ledger sequences and record digests
  - binds ledger head, state counts, cursor and cursor digest
  - self-verifies manifest and records digest
  - detects runtime drift
  - rejects inconsistent counts/order/head and semantic authority escalation
- CLI: `ws-ri-runtime evidence-manifest`
- tests: `tests/test_improvement_handoff_export.py`
- dedicated runtime CI gate expanded to compile/test handoff + evidence export

### Operator model
The operator surface remains local CLI rather than a new network API. There is **no autonomous scheduler** in this tranche. A scheduler handoff is a request artifact, not an execution primitive.

## Governance

This PR does **not** authorize automatic merge, deployment, physical actuation, messaging, purchasing, proposal submission, partner contact, certification/readiness assertions, or scientific claim elevation.

`PROMOTED` remains a governed record state only. The feedback collector emits only `PROPOSED` records. Repeated execution requires an existing authorized scheduler or explicit operator invocation. A scheduler handoff does not itself grant authority. A staged ledger checkpoint is not claimed as signed ECHO inclusion until exact membership is verified inside a successfully verified ECHO checkpoint.

## Validation status

Current exact head: `f37234ebd54bd6974cb42bd6f919aed4360e5ea9`.

The prior `68c0152...` baseline is fully CI validated. The new scheduler-handoff/evidence-manifest tranche is:

`IMPLEMENTED IN SOFTWARE — EXACT-HEAD CI PENDING`
