### PR TITLE
Add Wave 2 OSS resilience designs for SPIRE and Gazebo

### DIFF
--- a/docs/oss_contributions/gazebo_3979_ghost_collider_design.md
+++ b/docs/oss_contributions/gazebo_3979_ghost_collider_design.md
@@ -1,0 +1,102 @@
+# Gazebo Sim #3979 — late removal leaves a ghost physics collider
+
+Upstream: `gazebosim/gz-sim#3979`
+
+Claims state: **SOURCE-REVIEWED FIX DESIGN / REQUIRES GAZEBO CONCURRENCY VALIDATION**
+
+## Failure mode
+
+A later-priority `Update` system can request model removal after the Physics system has already scanned `EachRemoved<Model>`. The ECM entity is physically deleted at iteration end and the removal view is cleared, so the next Physics update cannot discover the removal. The gz-physics / DART backend object survives and continues colliding even though `Server::HasEntity()` reports the model absent.
+
+The upstream reproducer demonstrates three useful controls:
+
+1. removal before Physics runs works;
+2. removal after Physics runs leaves the backend collider active;
+3. retaining the ground produces the same resting height as the failing case.
+
+That makes this a semantic-state divergence bug, not merely an ECM visibility problem.
+
+## Safety constraint
+
+The issue author reports that moving the existing removal call to `PostUpdate` makes the regression pass, but the production fix must account for parallel `PostUpdate` execution and backend thread-safety. Therefore Worldshepherd should not propose an unconditional backend mutation from `PostUpdate` without proving the synchronization contract.
+
+## Preferred correction
+
+Use a two-phase removal path:
+
+### Phase A — observe removal marks in `PostUpdate`
+
+`PostUpdate` is the lifecycle phase where `EachRemoved` is guaranteed to expose removals. Snapshot the identifiers and any descendant/backend handles needed for cleanup into a Physics-owned queue. Keep this phase read/record oriented if direct physics-engine mutation is not concurrency-safe.
+
+Conceptual shape:
+
+```cpp
+void Physics::PostUpdate(
+  const UpdateInfo &,
+  const EntityComponentManager &_ecm)
+{
+  _ecm.EachRemoved<components::Model>(
+    [this](const Entity &_entity, const components::Model *)
+    {
+      this->dataPtr->removedModels.push_back(_entity);
+      return true;
+    });
+}
+```
+
+The actual queue type and synchronization primitive must match Gazebo's system execution guarantees; the example is illustrative only.
+
+### Phase B — drain before the next physics step
+
+At the beginning of the next Physics `Update`, before stepping DART/gz-physics, drain the queued removals through the existing backend cleanup path. This guarantees no deleted collider participates in another physics step while avoiding mutation from a potentially parallel `PostUpdate` callback.
+
+Pseudo-order:
+
+```text
+iteration N:
+  Physics::Update()        -> normal step
+  LaterSystem::Update()    -> requests entity removal
+  Physics::PostUpdate()    -> snapshots removal
+  runner                   -> clears ECM removal view
+
+iteration N+1:
+  Physics::Update()
+    drain queued removals  -> backend collider removed
+    step physics           -> deleted object cannot collide
+```
+
+## Required invariants
+
+- Every model observed as removed by the ECM is eventually removed exactly once from the backend.
+- A late-removed collision never participates in the next physics step.
+- Duplicate/removal-of-already-gone entities is idempotent and does not crash.
+- Parent removal correctly removes descendants or delegates to the existing recursive cleanup path.
+- Reset/world-reload does not retain stale queued entity IDs.
+- Queue access is race-free under the scheduler's actual `PostUpdate` and `Update` execution model.
+
+## Regression matrix
+
+1. Existing upstream late-removal reproducer — must pass.
+2. PreUpdate removal — must remain passing.
+3. Retained-ground control — unchanged.
+4. Remove parent model with multiple collision descendants.
+5. Remove multiple models in the same iteration.
+6. Remove then reset before the next update.
+7. Request duplicate removal / remove already-gone entity.
+8. Dynamic plugin with explicit priorities proving the late-remover ordering.
+9. Thread/race sanitizer path where supported by Gazebo CI.
+10. Back-to-back create/remove cycles to detect stale bridge/backend entries.
+
+## Observability
+
+A debug/trace counter for queued and drained removals would make this class of divergence diagnosable without changing normal user-visible behavior. Any metric/logging should follow existing Gazebo conventions rather than a Worldshepherd namespace.
+
+## Worldshepherd relevance
+
+This is a strong semantic-health example: **control-plane state says the entity is gone while physical simulation state still behaves as if it exists**. The same assurance rule applies to robots, distributed middleware, and policy systems: health requires agreement between authoritative state and the subsystem that actually produces effects.
+
+A future Worldshepherd Gazebo fault harness should include an invariant check comparing ECM entity state, backend collision state, and observable dynamics after lifecycle operations.
+
+## Submission boundary
+
+Do not present the two-phase design as upstream-tested until it has been implemented against current `gz-sim` and run through the regression matrix. No competing fix PR was found during the 2026-09-12 scan, but re-check immediately before submission.

--- a/docs/oss_contributions/spire_7111_retry_backoff_design.md
+++ b/docs/oss_contributions/spire_7111_retry_backoff_design.md
@@ -1,0 +1,124 @@
+# SPIRE #7111 — decouple agent API retry backoff from reconciliation cadence
+
+Upstream: `spiffe/spire#7111`
+
+Claims state: **SOURCE-REVIEWED DESIGN / REQUIRES UPSTREAM TESTING AND MAINTAINER API SELECTION**
+
+## Problem confirmed in current source
+
+The agent manager currently derives the synchronize retry ceiling from the reconciliation interval:
+
+- `SyncInterval` is the normal synchronization cadence.
+- `synchronizeMaxIntervalMultiple = 48`.
+- `synchronizeMaxInterval = 8 * time.Minute`.
+- the manager computes `min(8m, 48 * SyncInterval)` and constructs the synchronize backoff using `SyncInterval` as its base interval.
+
+With the default 5-second sync interval this permits roughly a four-minute retry ceiling after transient upstream/API errors. This couples two distinct control loops: steady-state reconciliation frequency and failure-recovery retry policy.
+
+## Contribution objective
+
+Separate **normal reconcile cadence** from **transient-failure retry cadence** without changing default behavior unexpectedly for existing deployments.
+
+The preferred shape is an explicit retry policy that can be tuned independently while preserving the existing backoff implementation and clock injection used by tests.
+
+Candidate manager configuration fields:
+
+```go
+// SyncRetryInitialInterval controls the initial retry delay after a failed
+// synchronize attempt. Zero preserves the legacy behavior and uses SyncInterval.
+SyncRetryInitialInterval time.Duration
+
+// SyncRetryMaxInterval caps the synchronize retry delay. Zero preserves the
+// legacy computed ceiling min(8m, 48*SyncInterval).
+SyncRetryMaxInterval time.Duration
+```
+
+The zero-value compatibility rule is deliberate. Existing configs should behave identically unless the new knobs are configured.
+
+## Proposed manager construction
+
+Conceptually:
+
+```go
+retryInitial := m.c.SyncRetryInitialInterval
+if retryInitial == 0 {
+    retryInitial = m.c.SyncInterval
+}
+
+retryMax := m.c.SyncRetryMaxInterval
+if retryMax == 0 {
+    retryMax = min(synchronizeMaxInterval,
+        synchronizeMaxIntervalMultiple*m.c.SyncInterval)
+}
+
+// Reject or clamp an invalid max below initial during config validation rather
+// than silently constructing a nonsensical backoff policy.
+m.synchronizeBackoff = backoff.NewBackoff(
+    m.clk,
+    retryInitial,
+    backoff.WithMaxInterval(retryMax),
+)
+```
+
+No change is proposed to `svidSyncBackoff` or size-limited backoff behavior unless maintainers explicitly want those exposed separately.
+
+## HCL surface
+
+`cmd/spire-agent/cli/run/run.go` already exposes `experimental.sync_interval` and parses it into the agent configuration. A low-risk first upstream version can keep the new settings in the same experimental block:
+
+```hcl
+agent {
+  experimental {
+    sync_interval = "5s"
+    sync_retry_initial_interval = "1s"
+    sync_retry_max_interval = "30s"
+  }
+}
+```
+
+Candidate raw fields:
+
+```go
+SyncRetryInitialInterval string `hcl:"sync_retry_initial_interval"`
+SyncRetryMaxInterval     string `hcl:"sync_retry_max_interval"`
+```
+
+Parsing should use `time.ParseDuration`, reject non-positive configured values, and reject `max < initial`.
+
+## Required tests
+
+1. **Legacy compatibility** — with both new values zero/unset, verify the existing 5-second base and computed max behavior remain unchanged.
+2. **Independent retry base** — `SyncInterval=5s`, retry initial `1s`, retry max `30s`; first failure waits according to the retry policy rather than five seconds.
+3. **Ceiling** — repeated failures never exceed the configured retry max.
+4. **Recovery** — a successful synchronization resets the retry sequence and steady-state reconciliation returns to `SyncInterval`.
+5. **Large sync interval** — a large reconciliation interval no longer forces an excessively large transient retry when explicit retry settings are supplied.
+6. **Validation** — reject zero/negative explicit durations and `max < initial`.
+7. **Fake-clock deterministic test** — use the existing injected clock/backoff test structure; do not add wall-clock sleeps.
+8. **No retry storm regression** — repeated failure still uses exponential backoff/jitter semantics already provided by the backoff package rather than a tight fixed retry loop.
+
+## Observability recommendation
+
+If the current telemetry surface does not expose retry state, add or reuse metrics/log fields for:
+
+- synchronize attempt result;
+- current retry interval;
+- consecutive synchronize failures;
+- successful recovery/reset.
+
+This should be implemented using existing SPIRE telemetry conventions rather than a Worldshepherd-specific namespace.
+
+## Worldshepherd relevance
+
+This issue directly matches the Worldshepherd assurance-plane principle that **normal operating cadence, degraded-state recovery, and semantic health must be modeled independently**. A process that remains alive while waiting several minutes after a transient control-plane failure may be operationally degraded even though ordinary liveness checks stay green.
+
+Worldshepherd should contribute the smallest upstream-compatible retry-policy change and a deterministic fake-clock regression suite; SARA/ECHO can then consume the resulting retry/recovery telemetry without embedding SPIRE-specific recovery logic.
+
+## Submission boundary
+
+Do not claim upstream acceptance. Before submission:
+
+- verify current `main` has no competing PR for #7111;
+- inspect maintainers' preference for experimental versus stable configuration placement;
+- run manager and CLI config test suites;
+- update `doc/spire_agent.md` if the configuration surface is accepted;
+- preserve backward-compatible zero-value behavior unless maintainers request a default change.


### PR DESCRIPTION
## Summary

Clean follow-on to merged PR #182, based directly on current `main`.

Adds two source-reviewed, claims-controlled contribution designs discovered by the expanded Worldshepherd OSS scan:

- **SPIFFE/SPIRE #7111** — decouple transient synchronize retry backoff from normal agent reconciliation cadence while preserving legacy behavior when new settings are unset. Includes proposed config shape, validation, deterministic fake-clock tests, observability, and submission boundaries.
- **Gazebo Sim #3979** — two-phase lifecycle correction for late entity removals that can leave a backend ghost collider after the ECM entity is gone. Separates `PostUpdate` removal observation from pre-step backend cleanup and defines concurrency/idempotency regression invariants.

## Claims boundary

These are source-reviewed fix designs, not claims of upstream acceptance or execution against the external projects. SPIRE configuration placement remains a maintainer/API decision. Gazebo backend cleanup must be validated against actual scheduler and physics-backend concurrency guarantees before an upstream patch is submitted.

## Scan status

At preparation time, no matching implementation PR was found for SPIRE #7111 or Gazebo #3979. Re-check immediately before upstream submission to avoid duplicate work.